### PR TITLE
RDS: fix configuration group family name

### DIFF
--- a/edbterraform/data/terraform/aws/modules/database/main.tf
+++ b/edbterraform/data/terraform/aws/modules/database/main.tf
@@ -60,7 +60,7 @@ resource "aws_db_instance" "rds_server" {
 
 resource "aws_db_parameter_group" "edb_rds_db_params" {
   name   = format("db-parameter-group-rds-%s-%s", var.name_id, lower(var.database.name))
-  family = format("%s%s", var.database.spec.engine, var.database.spec.engine_version)
+  family = format(contains(["postgres", "mysql", "mariadb"], var.database.spec.engine) ? "%s%s" : "%s-%s", var.database.spec.engine, var.database.spec.engine_version)
 
   dynamic "parameter" {
     for_each = { for i, v in lookup(var.database.spec, "settings", []) : i => v }


### PR DESCRIPTION
Depending on the database engine, the configuration group family format can be `dbengine-version` or `dbengineversion`.

With this fix, Oracle database provisioning in RDS is supported.

Note: using the db.t3.micro instance type is not allowed with oracle-ee. Tests with db.t3.large worked.

Infrastructure file sample:
```yaml
  databases:
    mydb1:
      engine: oracle-ee
      engine_version: 19
      instance_type: db.t3.large
      port: 1521
```