### PR TITLE
Fix EBS attachment for additional volumes

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -92,18 +92,6 @@ locals {
   ]
 }
 
-locals {
-  linux_nvme_device_names = [
-    "/dev/nvme1n1",
-    "/dev/nvme2n1",
-    "/dev/nvme3n1",
-    "/dev/nvme4n1",
-    "/dev/nvme5n1",
-    "/dev/nvme6n1",
-    "/dev/nvme7n1"
-  ]
-}
-
 resource "aws_volume_attachment" "attached_volume" {
   for_each = { for i, v in lookup(var.machine.spec, "additional_volumes", []) : i => v }
 
@@ -148,7 +136,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.linux_nvme_device_names, tonumber(each.key))} ${each.value.mount_point} >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.linux_ebs_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
     ]
 
     connection {

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -1,18 +1,54 @@
 #!/bin/bash
-COUNTER=0
-DEVICE=$1
-MOUNTPOINT=$2
 
-while [ ! -b ${DEVICE} ]; do
-    sleep 2
-    COUNTER=$((COUNTER + 1))
-    if [ $COUNTER -ge 10 ]; then
-        exit 2
-    fi
+# Expected EBS device path: /dev/sdX
+TARGET_EBS_DEVICE=$1
+# Mount point
+MOUNT_POINT=$2
+# Total number of nvme devices that should be present on the system
+N_NVME_DEVICE=$3
+
+TARGET_NVME_DEVICE=""
+
+# Install nvme-cli
+if [ -f /etc/redhat-release ]; then
+	sudo yum install nvme-cli -y
+fi
+if [ -f /etc/debian_version ]; then
+	sudo apt update -y
+	sudo apt install nvme-cli -y
+fi
+
+# Wait for the availability of all the NVME devices that should be
+# present on the system.
+while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
+	sleep 2
+	COUNTER=$((COUNTER + 1))
+	if [ $COUNTER -ge 10 ]; then
+		echo "ERROR: unable to get the full list of NVME devices after 20s"
+		exit 2
+	fi
 done
 
+# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+# NVME device.
+for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+	if [ "$EBS_DEVICE" = "$TARGET_EBS_DEVICE" ]; then
+		TARGET_NVME_DEVICE=${NVME_DEVICE}
+		break
+	fi
+done;
 
-sudo mkfs.ext4 "${DEVICE}"
-sudo mkdir -p "${MOUNTPOINT}"
-echo "${DEVICE} ${MOUNTPOINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t ext4 -o noatime ${DEVICE} ${MOUNTPOINT}
+if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICE}"
+	exit 2
+fi
+
+# Mount point and volume creation
+sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkdir -p "${MOUNT_POINT}"
+# Get device UUID with blkid as exported format:
+# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}


### PR DESCRIPTION
Using hardcoded NVME device paths does not work because they can change at boot time, or can be presented to the system in an unexpected order.

To fix this, we pass the EBS device path (/dev/sdX) which is explicitly assigned by terraform and use the nvme-cli tool for finding out the right NVME device, based on EBS device path.

Once we have the right NVME device, we can find out disk UUID and use it for updating /etc/fstab.