### PR TITLE
Gcloud AlloyDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ describing the target cloud infrastructure.
 | AWS      | RDS Aurora               |:white_check_mark:|
 | GCloud   | Compute Engine - VM      |:white_check_mark:|
 | GCloud   | CloudSQL                 |:white_check_mark:|
-| GCloud   | AlloyDB                  |       :x:        |
+| GCloud   | AlloyDB                  |:white_check_mark:|
 | Azure    | VM                       |       :x:        |
 | Azure    | Database - Flexible      |       :x:        |
 | Azure    | CosmosDB                 |       :x:        |
@@ -23,7 +23,7 @@ describing the target cloud infrastructure.
 ## Infrastructure file
 
 Following are examples of infrastructure files describing the target cloud
-infrastructure. Example yaml files found inside [infrastructure-examples dir](./infrastructure-examples/)
+infrastructure. Example yaml files found inside [infrastructure-examples directory](./infrastructure-examples/)
 
 ### AWS EC2 machines
 

--- a/edbterraform/data/templates/gcloud/alloy.tf.j2
+++ b/edbterraform/data/templates/gcloud/alloy.tf.j2
@@ -1,0 +1,9 @@
+module "alloy_{{ region_ }}" {
+  source = "./modules/alloy"
+
+  depends_on = []
+
+  providers = {
+    google = google.{{ region_ }}
+  }
+}

--- a/edbterraform/data/templates/gcloud/alloy.tf.j2
+++ b/edbterraform/data/templates/gcloud/alloy.tf.j2
@@ -1,9 +1,29 @@
 module "alloy_{{ region_ }}" {
   source = "./modules/alloy"
 
-  depends_on = []
+  for_each = ({
+    for rm in lookup(local.region_alloys, "{{ region }}", []) :
+      rm.name => rm
+    })
+
+  name = "${each.key}-{{ region }}-${random_id.apply.hex}"
+  network = module.vpc_{{ region_ }}.vpc_id
+  region = each.value.spec.region
+  zone = try(each.value.spec.az, null)
+  port = try(each.value.spec.port, null)
+  cpu_count = try(each.value.spec.cpu_count, null)
+  username = try(each.value.spec.username, null)
+  password = each.value.spec.password
+  settings = ([
+    for setting in lookup(each.value.spec, "settings", []) : {
+      name = setting.name
+      value = setting.value
+    }
+  ])
+
+  depends_on = [module.vpc_{{ region_ }}, module.service_connection_{{ region_ }}]
 
   providers = {
-    google = google.{{ region_ }}
+    google = google-beta.{{ region_ }}
   }
 }

--- a/edbterraform/data/templates/gcloud/alloy.tf.j2
+++ b/edbterraform/data/templates/gcloud/alloy.tf.j2
@@ -21,7 +21,7 @@ module "alloy_{{ region_ }}" {
     }
   ])
 
-  depends_on = [module.vpc_{{ region_ }}, module.service_connection_{{ region_ }}]
+  depends_on = [module.security_{{ region_ }}]
 
   providers = {
     google = google-beta.{{ region_ }}

--- a/edbterraform/data/templates/gcloud/database.tf.j2
+++ b/edbterraform/data/templates/gcloud/database.tf.j2
@@ -27,7 +27,7 @@ module "database_{{ region_ }}" {
     }
   ])
 
-  depends_on = [module.vpc_{{ region_ }}, module.service_connection_{{ region_ }}]
+  depends_on = [module.security_{{ region_ }}]
 
   providers = {
     google = google.{{ region_ }}

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -61,50 +61,34 @@ resource "local_file" "servers_yml" {
   content         = <<-EOT
 ---
 servers:
-{% if machine_regions | length > 0 %}
-  machines:
-{% endif %}
-{% for region in machine_regions %}
-{% set region_ = region | replace('-', '_') %}
-{% set module_ = "module.machine_" ~ region_  %}
-%{for key, value in {{ module_ }} ~}
+{% set boxes = {
+  'machines': { 
+    'active': has_machines,
+    'regions': machine_regions,
+    'module_base': 'module.machine_',
+  },
+  'databases': {
+    'active': has_databases,
+    'regions': database_regions,
+    'module_base': "module.database_",
+  },
+  'alloy': {
+    'active': has_alloy,
+    'regions': alloy_regions,
+    'module_base': "module.alloy_",
+  }
+} %}
+{% for type, attributes in boxes.items() if attributes["active"] %}
+  {{type}}:
+{%   for region in attributes["regions"] -%}
+{%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
+%{ for key, value in {{ module }} ~}
     ${key}:
-      type: ${ value.machine_ips.type }
-      region: ${ value.machine_ips.region }
-      az: ${ value.machine_ips.az }
-      public_ip: ${ value.machine_ips.public_ip }
-      private_ip: ${ value.machine_ips.private_ip }
-%{endfor~}
-{% endfor %}
-{% if database_regions | length > 0 %}
-  databases:
-{% endif %}
-{% for region in database_regions %}
-{% set region_ = region | replace('-', '_') %}
-{% set module_ = "module.database_" ~ region_  %}
-%{for key, value in {{module_}} ~}
-    ${key}:
-      region: ${ value.database_ips.region }
-      username: ${ value.database_ips.username }
-      password: ${ value.database_ips.password }
-      address: ${ value.database_ips.address }
-      port: ${ value.database_ips.port }
-      dbname: ${ value.database_ips.dbname }
-%{endfor~}
-{% endfor %}
-{% if alloy_regions | length > 0 %}
-  alloy:
-{% endif %}
-{% for region in alloy_regions %}
-{% set region_ = region | replace('-', '_') %}
-{% set module_ = "module.alloy_" ~ region_ %}
-%{for key, value in {{module_}} ~}
-    ${key}:
-      region: ${ value.ips.region }
-      password: ${ value.ips.password }
-      address: ${ value.ips.address }
-      port: ${ value.ips.port }
-%{endfor~}
+%{   for name, item in value ~}
+      ${name}: ${try(jsonencode(item), "Error, unsupported type",)}
+%{   endfor ~}
+%{ endfor ~}
+{%   endfor %}
 {% endfor %}
     EOT
 }

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -1,27 +1,27 @@
 locals {
-{% if has_regions %}
   region_az_networks = {
     for region, region_spec in var.regions: region => {
       for az, network in region_spec.azs: az => network
     }
   }
-{% endif %}
-{% if has_machines %}
   region_machines = {
     for name, machine_spec in var.machines: machine_spec.region => {
       name = name
       spec = machine_spec
     }...
   }
-{% endif %}
-{% if has_databases %}
   region_databases = {
     for name, database_spec in var.databases: database_spec.region => {
       name = name
       spec = database_spec
     }...
   }
-{% endif %}
+  region_alloys = {
+    for name, spec in var.alloy: spec.region => {
+      name = name
+      spec = spec
+    }...
+  }
 }
 
 resource "random_id" "apply" {
@@ -45,6 +45,10 @@ resource "random_id" "apply" {
 {%    include "database.tf.j2" %}
 {%  endif %}
 
+{%   if has_alloy %}
+{%     include "alloy.tf.j2" %}
+{%   endif %}
+
 {% endfor %}
 
 {% if has_region_peering %}
@@ -62,13 +66,14 @@ servers:
 {% endif %}
 {% for region in machine_regions %}
 {% set region_ = region | replace('-', '_') %}
-%{for key in keys(module.machine_{{ region_ }}) ~}
+{% set module_ = "module.machine_" ~ region_  %}
+%{for key, value in {{ module_ }} ~}
     ${key}:
-      type: ${module.machine_{{ region_ }}[key].machine_ips.type}
-      region: ${module.machine_{{ region_ }}[key].machine_ips.region}
-      az: ${module.machine_{{ region_ }}[key].machine_ips.az}
-      public_ip: ${module.machine_{{ region_ }}[key].machine_ips.public_ip}
-      private_ip: ${module.machine_{{ region_ }}[key].machine_ips.private_ip}
+      type: ${ value.machine_ips.type }
+      region: ${ value.machine_ips.region }
+      az: ${ value.machine_ips.az }
+      public_ip: ${ value.machine_ips.public_ip }
+      private_ip: ${ value.machine_ips.private_ip }
 %{endfor~}
 {% endfor %}
 {% if database_regions | length > 0 %}
@@ -76,14 +81,31 @@ servers:
 {% endif %}
 {% for region in database_regions %}
 {% set region_ = region | replace('-', '_') %}
-%{for key in keys(module.database_{{ region_ }}) ~}
+{% set module_ = "module.database_" ~ region_  %}
+%{for key, value in {{module_}} ~}
     ${key}:
-      region: ${module.database_{{ region_ }}[key].database_ips.region}
-      username: "${module.database_{{ region_ }}[key].database_ips.username}"
-      password: "${module.database_{{ region_ }}[key].database_ips.password}"
-      address: ${module.database_{{ region_ }}[key].database_ips.address}
-      port: ${module.database_{{ region_ }}[key].database_ips.port}
-      dbname: "${module.database_{{ region_ }}[key].database_ips.dbname}"
+      region: ${ value.database_ips.region }
+      username: ${ value.database_ips.username }
+      password: ${ value.database_ips.password }
+      address: ${ value.database_ips.address }
+      port: ${ value.database_ips.port }
+      dbname: ${ value.database_ips.dbname }
+%{endfor~}
+{% endfor %}
+{% if alloy_regions | length > 0 %}
+  alloy:
+{% endif %}
+{% for region in alloy_regions %}
+{% set region_ = region | replace('-', '_') %}
+{% set module_ = "module.alloy_" ~ region_ %}
+%{for key, value in {{module_}} ~}
+    ${key}:
+      region: ${ value.ips.region }
+      username: ${ value.ips.username }
+      password: ${ value.ips.password }
+      address: ${ value.ips.address }
+      port: ${ value.ips.port }
+      dbname: ${ value.ips.dbname }
 %{endfor~}
 {% endfor %}
     EOT

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -1,7 +1,7 @@
 locals {
   region_az_networks = {
     for region, region_spec in var.regions: region => {
-      for az, network in region_spec.azs: az => network
+      for az, network in try(region_spec.azs, {}): az => network
     }
   }
   region_machines = {

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -92,3 +92,15 @@ servers:
 {% endfor %}
     EOT
 }
+
+{% for type, attributes in boxes.items() if attributes["active"] %}
+output "{{type}}" {
+  value = [
+{%   for region in attributes["regions"] -%}
+{%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
+    {{ module }}[*],
+{%   endfor %}
+  ]
+  sensitive = true
+}
+{% endfor %}

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -101,11 +101,9 @@ servers:
 %{for key, value in {{module_}} ~}
     ${key}:
       region: ${ value.ips.region }
-      username: ${ value.ips.username }
       password: ${ value.ips.password }
       address: ${ value.ips.address }
       port: ${ value.ips.port }
-      dbname: ${ value.ips.dbname }
 %{endfor~}
 {% endfor %}
     EOT

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -37,7 +37,7 @@ module "service_connection_{{ region_ }}" {
   name = "{{ region }}-${random_id.apply.hex}"
   network = module.vpc_{{ region_ }}.vpc_id
 
-  depends_on = [module.vpc_{{ region_ }}, local.region_databases]
+  depends_on = [local.region_databases, module.network_{{ region_ }}]
   
   providers = {
     google = google.{{ region_ }}
@@ -68,7 +68,7 @@ module "security_{{ region_ }}" {
       ] 
     ])
 
-  depends_on = [module.network_{{ region_ }}]
+  depends_on = [module.service_connection_{{ region_ }}]
 
   providers = {
     google = google.{{ region_ }}

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -30,7 +30,7 @@ module "service_connection_{{ region_ }}" {
   # Creates a single service connection,
   # if region has dbaas
   for_each = (
-    contains(keys(try(local.region_databases, {})), "{{ region }}") ? 
+    contains(keys(merge(local.region_databases, local.region_alloys)), "{{ region }}") ? 
       toset([ "{{region}}" ]) : toset([])
   )
 

--- a/edbterraform/data/templates/gcloud/providers.tf.j2
+++ b/edbterraform/data/templates/gcloud/providers.tf.j2
@@ -8,4 +8,9 @@ provider "google" {
   alias = "{{ region_ }}"
 }
 
+provider "google-beta" {
+  region = "{{ region }}"
+  alias = "{{ region_ }}"
+}
+
 {% endfor %}

--- a/edbterraform/data/templates/gcloud/region_peering.tf.j2
+++ b/edbterraform/data/templates/gcloud/region_peering.tf.j2
@@ -1,3 +1,4 @@
+{% set previous_created = [] %}
 {% for (requester, accepter) in peers %}
 {%   set requester_ = requester|replace('-', '_') %}
 {%   set accepter_ = accepter|replace('-', '_') %}
@@ -8,7 +9,11 @@ module "vpc_peering_{{ requester_ }}_{{ accepter_ }}" {
   peering_name = "peer-{{ requester }}-{{ accepter }}-${random_id.apply.hex}"
   peer_network = module.vpc_{{ accepter_ }}.vpc_id
 
-  depends_on = [module.vpc_{{ requester_ }}, module.vpc_{{ accepter_ }}]
+  depends_on = [
+    module.security_{{ requester_ }},
+    module.security_{{ accepter_ }},
+    {% if previous_created %}{{ previous_created[-1] }},{% endif %}
+  ]
 
   providers = {
     google = google.{{ requester_ }}
@@ -30,4 +35,5 @@ module "vpc_peering_{{ accepter_ }}_{{ requester_ }}" {
   }
 
 }
+{% set dummy = previous_created.append("module.vpc_peering_" + accepter_ + "_" + requester_) %}
 {% endfor %}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
@@ -1,0 +1,47 @@
+resource "google_alloydb_cluster" "main" {
+  cluster_id = var.name
+  location   = var.region
+  network    = var.network
+  # value not configurable at the moment
+  # database_version = "POSTGRES_14"
+
+  initial_user {
+    user = var.username
+    password = var.password
+  }
+
+  automated_backup_policy {
+    enabled = var.automated_backups
+    quantity_based_retention {
+        count = var.backup_count
+    }
+    weekly_schedule {
+        start_times {
+          hours = var.backup_start_time.hours
+          minutes = var.backup_start_time.minutes
+          seconds = var.backup_start_time.seconds
+          nanos = var.backup_start_time.nanos
+        }
+    }
+  }
+  
+}
+
+resource "google_alloydb_instance" "main" {
+  cluster       = google_alloydb_cluster.main.name
+  instance_id   = var.name
+  instance_type = "PRIMARY"
+  # ZONAL only available for READ_POOL instances
+  availability_type = "REGIONAL"
+
+  database_flags = { 
+    for setting in var.settings:
+      setting.name => setting.value
+    }
+
+  machine_config {
+    cpu_count = var.cpu_count
+  }
+
+  depends_on = [google_alloydb_cluster.main]
+}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
@@ -6,25 +6,25 @@ resource "google_alloydb_cluster" "main" {
   # database_version = "POSTGRES_14"
 
   initial_user {
-    user = var.username
+    user     = var.username
     password = var.password
   }
 
   automated_backup_policy {
     enabled = var.automated_backups
     quantity_based_retention {
-        count = var.backup_count
+      count = var.backup_count
     }
     weekly_schedule {
-        start_times {
-          hours = var.backup_start_time.hours
-          minutes = var.backup_start_time.minutes
-          seconds = var.backup_start_time.seconds
-          nanos = var.backup_start_time.nanos
-        }
+      start_times {
+        hours   = var.backup_start_time.hours
+        minutes = var.backup_start_time.minutes
+        seconds = var.backup_start_time.seconds
+        nanos   = var.backup_start_time.nanos
+      }
     }
   }
-  
+
 }
 
 resource "google_alloydb_instance" "main" {
@@ -34,10 +34,10 @@ resource "google_alloydb_instance" "main" {
   # ZONAL only available for READ_POOL instances
   availability_type = "REGIONAL"
 
-  database_flags = { 
-    for setting in var.settings:
-      setting.name => setting.value
-    }
+  database_flags = {
+    for setting in var.settings :
+    setting.name => setting.value
+  }
 
   machine_config {
     cpu_count = var.cpu_count

--- a/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
@@ -1,10 +1,8 @@
 output "ips" {
   value = {
-    region   = var.aurora.spec.region
-    username = aws_rds_cluster.aurora_cluster.master_username
-    password = aws_rds_cluster.aurora_cluster.master_password
-    address  = aws_rds_cluster.aurora_cluster.endpoint
-    port     = var.alloy.spec.port
-    dbname   = var.alloy.spec.dbname
+    region   = var.region
+    password = var.password
+    address  = google_alloydb_instance.main.ip_address
+    port     = var.port
   }
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
@@ -1,8 +1,21 @@
-output "ips" {
-  value = {
-    region   = var.region
-    password = var.password
-    address  = google_alloydb_instance.main.ip_address
-    port     = var.port
-  }
+output "region" {
+  value = var.region
+}
+output "zone" {
+  value = google_alloydb_instance.main.gce_zone
+}
+output "username" {
+  value = google_alloydb_cluster.main.initial_user.0.user
+}
+output "password" {
+  value = google_alloydb_cluster.main.initial_user.0.password
+}
+output "private_ip" {
+  value = google_alloydb_instance.main.ip_address
+}
+output "port" {
+  value = var.port
+}
+output "version" {
+  value = google_alloydb_cluster.main.database_version
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
@@ -1,0 +1,10 @@
+output "ips" {
+  value = {
+    region   = var.aurora.spec.region
+    username = aws_rds_cluster.aurora_cluster.master_username
+    password = aws_rds_cluster.aurora_cluster.master_password
+    address  = aws_rds_cluster.aurora_cluster.endpoint
+    port     = var.alloy.spec.port
+    dbname   = var.alloy.spec.dbname
+  }
+}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = ">= 4.46.0"
     }
   }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/providers.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
+      version = ">= 4.46.0"
     }
   }
   required_version = ">= 0.13"

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -2,71 +2,71 @@ variable "name" {}
 variable "network" {}
 variable "region" {}
 variable "zone" {
-    type = string
-    default = ""
-    nullable = false
+  type     = string
+  default  = ""
+  nullable = false
 }
 variable "port" {
-  type = number
-  default = 5432
+  type     = number
+  default  = 5432
   nullable = false
 }
 variable "cpu_count" {
-    type = number
-    default = 2
-    nullable = false
-    validation {
-      condition = (
-        64 % var.cpu_count == 0 &&
-        var.cpu_count >= 2
-        )
-        error_message = "cpu_count must be 2, 4, 8, 16, 32, 64"
-    }
+  type     = number
+  default  = 2
+  nullable = false
+  validation {
+    condition = (
+      64 % var.cpu_count == 0 &&
+      var.cpu_count >= 2
+    )
+    error_message = "cpu_count must be 2, 4, 8, 16, 32, 64"
+  }
 }
 variable "username" {
-    type = string
-    default = "postgres"
-    nullable = false
-    sensitive = true
+  type      = string
+  default   = "postgres"
+  nullable  = false
+  sensitive = true
 }
 variable "password" {}
 variable "settings" {
-    type = list(object({
+  type = list(object({
     name  = string
     value = string
   }))
 
-    validation {
-      condition = alltrue([
-        for setting in var.settings:
-            setting.name != "max_connections" ||
-            tonumber(setting.value) >= 1000
-      ])
-      error_message = "max_connections minimum allowed value: 1000"
-    }
+  validation {
+    condition = alltrue([
+      for setting in var.settings :
+      setting.name != "max_connections" ||
+      tonumber(setting.value) >= 1000
+    ])
+    error_message = "max_connections minimum allowed value: 1000"
+  }
 
 }
 variable "automated_backups" {
-  type = bool
-  default = false
+  type     = bool
+  default  = false
   nullable = false
 }
 variable "backup_count" {
-  type = number
-  default = 0
+  type     = number
+  default  = 0
   nullable = false
 }
 variable "backup_start_time" {
   default = {
-    hours = 0
+    hours   = 0
     minutes = 0
     seconds = 0
-    nanos = 0
+    nanos   = 0
   }
   nullable = false
 }
 variable "backup_days" {
-  type = list(string)
-  default = [ "SUNDAY" ]
+  type     = list(string)
+  default  = ["SUNDAY"]
   nullable = false
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -1,0 +1,72 @@
+variable "name" {}
+variable "network" {}
+variable "region" {}
+variable "zone" {
+    type = string
+    default = ""
+    nullable = false
+}
+variable "port" {
+  type = number
+  default = 5432
+  nullable = false
+}
+variable "cpu_count" {
+    type = number
+    default = 2
+    nullable = false
+    validation {
+      condition = (
+        64 % var.cpu_count == 0 &&
+        var.cpu_count >= 2
+        )
+        error_message = "cpu_count must be 2, 4, 8, 16, 32, 64"
+    }
+}
+variable "username" {
+    type = string
+    default = "postgres"
+    nullable = false
+    sensitive = true
+}
+variable "password" {}
+variable "settings" {
+    type = list(object({
+    name  = string
+    value = string
+  }))
+
+    validation {
+      condition = alltrue([
+        for setting in var.settings:
+            setting.name != "max_connections" ||
+            tonumber(setting.value) >= 1000
+      ])
+      error_message = "max_connections minimum allowed value: 1000"
+    }
+
+}
+variable "automated_backups" {
+  type = bool
+  default = false
+  nullable = false
+}
+variable "backup_count" {
+  type = number
+  default = 0
+  nullable = false
+}
+variable "backup_start_time" {
+  default = {
+    hours = 0
+    minutes = 0
+    seconds = 0
+    nanos = 0
+  }
+  nullable = false
+}
+variable "backup_days" {
+  type = list(string)
+  default = [ "SUNDAY" ]
+  nullable = false
+}

--- a/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
@@ -1,11 +1,24 @@
-output "database_ips" {
-  value = {
-    region    = var.region
-    username  = var.username
-    password  = var.password
-    address   = google_sql_database_instance.instance.private_ip_address
-    public_ip = google_sql_database_instance.instance.public_ip_address
-    port      = var.port
-    dbname    = google_sql_database.db.name
-  }
+output "region" {
+  value = google_sql_database_instance.instance.region
+}
+output "username" {
+  value = google_sql_user.user.name
+}
+output "password" {
+  value = google_sql_user.user.password
+}
+output "private_ip" {
+  value = google_sql_database_instance.instance.private_ip_address
+}
+output "public_ip" {
+  value = google_sql_database_instance.instance.public_ip_address
+}
+output "port" {
+  value = var.port
+}
+output "version" {
+  value = google_sql_database_instance.instance.database_version
+}
+output "dbname" {
+  value = google_sql_database.db.name
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -1,10 +1,18 @@
-output "machine_ips" {
-  value = {
-    type       = var.machine.spec.type
-    az         = var.machine.spec.az
-    region     = var.machine.spec.region
-    public_ip  = google_compute_instance.machine.network_interface.0.access_config.0.nat_ip
-    private_ip = google_compute_instance.machine.network_interface.0.network_ip
-  }
+output "type" {
+  value = var.machine.spec.type
 }
-
+output "instance_type" {
+  value = google_compute_instance.machine.machine_type
+}
+output "zone" {
+  value = google_compute_instance.machine.zone
+}
+output "region" {
+  value = var.machine.spec.region
+}
+output "public_ip" {
+  value = google_compute_instance.machine.network_interface.0.access_config.0.nat_ip
+}
+output "private_ip" {
+  value = google_compute_instance.machine.network_interface.0.network_ip
+}

--- a/edbterraform/data/terraform/gcloud/variables.tf
+++ b/edbterraform/data/terraform/gcloud/variables.tf
@@ -1,5 +1,6 @@
 variable "regions" {}
 variable "machines" {}
+variable "alloy" {}
 variable "databases" {}
 variable "cluster_name" {}
 variable "ssh_pub_key" {}

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -214,6 +214,17 @@ def build_vars(csp, infra_vars, ssh_priv_key, ssh_pub_key):
     return (terraform_vars, template_vars)
 
 def gcloud_build_vars(infra_vars, terraform_vars, template_vars):
+    # Add additional terraform variables
+    terraform_vars.update(dict(
+        alloy=infra_vars.get('alloy', dict()),
+    ))
+
+    # Build template variables
+    template_vars.update(dict(
+        has_alloy=('alloy' in infra_vars),
+        alloy_regions=object_regions('alloy', terraform_vars),
+    ))
+
     return (terraform_vars, template_vars)
 
 def aws_build_vars(infra_vars, terraform_vars, template_vars):

--- a/infrastructure-examples/alloy.yml
+++ b/infrastructure-examples/alloy.yml
@@ -1,0 +1,35 @@
+cluster_name: gcloud-infra
+gcloud:
+  ssh_user: rocky
+  operating_system:
+    name: rocky-linux-8
+  regions:
+    us-west4:
+      cidr_block: 10.4.0.0/16
+      azs:
+        us-west4-a: 10.4.1.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+  machines:
+    dbt2-driver2:
+      type: dbt2-driver
+      region: us-west4
+      az: us-west4-a
+      instance_type: c2-standard-4
+      volume:
+        type: pd-standard
+        size_gb: 50
+  alloy:
+    mydb2:
+      region: us-west4
+      cpu_count: 2
+      password: "12Password!"
+      settings:
+        - name: max_connections
+          value: 1000
+        - name: random_page_cost
+          value: 1.25
+        - name: work_mem
+          value: 16000

--- a/infrastructure-examples/gcloud-all.yml
+++ b/infrastructure-examples/gcloud-all.yml
@@ -1,0 +1,111 @@
+cluster_name: gcloud-infra
+gcloud:
+  ssh_user: rocky
+  operating_system:
+    name: rocky-linux-8
+  regions:
+    us-west1:
+      cidr_block: 10.1.0.0/16
+      azs:
+        us-west1-b: 10.1.20.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+    us-west2:
+      cidr_block: 10.2.0.0/16
+      azs:
+        us-west2-b: 10.2.20.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+      regional_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+    us-west4:
+      cidr_block: 10.4.0.0/16
+  machines:
+    dbt2-driver2:
+      type: dbt2-driver
+      region: us-west1
+      az: us-west1-b
+      instance_type: c2-standard-4
+      volume:
+        type: pd-standard
+        size_gb: 50
+    dbt2-proxy:
+      type: proxy
+      region: us-west2
+      az: us-west2-b
+      ip_forward: true
+      instance_type: c2-standard-4
+      volume:
+        type: pd-standard
+        size_gb: 50
+  databases:
+    mydb1:
+      region: us-west2
+      az: us-west2-b
+      engine: postgres
+      engine_version: 14
+      instance_type: db-f1-micro
+      dbname: "dbt2"
+      username: "postgres"
+      password: "12Password!"
+      port: 5432
+      volume:
+        size_gb: 50
+        type: pd-ssd
+        iops: 1000
+        encrypted: true
+      settings:
+        - name: checkpoint_timeout
+          value: 900
+        - name: max_connections
+          value: 300
+        - name: max_wal_size
+          value: 5000
+        - name: random_page_cost
+          value: 1.25
+        - name: work_mem
+          value: 16000
+    mydb2:
+      region: us-west2
+      az: us-west2-b
+      engine: postgres
+      engine_version: 14
+      instance_type: db-f1-micro
+      dbname: "dbt2"
+      username: "postgres"
+      password: "12Password!"
+      port: 5432
+      volume:
+        size_gb: 50
+        type: pd-ssd
+        iops: 1000
+        encrypted: true
+      settings:
+        - name: checkpoint_timeout
+          value: 900
+        - name: max_connections
+          value: 300
+        - name: max_wal_size
+          value: 5000
+        - name: random_page_cost
+          value: 1.25
+        - name: work_mem
+          value: 16000
+  alloy:
+    mydb2:
+      region: us-west4
+      cpu_count: 2
+      password: "12Password!"
+      settings:
+        - name: max_connections
+          value: 1000
+        - name: random_page_cost
+          value: 1.25
+        - name: work_mem
+          value: 16000


### PR DESCRIPTION
AlloyDB:
* uses `google-beta` provider
* database name not configurable through terraform
* ports not configurable
* database version not configurable, inferred by final configuration
  * currently postgres 14 compatable
* private network only and peered to same regions VPC with no public access option
  * create bastion host in the same region or use alternative connection method

Template changes:
* `main.tf.j2` 
  * removal of jinja2 check for locals and instead initial variable defined in `variable.tf`
  * outputs modified
    * able to use `terraform output -json`

Fixes:
* region peering race condition
* allow cloudsql and alloydb to be created without zones defined for its region