### PR TITLE
Reduce resource name collisions with a generated key

### DIFF
--- a/edbterraform/data/templates/aws/aurora.tf.j2
+++ b/edbterraform/data/templates/aws/aurora.tf.j2
@@ -8,6 +8,7 @@ module "aurora_{{ region_ }}" {
   cluster_name             = var.cluster_name
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
   created_by               = var.created_by
+  name_id                  = random_id.apply.hex
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/database.tf.j2
+++ b/edbterraform/data/templates/aws/database.tf.j2
@@ -8,6 +8,7 @@ module "database_{{ region_ }}" {
   cluster_name             = var.cluster_name
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
   created_by               = var.created_by
+  name_id                  = random_id.apply.hex
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/key_pair.tf.j2
+++ b/edbterraform/data/templates/aws/key_pair.tf.j2
@@ -1,8 +1,9 @@
 module "key_pair_{{ region_ }}" {
   source = "./modules/key_pair"
 
-  cluster_name = var.cluster_name
+  key_name = var.cluster_name
   ssh_pub_key  = var.ssh_pub_key
+  name_id = random_id.apply.hex
 
   providers = {
     aws = aws.{{ region_ }}

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -32,6 +32,10 @@ locals {
 {% endif %}
 }
 
+resource "random_id" "apply" {
+  byte_length = 4
+}
+
 {% for region in regions.keys() %}
 {%   set region_ = region | replace('-', '_') %}
 

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -3,6 +3,7 @@ module "vpc_{{ region_ }}" {
 
   vpc_cidr_block = lookup(lookup(var.regions, "{{ region }}"), "cidr_block")
   vpc_tag        = var.vpc_tag
+  name_id        = random_id.apply.hex
 
   providers = {
     aws = aws.{{ region_ }}

--- a/edbterraform/data/terraform/aws/modules/aurora/main.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/main.tf
@@ -3,6 +3,7 @@ variable "vpc_id" {}
 variable "custom_security_group_id" {}
 variable "cluster_name" {}
 variable "created_by" {}
+variable "name_id" { default="0" }
 
 terraform {
   required_providers {
@@ -21,7 +22,7 @@ data "aws_subnets" "ids" {
 }
 
 resource "aws_db_subnet_group" "aurora" {
-  name       = format("rds-subnet-group-%s", var.aurora.name)
+  name       = format("rds-subnet-group-%s-%s", var.name_id, var.aurora.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
   tags = {
@@ -70,7 +71,7 @@ resource "aws_rds_cluster_instance" "aurora_instance" {
 }
 
 resource "aws_db_parameter_group" "aurora_db_params" {
-  name   = format("db-parameter-group-%s", lower(var.aurora.name))
+  name   = format("db-parameter-group-%s-%s", var.name_id, lower(var.aurora.name))
   family = format("%s%s", var.aurora.spec.engine, var.aurora.spec.engine_version)
 
   dynamic "parameter" {

--- a/edbterraform/data/terraform/aws/modules/database/main.tf
+++ b/edbterraform/data/terraform/aws/modules/database/main.tf
@@ -3,6 +3,7 @@ variable "vpc_id" {}
 variable "custom_security_group_id" {}
 variable "cluster_name" {}
 variable "created_by" {}
+variable "name_id" { default="0" }
 
 terraform {
   required_providers {
@@ -21,7 +22,7 @@ data "aws_subnets" "ids" {
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name       = format("rds-subnet-group-%s", var.database.name)
+  name       = format("rds-subnet-group-%s-%s", var.name_id, var.database.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
   tags = {
@@ -58,7 +59,7 @@ resource "aws_db_instance" "rds_server" {
 }
 
 resource "aws_db_parameter_group" "edb_rds_db_params" {
-  name   = format("db-parameter-group-%s", lower(var.database.name))
+  name   = format("db-parameter-group-%s-%s", var.name_id, lower(var.database.name))
   family = format("%s%s", var.database.spec.engine, var.database.spec.engine_version)
 
   dynamic "parameter" {

--- a/edbterraform/data/terraform/aws/modules/key_pair/main.tf
+++ b/edbterraform/data/terraform/aws/modules/key_pair/main.tf
@@ -1,5 +1,6 @@
 variable "ssh_pub_key" {}
-variable "cluster_name" {}
+variable "key_name" {}
+variable "name_id" { default="0" }
 
 terraform {
   required_providers {
@@ -11,6 +12,6 @@ terraform {
 }
 
 resource "aws_key_pair" "key_pair" {
-  key_name   = var.cluster_name
+  key_name   = "${var.key_name}-${var.name_id}"
   public_key = file(var.ssh_pub_key)
 }

--- a/edbterraform/data/terraform/aws/modules/vpc/main.tf
+++ b/edbterraform/data/terraform/aws/modules/vpc/main.tf
@@ -1,5 +1,6 @@
 variable "vpc_cidr_block" {}
 variable "vpc_tag" {}
+variable "name_id" { default = "0" }
 
 terraform {
   required_providers {
@@ -17,7 +18,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = var.vpc_tag
+    Name = "${var.vpc_tag}-${var.name_id}"
   }
 }
 


### PR DESCRIPTION
Use of terraform's resource `random_id`.
Will be made once, when `terraform apply` is first ran.
Can be made to change by watching variables or calling a function like timestamp() with 'keepers'.