### PR TITLE
Open ports to region's subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ aws:
         - port: 22
           protocol: tcp
           description: "SSH"
-      region_ports:
         - port: 30000
           protocol: tcp
           description: "DBT-2"
@@ -211,13 +210,6 @@ aws:
         size_gb: 50
         iops: 5000
         encrypted: false
-      service_ports:
-        - port: 8010
-          protocol: tcp
-          description: "master web UI"
-        - port: 9989
-          protocol: tcp
-          description: "worker connection port"
     ebac-worker-0:
       type: worker
       region: us-east-2
@@ -235,9 +227,9 @@ aws:
           iops: 5000
           encrypted: false
 ```
-**notes:
-* service_ports: ports open to the public
-* region_ports: ports open and restricted to region's subnet cidrblocks
+#### Options:
+* `service_ports`: ports open to the public
+* `region_ports`: ports open and restricted to region's subnet cidrblocks
 
 ## Prerequisites and installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ aws:
         - port: 22
           protocol: tcp
           description: "SSH"
+      region_ports:
         - port: 30000
           protocol: tcp
           description: "DBT-2"
@@ -172,6 +173,71 @@ aws:
         - name: work_mem
           value: 16000
 ```
+
+### AWS Buildbot Master and Worker
+
+```yaml
+cluster_name: BuildBot-Demo
+aws:
+  ssh_user: ubuntu
+  operating_system:
+    name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-
+    owner: 099720109477
+  regions:
+    us-east-2:
+      cidr_block: 10.0.0.0/16
+      azs:
+        us-east-2b: 10.0.0.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+      region_ports:
+        - port: 9989
+          protocol: tcp
+          description: "worker connection to master"
+        - port: 8010
+          protocol: tcp
+          description: "master web UI"
+  machines:
+    ebac-master:
+      count: 1
+      type: master
+      region: us-east-2
+      az: us-east-2b
+      instance_type: c5.xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      service_ports:
+        - port: 8010
+          protocol: tcp
+          description: "master web UI"
+        - port: 9989
+          protocol: tcp
+          description: "worker connection port"
+    ebac-worker-0:
+      type: worker
+      region: us-east-2
+      az: us-east-2b
+      instance_type: c5.xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      additional_volumes:
+        - mount_point: /var/lib/buildbot-worker
+          size_gb: 300
+          type: io2
+          iops: 5000
+          encrypted: false
+```
+**notes:
+* service_ports: ports open to the public
+* region_ports: ports open and restricted to region's subnet cidrblocks
 
 ## Prerequisites and installation
 

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -50,7 +50,11 @@ module "security_{{ region_ }}" {
   project_tag      = var.project_tag
   service_ports    = lookup(lookup(var.regions, "{{ region }}", null), "service_ports", [])
   cluster_name     = var.cluster_name
-
+  region_cidrblocks = ([ for k, v 
+                      in lookup(lookup(var.regions, "{{ region }}", null), "azs", [])
+                      : v ])
+  region_ports = lookup(lookup(var.regions, "{{ region }}", null), "region_ports", [])
+  
   depends_on = [module.routes_{{ region_ }}]
 
   providers = {

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -3,6 +3,8 @@ variable "public_cidrblock" {}
 variable "project_tag" {}
 variable "service_ports" {}
 variable "cluster_name" {}
+variable "region_cidrblocks" {}
+variable "region_ports" {}
 
 terraform {
   required_providers {
@@ -35,6 +37,20 @@ resource "aws_security_group" "rules" {
       // Not recommended for production. 
       // Limit IP Addresses in a Production Environment !
       cidr_blocks = [var.public_cidrblock]
+    }
+  }
+
+  // Allow connections from regions cidr block to specific ports
+  // Reduced exposure compared to service ports
+  dynamic "ingress" {
+    for_each = var.region_ports
+    iterator = region_ports
+    content {
+      from_port = region_ports.value.port
+      to_port = region_ports.value.port
+      protocol = region_ports.value.protocol
+      description = region_ports.value.description
+      cidr_blocks = var.region_cidrblocks
     }
   }
 


### PR DESCRIPTION
Open ports for region's subnet cidr blocks
* Open ports by region with `region_ports` option to reduce exposure for services needed by machines in the same region
* `service_ports` opens the ports to any ip currently