### PR TITLE
Add differentiators to some resource names

### DIFF
--- a/edbterraform/data/terraform/aws/modules/aurora/main.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/main.tf
@@ -21,7 +21,7 @@ data "aws_subnets" "ids" {
 }
 
 resource "aws_db_subnet_group" "aurora" {
-  name       = format("rds-subnet-group-%s", var.aurora.name)
+  name       = format("rds-subnet-group-aurora-%s", var.aurora.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
   tags = {
@@ -70,7 +70,7 @@ resource "aws_rds_cluster_instance" "aurora_instance" {
 }
 
 resource "aws_db_parameter_group" "aurora_db_params" {
-  name   = format("db-parameter-group-%s", lower(var.aurora.name))
+  name   = format("db-parameter-group-aurora-%s", lower(var.aurora.name))
   family = format("%s%s", var.aurora.spec.engine, var.aurora.spec.engine_version)
 
   dynamic "parameter" {

--- a/edbterraform/data/terraform/aws/modules/database/main.tf
+++ b/edbterraform/data/terraform/aws/modules/database/main.tf
@@ -21,7 +21,7 @@ data "aws_subnets" "ids" {
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name       = format("rds-subnet-group-%s", var.database.name)
+  name       = format("rds-subnet-group-rds-%s", var.database.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
   tags = {
@@ -58,7 +58,7 @@ resource "aws_db_instance" "rds_server" {
 }
 
 resource "aws_db_parameter_group" "edb_rds_db_params" {
-  name   = format("db-parameter-group-%s", lower(var.database.name))
+  name   = format("db-parameter-group-rds-%s", lower(var.database.name))
   family = format("%s%s", var.database.spec.engine, var.database.spec.engine_version)
 
   dynamic "parameter" {


### PR DESCRIPTION
Add another keyword to the names for subnet groups and database parameters so that tests on Aurora and RDS do not clash in names.