### PR TITLE
Support for tagging in each provider module collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ infrastructure. Example yaml files found inside [infrastructure-examples directo
 
 ```yaml
 aws:
-  cluster_name: ec2-machines-demo
+  tags:
+    cluster_name: ec2-machines-demo
+    created_by: terraform
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -102,7 +104,8 @@ aws:
 
 ```yaml
 aws:
-  cluster_name: rds-database-demo
+  tags:
+    cluster_name: rds-database-demo
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
@@ -144,7 +147,8 @@ aws:
 
 ```yaml
 aws:
-  cluster_name: aurora-demo
+  tags:
+    cluster_name: aurora-demo
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
@@ -182,7 +186,8 @@ aws:
 
 ```yaml
 aws:
-  cluster_name: BuildBot-Demo
+  tags:
+    cluster_name: BuildBot-Demo
   ssh_user: ubuntu
   operating_system:
     name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-
@@ -237,7 +242,8 @@ aws:
 
 ```yaml
 gcloud:
-  cluster_name: gcloud-infra
+  tags:
+    cluster_name: gcloud-infra
   ssh_user: rocky
   operating_system:
     name: rocky-linux-8

--- a/edbterraform/data/templates/aws/aurora.tf.j2
+++ b/edbterraform/data/templates/aws/aurora.tf.j2
@@ -5,10 +5,9 @@ module "aurora_{{ region_ }}" {
 
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
   aurora                   = each.value
-  cluster_name             = module.spec.value.cluster_name
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
-  created_by               = var.created_by
   name_id                  = module.spec.hex_id
+  tags                     = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/aurora.tf.j2
+++ b/edbterraform/data/templates/aws/aurora.tf.j2
@@ -7,6 +7,7 @@ module "aurora_{{ region_ }}" {
   aurora                   = each.value
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
   name_id                  = module.spec.hex_id
+  cluster_name             = module.spec.value.tags.cluster_name
   tags                     = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]

--- a/edbterraform/data/templates/aws/database.tf.j2
+++ b/edbterraform/data/templates/aws/database.tf.j2
@@ -5,10 +5,9 @@ module "database_{{ region_ }}" {
 
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
   database                 = each.value
-  cluster_name             = module.spec.value.cluster_name
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
-  created_by               = var.created_by
   name_id                  = module.spec.hex_id
+  tags                     = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/key_pair.tf.j2
+++ b/edbterraform/data/templates/aws/key_pair.tf.j2
@@ -1,7 +1,7 @@
 module "key_pair_{{ region_ }}" {
   source = "./modules/key_pair"
 
-  key_name = module.spec.value.cluster_name
+  key_name = module.spec.value.tags.cluster_name
   ssh_pub_key  = var.ssh_pub_key
   name_id = module.spec.hex_id
 

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -8,13 +8,12 @@ module "machine_{{ region_ }}" {
   cidr_block               = lookup(lookup(module.spec.region_zone_networks, "{{ region }}", null), each.value.spec.zone, null)
   az                       = each.value.spec.zone
   machine                  = each.value
-  cluster_name             = module.spec.value.cluster_name
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
   ssh_pub_key              = var.ssh_pub_key
   ssh_priv_key             = var.ssh_priv_key
   ssh_user                 = module.spec.value.ssh_user
-  created_by               = var.created_by
   key_name                 = module.key_pair_{{ region_ }}.key_pair_id
+  tags                     = each.value.spec.tags
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -36,7 +36,7 @@ module "routes_{{ region_ }}" {
   vpc_id             = module.vpc_{{ region_ }}.vpc_id
   project_tag        = var.project_tag
   public_cidrblock   = var.public_cidrblock
-  cluster_name       = module.spec.value.cluster_name
+  cluster_name       = module.spec.value.tags.cluster_name
 
   depends_on = [module.network_{{ region_ }}]
 
@@ -52,7 +52,7 @@ module "security_{{ region_ }}" {
   public_cidrblock = var.public_cidrblock
   project_tag      = var.project_tag
   service_ports    = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "service_ports", [])
-  cluster_name     = module.spec.value.cluster_name
+  cluster_name     = module.spec.value.tags.cluster_name
   region_cidrblocks = ([ for k, v 
                       in lookup(lookup(module.spec.value.regions, "{{ region }}", null), "azs", [])
                       : v ])

--- a/edbterraform/data/templates/azure/kubernetes.tf.j2
+++ b/edbterraform/data/templates/azure/kubernetes.tf.j2
@@ -9,12 +9,12 @@ module "kubernetes_{{ region_ }}" {
   aksServicePrincipalAppId        = each.value.spec.aksServicePrincipalAppId
   aksServicePrincipalClientSecret = each.value.spec.aksServicePrincipalClientSecret
   nodeCount                       = each.value.spec.nodeCount
-  cluster_name                    = module.spec.value.cluster_name
+  cluster_name                    = module.spec.value.tags.cluster_name
   logAnalyticsWorkspaceLocation   = each.value.spec.logAnalyticsWorkspaceLocation
-  logAnalyticsWorkspaceName       = "${replace(module.spec.value.cluster_name,"-","")}${module.spec.pet_name}Workspace"
+  logAnalyticsWorkspaceName       = "${replace(module.spec.value.tags.cluster_name,"-","")}${module.spec.pet_name}Workspace"
   logAnalyticsWorkspaceSku        = each.value.spec.logAnalyticsWorkspaceSku
   resourceGroupLocation           = each.value.spec.resourceGroupLocation
-  resourceGroupName               = "${module.spec.value.cluster_name}-RG-${module.spec.pet_name}"
+  resourceGroupName               = "${module.spec.value.tags.cluster_name}-RG-${module.spec.pet_name}"
   vmSize                          = each.value.spec.instance_type
   solutionName                    = each.value.spec.solutionName
   publisherName                   = each.value.spec.publisherName

--- a/edbterraform/data/templates/azure/kubernetes.tf.j2
+++ b/edbterraform/data/templates/azure/kubernetes.tf.j2
@@ -6,18 +6,16 @@ module "kubernetes_{{ region_ }}" {
       rm.name => rm 
     })
 
-  aksServicePrincipalAppId        = each.value.spec.aksServicePrincipalAppId
-  aksServicePrincipalClientSecret = each.value.spec.aksServicePrincipalClientSecret
-  nodeCount                       = each.value.spec.nodeCount
+  nodeCount                       = each.value.spec.node_count
   cluster_name                    = module.spec.value.tags.cluster_name
-  logAnalyticsWorkspaceLocation   = each.value.spec.logAnalyticsWorkspaceLocation
+  logAnalyticsWorkspaceLocation   = each.value.spec.log_analytics_location
   logAnalyticsWorkspaceName       = "${replace(module.spec.value.tags.cluster_name,"-","")}${module.spec.pet_name}Workspace"
-  logAnalyticsWorkspaceSku        = each.value.spec.logAnalyticsWorkspaceSku
-  resourceGroupLocation           = each.value.spec.resourceGroupLocation
+  logAnalyticsWorkspaceSku        = each.value.spec.log_analytics_sku
+  resourceGroupLocation           = each.value.spec.resource_group_location
   resourceGroupName               = "${module.spec.value.tags.cluster_name}-RG-${module.spec.pet_name}"
   vmSize                          = each.value.spec.instance_type
-  solutionName                    = each.value.spec.solutionName
-  publisherName                   = each.value.spec.publisherName
+  solutionName                    = each.value.spec.solution_name
+  publisherName                   = each.value.spec.publisher_name
   ssh_user                        = module.spec.value.ssh_user
   sshPublicKey                    = var.ssh_pub_key  
   tags                            = each.value.spec.tags

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -9,7 +9,7 @@ module "machine_{{ region_ }}" {
   resource_name                   = module.vpc_{{ region_ }}.resource_name
   subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone].subnet_id
   operating_system                = module.spec.value.operating_system
-  cluster_name                    = module.spec.value.cluster_name
+  cluster_name                    = module.spec.value.tags.cluster_name
   machine                         = (
     merge(
       each.value.spec,
@@ -22,6 +22,7 @@ module "machine_{{ region_ }}" {
   private_key                     = var.ssh_priv_key
   public_key_name                 = module.key_pair_{{ region_ }}.name
   name_id                         = module.spec.hex_id
+  tags                            = each.value.spec.tags
 
   depends_on = [
     module.key_pair_{{ region_ }},

--- a/edbterraform/data/templates/gcloud/alloy.tf.j2
+++ b/edbterraform/data/templates/gcloud/alloy.tf.j2
@@ -19,6 +19,7 @@ module "alloy_{{ region_ }}" {
       value = setting.value
     }
   ])
+  tags = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/database.tf.j2
+++ b/edbterraform/data/templates/gcloud/database.tf.j2
@@ -26,6 +26,7 @@ module "database_{{ region_ }}" {
       value = setting.value
     }
   ])
+  tags = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/kubernetes.tf.j2
+++ b/edbterraform/data/templates/gcloud/kubernetes.tf.j2
@@ -12,6 +12,7 @@ module "kubernetes_{{ region_ }}" {
   subnetwork                      = module.network_{{ region_ }}[each.value.spec.zone].name
   network                         = module.vpc_{{ region_ }}.name
   name_id                         = module.spec.hex_id
+  node_count                      = each.value.spec.node_count
   tags = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]

--- a/edbterraform/data/templates/gcloud/kubernetes.tf.j2
+++ b/edbterraform/data/templates/gcloud/kubernetes.tf.j2
@@ -6,12 +6,13 @@ module "kubernetes_{{ region_ }}" {
       rm.name => rm 
     })
 
-  cluster_name                    = module.spec.value.cluster_name
+  cluster_name                    = module.spec.value.tags.cluster_name
   region                          = each.value.spec.region
   machine                         = each.value
   subnetwork                      = module.network_{{ region_ }}[each.value.spec.zone].name
   network                         = module.vpc_{{ region_ }}.name
   name_id                         = module.spec.hex_id
+  tags = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -7,7 +7,7 @@ module "machine_{{ region_ }}" {
     })
 
   operating_system                = module.spec.value.operating_system
-  cluster_name                    = module.spec.value.cluster_name
+  cluster_name                    = module.spec.value.tags.cluster_name
   zone                            = each.value.spec.zone
   machine                         = each.value
   ssh_user                        = module.spec.value.ssh_user
@@ -16,6 +16,7 @@ module "machine_{{ region_ }}" {
   ssh_metadata                    = module.key_pair_{{ region_ }}.keys
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone].name
   name_id                         = module.spec.hex_id
+  tags = each.value.spec.tags
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
 

--- a/edbterraform/data/terraform/aws/modules/aurora/main.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/main.tf
@@ -9,6 +9,10 @@ variable "publicly_accessible" {
   default  = true
   nullable = false
 }
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
 
 terraform {
   required_providers {
@@ -30,10 +34,7 @@ resource "aws_db_subnet_group" "aurora" {
   name       = format("rds-subnet-group-aurora-%s-%s", var.name_id, var.aurora.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "aurora")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }
 
 resource "aws_rds_cluster" "aurora_cluster" {
@@ -51,10 +52,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [var.custom_security_group_id]
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "aurora-cluster")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }
 
 resource "aws_rds_cluster_instance" "aurora_instance" {
@@ -69,10 +67,7 @@ resource "aws_rds_cluster_instance" "aurora_instance" {
   apply_immediately       = true
   publicly_accessible     = var.publicly_accessible
 
-  tags = {
-    Name       = format("%s-%s-%s", var.cluster_name, "aurora-instance", count.index)
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }
 
 resource "aws_db_parameter_group" "aurora_db_params" {
@@ -88,8 +83,5 @@ resource "aws_db_parameter_group" "aurora_db_params" {
     }
   }
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "rds-aurora")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }

--- a/edbterraform/data/terraform/aws/modules/aurora/main.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/main.tf
@@ -2,7 +2,6 @@ variable "aurora" {}
 variable "vpc_id" {}
 variable "custom_security_group_id" {}
 variable "cluster_name" {}
-variable "created_by" {}
 variable "name_id" { default = "0" }
 variable "publicly_accessible" {
   type     = bool

--- a/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
@@ -37,3 +37,7 @@ output "dbname" {
 output "instance_type" {
   value = aws_rds_cluster.aurora_cluster.db_cluster_instance_class
 }
+
+output "tags" {
+  value = aws_rds_cluster.aurora_cluster.tags_all
+}

--- a/edbterraform/data/terraform/aws/modules/database/main.tf
+++ b/edbterraform/data/terraform/aws/modules/database/main.tf
@@ -1,13 +1,15 @@
 variable "database" {}
 variable "vpc_id" {}
 variable "custom_security_group_id" {}
-variable "cluster_name" {}
-variable "created_by" {}
 variable "name_id" { default = "0" }
 variable "publicly_accessible" {
   type     = bool
   default  = true
   nullable = false
+}
+variable "tags" {
+  type    = map(string)
+  default = {}
 }
 
 terraform {
@@ -30,10 +32,7 @@ resource "aws_db_subnet_group" "rds" {
   name       = format("rds-subnet-group-rds-%s-%s", var.name_id, var.database.name)
   subnet_ids = tolist(data.aws_subnets.ids.ids)
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "rds")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }
 
 resource "aws_db_instance" "rds_server" {
@@ -57,10 +56,7 @@ resource "aws_db_instance" "rds_server" {
   vpc_security_group_ids  = [var.custom_security_group_id]
   skip_final_snapshot     = true
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "rds")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }
 
 resource "aws_db_parameter_group" "edb_rds_db_params" {
@@ -76,8 +72,5 @@ resource "aws_db_parameter_group" "edb_rds_db_params" {
     }
   }
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, "rds")
-    Created_By = var.created_by
-  }
+  tags = var.tags
 }

--- a/edbterraform/data/terraform/aws/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/database/outputs.tf
@@ -37,3 +37,7 @@ output "instance_type" {
 output "dbname" {
   value = aws_db_instance.rds_server.db_name
 }
+
+output "tags" {
+  value = aws_db_instance.rds_server.tags_all
+}

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -6,12 +6,11 @@ variable "ssh_user" {}
 variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
 variable "custom_security_group_id" {}
-variable "created_by" {}
 variable "key_name" {}
 variable "operating_system" {}
 variable "tags" {
   type    = map(string)
-  default = string
+  default = {}
 }
 
 terraform {

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -6,10 +6,13 @@ variable "ssh_user" {}
 variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
 variable "custom_security_group_id" {}
-variable "cluster_name" {}
 variable "created_by" {}
 variable "key_name" {}
 variable "operating_system" {}
+variable "tags" {
+  type    = map(string)
+  default = string
+}
 
 terraform {
   required_providers {
@@ -56,10 +59,7 @@ resource "aws_instance" "machine" {
     iops                  = var.machine.spec.volume.type == "io2" ? var.machine.spec.volume.iops : var.machine.spec.volume.type == "io1" ? var.machine.spec.volume.iops : null
   }
 
-  tags = {
-    Name       = format("%s-%s", var.cluster_name, var.machine.name)
-    Created_By = var.created_by
-  }
+  tags = var.tags
 
   connection {
     private_key = file(var.ssh_pub_key)
@@ -75,9 +75,7 @@ resource "aws_ebs_volume" "ebs_volume" {
   iops              = each.value.type == "io2" ? each.value.iops : each.value.type == "io1" ? each.value.iops : null
   encrypted         = each.value.encrypted
 
-  tags = {
-    Name = format("%s-%s-%s-%s", var.machine.name, var.cluster_name, "ebs", each.key)
-  }
+  tags = var.tags
 }
 
 locals {

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -25,3 +25,7 @@ output "private_ip" {
 output "public_dns" {
   value = aws_instance.machine.public_dns
 }
+
+output "tags" {
+  value = aws_instance.machine.tags_all
+}

--- a/edbterraform/data/terraform/aws/modules/specification/main.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/main.tf
@@ -1,3 +1,6 @@
 resource "random_id" "apply" {
   byte_length = 4
 }
+
+resource "random_pet" "name" {
+}

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -15,7 +15,13 @@ output "region_machines" {
   value = {
     for name, machine_spec in var.spec.machines : machine_spec.region => {
       name = name
-      spec = machine_spec
+      spec = merge(machine_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, machine_spec.tags, {
+          # machine module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -24,7 +30,13 @@ output "region_databases" {
   value = {
     for name, database_spec in var.spec.databases : database_spec.region => {
       name = name
-      spec = database_spec
+      spec = merge(database_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, database_spec.tags, {
+          # database module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -33,11 +45,21 @@ output "region_auroras" {
   value = {
     for name, aurora_spec in var.spec.aurora : aurora_spec.region => {
       name = name
-      spec = aurora_spec
+      spec = merge(aurora_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, aurora_spec.tags, {
+          # aurora module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
 
 output "hex_id" {
   value = random_id.apply.hex
+}
+
+output "pet_name" {
+  value = random_pet.name.id
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -1,7 +1,10 @@
 variable "spec" {
   type = object({
-    ssh_user     = string
-    cluster_name = string
+    tags = optional(object({
+      cluster_name = optional(string, "AWS-Cluster")
+      created_by   = optional(string, "EDB-Terraform-AWS")
+    }), {})
+    ssh_user = string
     operating_system = optional(object({
       name  = string
       owner = number
@@ -38,6 +41,7 @@ variable "spec" {
         type        = string
         encrypted   = optional(bool)
       })), [])
+      tags = optional(map(string), {})
     })), {})
     databases = optional(map(object({
       region         = string
@@ -58,6 +62,7 @@ variable "spec" {
         name  = string
         value = number
       })), [])
+      tags = optional(map(string), {})
     })), {})
     aurora = optional(map(object({
       region         = string
@@ -74,6 +79,7 @@ variable "spec" {
         name  = string
         value = string
       })), [])
+      tags = optional(map(string), {})
     })), {})
   })
 

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -1,5 +1,6 @@
 variable "spec" {
   type = object({
+    # Project Level Tags to be merged with other tags
     tags = optional(object({
       cluster_name = optional(string, "AWS-Cluster")
       created_by   = optional(string, "EDB-Terraform-AWS")

--- a/edbterraform/data/terraform/aws/variables.tf
+++ b/edbterraform/data/terraform/aws/variables.tf
@@ -51,9 +51,3 @@ variable "custom_security_group_id" {
   type        = string
   default     = ""
 }
-
-variable "created_by" {
-  type        = string
-  description = "EDB terraform AWS"
-  default     = "EDB terraform AWS"
-}

--- a/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
@@ -47,9 +47,8 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     network_plugin    = "kubenet"
     load_balancer_sku = "standard"
   }
-  service_principal {
-    client_id     = var.aksServicePrincipalAppId
-    client_secret = var.aksServicePrincipalClientSecret
+  identity {
+    type = "SystemAssigned"
   }
 }
 

--- a/edbterraform/data/terraform/azure/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/outputs.tf
@@ -8,24 +8,23 @@ output "client_key" {
   sensitive = true
 }
 
-output "cluster_ca_certificate" {
+output "ca_certificate" {
   value     = azurerm_kubernetes_cluster.k8s.kube_config[0].cluster_ca_certificate
   sensitive = true
 }
 
-output "cluster_password" {
+output "password" {
   value     = azurerm_kubernetes_cluster.k8s.kube_config[0].password
   sensitive = true
 }
 
-output "cluster_username" {
+output "username" {
   value     = azurerm_kubernetes_cluster.k8s.kube_config[0].username
   sensitive = true
 }
 
 output "host" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].host
-  sensitive = true
+  value = azurerm_kubernetes_cluster.k8s.kube_config[0].host
 }
 
 output "kube_config" {
@@ -37,7 +36,7 @@ output "resource_group_name" {
   value = azurerm_resource_group.rg.name
 }
 
-output "kubernetes_cluster_name" {
+output "cluster_name" {
   value = azurerm_kubernetes_cluster.k8s.name
 }
 

--- a/edbterraform/data/terraform/azure/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/variables.tf
@@ -1,11 +1,3 @@
-variable "aksServicePrincipalAppId" {
-  default = "<YourServicePrincipalAppId"
-}
-
-variable "aksServicePrincipalClientSecret" {
-  default = "<YourServicePrincipalClientSecret>"
-}
-
 variable "cluster_name" {
   default = "EDB-k8s"
 }

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -66,6 +66,8 @@ resource "azurerm_linux_virtual_machine" "main" {
     version   = var.operating_system.version
   }
 
+  tags = var.tags
+
   depends_on = [azurerm_network_interface.internal, ]
 }
 

--- a/edbterraform/data/terraform/azure/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/outputs.tf
@@ -16,3 +16,6 @@ output "public_ip" {
 output "private_ip" {
   value = azurerm_linux_virtual_machine.main.private_ip_address
 }
+output "tags" {
+  value = azurerm_linux_virtual_machine.main.tags
+}

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -20,6 +20,10 @@ variable "machine" {
     })
   })
 }
+variable "tags" {
+  type    = map(sting)
+  default = {}
+}
 variable "cluster_name" {}
 locals {
   zones         = var.machine.zone == null ? null : [var.machine.zone]

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -21,7 +21,7 @@ variable "machine" {
   })
 }
 variable "tags" {
-  type    = map(sting)
+  type    = map(string)
   default = {}
 }
 variable "cluster_name" {}

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -15,7 +15,13 @@ output "region_machines" {
   value = {
     for name, machine_spec in var.spec.machines : machine_spec.region => {
       name = name
-      spec = machine_spec
+      spec = merge(machine_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, machine_spec.tags, {
+          # machine module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -24,7 +30,13 @@ output "region_kubernetes" {
   value = {
     for name, spec in var.spec.kubernetes : spec.region => {
       name = name
-      spec = spec
+      spec = merge(spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, spec.tags, {
+          # kubernetes module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -1,7 +1,11 @@
 variable "spec" {
   type = object({
-    ssh_user     = optional(string)
-    cluster_name = string
+    # Project Level Tags
+    tags = optional(object({
+      cluster_name = optional(string, "Azure-Cluster")
+      created_by   = optional(string, "EDB-Terraform-Azure")
+    }), {})
+    ssh_user = optional(string)
     operating_system = optional(object({
       publisher = string
       offer     = string
@@ -39,6 +43,7 @@ variable "spec" {
         iops        = optional(number)
         type        = string
       })), [])
+      tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
       region                          = string

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -1,6 +1,6 @@
 variable "spec" {
   type = object({
-    # Project Level Tags
+    # Project Level Tags to be merged with other tags
     tags = optional(object({
       cluster_name = optional(string, "Azure-Cluster")
       created_by   = optional(string, "EDB-Terraform-Azure")
@@ -46,18 +46,15 @@ variable "spec" {
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
-      region                          = string
-      resourceGroupLocation           = optional(string)
-      logAnalyticsWorkspaceLocation   = optional(string)
-      zone                            = string
-      nodeCount                       = number
-      instance_type                   = string
-      aksServicePrincipalAppId        = string
-      aksServicePrincipalClientSecret = string
-      logAnalyticsWorkspaceSku        = string
-      solutionName                    = string
-      publisherName                   = string
-      tags                            = optional(map(string), {})
+      region                  = string
+      resource_group_location = optional(string)
+      log_analytics_location  = optional(string)
+      node_count              = number
+      instance_type           = string
+      log_analytics_sku       = string
+      solution_name           = string
+      publisher_name          = string
+      tags                    = optional(map(string), {})
     })), {})
   })
 

--- a/edbterraform/data/terraform/azure/variables.tf
+++ b/edbterraform/data/terraform/azure/variables.tf
@@ -52,9 +52,3 @@ variable "subnet_tag" {
 variable "vpc_tag" {
   default = "edb-vpc"
 }
-
-variable "created_by" {
-  type        = string
-  description = "EDB terraform Azure"
-  default     = "EDB terraform Azure"
-}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
@@ -25,6 +25,8 @@ resource "google_alloydb_cluster" "main" {
     }
   }
 
+  labels = var.tags
+
 }
 
 resource "google_alloydb_instance" "main" {
@@ -44,4 +46,6 @@ resource "google_alloydb_instance" "main" {
   }
 
   depends_on = [google_alloydb_cluster.main]
+
+  labels = var.tags
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
@@ -24,3 +24,6 @@ output "port" {
 output "version" {
   value = google_alloydb_cluster.main.database_version
 }
+output "tags" {
+  value = google_alloydb_cluster.main.labels
+}

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -70,9 +70,9 @@ variable "tags" {
   default = {}
 
   validation {
-    condition     = alltrue([
-      for key, value in var.tags:
-        lower(key) == key && lower(value) == value
+    condition = alltrue([
+      for key, value in var.tags :
+      lower(key) == key && lower(value) == value
     ])
     error_message = <<-EOT
 GCloud expects all tags(labels) to be lowercase

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -68,4 +68,20 @@ variable "backup_days" {
 variable "tags" {
   type    = map(string)
   default = {}
+
+  validation {
+    condition     = alltrue([
+      for key, value in var.tags:
+        lower(key) == key && lower(value) == value
+    ])
+    error_message = <<-EOT
+GCloud expects all tags(labels) to be lowercase
+Fix the following tags:
+%{for key, value in var.tags}
+%{if !(lower(key) == key && lower(value) == value)}
+  ${key}: ${value}
+%{endif}
+%{endfor}
+    EOT
+  }
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -65,3 +65,7 @@ variable "backup_days" {
   default  = ["SUNDAY"]
   nullable = false
 }
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/edbterraform/data/terraform/gcloud/modules/database/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/main.tf
@@ -18,6 +18,7 @@ resource "google_sql_database_instance" "instance" {
     disk_type             = upper(replace(var.disk_type, ".", "_"))
     disk_autoresize       = var.autoresize
     disk_autoresize_limit = (var.autoresize ? var.autoresize_limit : null)
+    user_labels = var.tags
 
     location_preference {
       zone = var.zone

--- a/edbterraform/data/terraform/gcloud/modules/database/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/main.tf
@@ -18,7 +18,7 @@ resource "google_sql_database_instance" "instance" {
     disk_type             = upper(replace(var.disk_type, ".", "_"))
     disk_autoresize       = var.autoresize
     disk_autoresize_limit = (var.autoresize ? var.autoresize_limit : null)
-    user_labels = var.tags
+    user_labels           = var.tags
 
     location_preference {
       zone = var.zone

--- a/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
@@ -25,4 +25,6 @@ output "version" {
 output "dbname" {
   value = google_sql_database.db.name
 }
-
+output "tags" {
+  value = google_sql_database_instance.instance.settings[0].user_labels
+}

--- a/edbterraform/data/terraform/gcloud/modules/database/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/variables.tf
@@ -89,4 +89,20 @@ variable "deletion_protection" {
 variable "tags" {
   type    = map(string)
   default = {}
+
+  validation {
+    condition     = alltrue([
+      for key, value in var.tags:
+        lower(key) == key && lower(value) == value
+    ])
+    error_message = <<-EOT
+GCloud expects all tags(labels) to be lowercase
+Fix the following tags:
+%{for key, value in var.tags}
+%{if !(lower(key) == key && lower(value) == value)}
+  ${key}: ${value}
+%{endif}
+%{endfor}
+    EOT
+  }
 }

--- a/edbterraform/data/terraform/gcloud/modules/database/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/variables.tf
@@ -86,3 +86,7 @@ variable "deletion_protection" {
   default  = false
   nullable = false
 }
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/edbterraform/data/terraform/gcloud/modules/database/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/variables.tf
@@ -91,9 +91,9 @@ variable "tags" {
   default = {}
 
   validation {
-    condition     = alltrue([
-      for key, value in var.tags:
-        lower(key) == key && lower(value) == value
+    condition = alltrue([
+      for key, value in var.tags :
+      lower(key) == key && lower(value) == value
     ])
     error_message = <<-EOT
 GCloud expects all tags(labels) to be lowercase

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
@@ -6,6 +6,7 @@ resource "google_container_cluster" "primary" {
 
   network    = var.network
   subnetwork = var.subnetwork
+  labels     = var.tags
 }
 
 resource "google_container_node_pool" "primary_nodes" {

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
@@ -6,14 +6,15 @@ resource "google_container_cluster" "primary" {
 
   network    = var.network
   subnetwork = var.subnetwork
-  labels     = var.tags
+
+  resource_labels = var.tags
 }
 
 resource "google_container_node_pool" "primary_nodes" {
   name       = var.cluster_name
   location   = var.machine.spec.region
   cluster    = google_container_cluster.primary.name
-  node_count = 3
+  node_count = var.node_count
 
   node_config {
     oauth_scopes = [
@@ -22,6 +23,7 @@ resource "google_container_node_pool" "primary_nodes" {
     ]
 
     machine_type = var.machine.spec.instance_type
+    labels       = var.tags
     tags         = [format("%s-%s", var.cluster_name, "gke-node"), format("%s-%s", var.cluster_name, "gke")]
     metadata = {
       disable-legacy-endpoints = "true"

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
@@ -1,14 +1,14 @@
 output "region" {
   value = var.machine.spec.region
 }
-output "kubernetes_cluster_name" {
+output "cluster_name" {
   value       = google_container_cluster.primary.name
   description = "GKE Cluster Name"
 }
-output "kubernetes_cluster_host" {
+output "host" {
   value       = google_container_cluster.primary.endpoint
   description = "GKE Cluster Host"
 }
 output "tags" {
-  value = google_container_cluster.primary.labels
+  value = google_container_cluster.primary.resource_labels
 }

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
@@ -9,3 +9,6 @@ output "kubernetes_cluster_host" {
   value       = google_container_cluster.primary.endpoint
   description = "GKE Cluster Host"
 }
+output "tags" {
+  value = google_container_cluster.primary.labels
+}

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
@@ -4,3 +4,7 @@ variable "cluster_name" {}
 variable "subnetwork" {}
 variable "network" {}
 variable "name_id" { default = "0" }
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
@@ -3,15 +3,18 @@ variable "region" {}
 variable "cluster_name" {}
 variable "subnetwork" {}
 variable "network" {}
+variable "node_count" {
+  type = number
+}
 variable "name_id" { default = "0" }
 variable "tags" {
   type    = map(string)
   default = {}
 
   validation {
-    condition     = alltrue([
-      for key, value in var.tags:
-        lower(key) == key && lower(value) == value
+    condition = alltrue([
+      for key, value in var.tags :
+      lower(key) == key && lower(value) == value
     ])
     error_message = <<-EOT
 GCloud expects all tags(labels) to be lowercase

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
@@ -7,4 +7,21 @@ variable "name_id" { default = "0" }
 variable "tags" {
   type    = map(string)
   default = {}
+
+  validation {
+    condition     = alltrue([
+      for key, value in var.tags:
+        lower(key) == key && lower(value) == value
+    ])
+    error_message = <<-EOT
+GCloud expects all tags(labels) to be lowercase
+Fix the following tags:
+%{for key, value in var.tags}
+%{if !(lower(key) == key && lower(value) == value)}
+  ${key}: ${value}
+%{endif}
+%{endfor}
+    EOT
+  }
+
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -16,3 +16,6 @@ output "public_ip" {
 output "private_ip" {
   value = google_compute_instance.machine.network_interface.0.network_ip
 }
+output "tags" {
+  value = google_compute_instance.machine.labels
+}

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -16,4 +16,20 @@ variable "ip_forward" {
 variable "tags" {
   type    = map(string)
   default = {}
+
+  validation {
+    condition     = alltrue([
+      for key, value in var.tags:
+        lower(key) == key && lower(value) == value
+    ])
+    error_message = <<-EOT
+GCloud expects all tags(labels) to be lowercase
+Fix the following tags:
+%{for key, value in var.tags}
+%{if !(lower(key) == key && lower(value) == value)}
+  ${key}: ${value}
+%{endif}
+%{endfor}
+    EOT
+  }
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -18,9 +18,9 @@ variable "tags" {
   default = {}
 
   validation {
-    condition     = alltrue([
-      for key, value in var.tags:
-        lower(key) == key && lower(value) == value
+    condition = alltrue([
+      for key, value in var.tags :
+      lower(key) == key && lower(value) == value
     ])
     error_message = <<-EOT
 GCloud expects all tags(labels) to be lowercase

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -13,3 +13,7 @@ variable "ip_forward" {
   default  = false
   nullable = false
 }
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -15,7 +15,13 @@ output "region_machines" {
   value = {
     for name, machine_spec in var.spec.machines : machine_spec.region => {
       name = name
-      spec = machine_spec
+      spec = merge(machine_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, machine_spec.tags, {
+          # machine module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -24,7 +30,13 @@ output "region_databases" {
   value = {
     for name, database_spec in var.spec.databases : database_spec.region => {
       name = name
-      spec = database_spec
+      spec = merge(database_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, database_spec.tags, {
+          # databases module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -33,7 +45,13 @@ output "region_alloys" {
   value = {
     for name, spec in var.spec.alloy : spec.region => {
       name = name
-      spec = spec
+      spec = merge(spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, spec.tags, {
+          # alloys module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }
@@ -42,7 +60,13 @@ output "region_kubernetes" {
   value = {
     for name, spec in var.spec.kubernetes : spec.region => {
       name = name
-      spec = spec
+      spec = merge(spec, spec.tags, {
+        # spec project tags
+        tags = merge(var.spec.tags, {
+          # kubernetes module specific tags
+          name = format("%s-%s", var.spec.tags.cluster_name, name)
+        })
+      })
     }...
   }
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -1,6 +1,6 @@
 variable "spec" {
   type = object({
-    # Project Level Tags used by other resources for naming or merged with other tags
+    # Project Level Tags to be merged with other tags
     tags = optional(object({
       cluster_name = optional(string, "gcp-cluster")
       created_by   = optional(string, "edb-terraform")
@@ -79,7 +79,7 @@ variable "spec" {
     kubernetes = optional(map(object({
       region        = string
       zone          = string
-      cpu_count     = number
+      node_count    = number
       instance_type = string
       tags          = optional(map(string), {})
     })), {})

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -86,22 +86,6 @@ variable "spec" {
   })
 
   validation {
-    condition     = alltrue([
-      for key, value in var.spec.tags:
-        lower(key) == key && lower(value) == value
-    ])
-    error_message = <<-EOT
-Gcloud expects all tags(labels) to be lowercase
-Fix the following tags:
-%{for key, value in var.spec.tags}
-%{if !(lower(key) == key && lower(value) == value)}
-  ${key}: ${value}
-%{endif}
-%{endfor}
-    EOT
-  }
-
-  validation {
     condition     = length(var.spec.machines) == 0 || var.spec.operating_system != null
     error_message = <<-EOT
     operating_system key must be defined within spec when machines are used

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -1,6 +1,6 @@
 variable "spec" {
   type = object({
-    # Project Level Tags
+    # Project Level Tags used by other resources for naming or merged with other tags
     tags = optional(object({
       cluster_name = optional(string, "gcp-cluster")
       created_by   = optional(string, "edb-terraform")

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -1,7 +1,11 @@
 variable "spec" {
   type = object({
-    ssh_user     = optional(string)
-    cluster_name = string
+    # Project Level Tags
+    tags = optional(object({
+      cluster_name = optional(string, "GCP-Cluster")
+      created_by   = optional(string, "EDB-terraform-GCP")
+    }), {})
+    ssh_user = optional(string)
     operating_system = optional(object({
       name = string
     }))
@@ -38,6 +42,7 @@ variable "spec" {
         type        = string
         encrypted   = optional(bool)
       })), [])
+      tags = optional(map(string), {})
     })), {})
     databases = optional(map(object({
       region         = string
@@ -59,6 +64,7 @@ variable "spec" {
         name  = string
         value = number
       })), [])
+      tags = optional(map(string), {})
     })), {})
     alloy = optional(map(object({
       region    = string
@@ -68,12 +74,14 @@ variable "spec" {
         name  = string
         value = string
       })), [])
+      tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
       region        = string
       zone          = string
       cpu_count     = number
       instance_type = string
+      tags          = optional(map(string), {})
     })), {})
   })
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -2,8 +2,8 @@ variable "spec" {
   type = object({
     # Project Level Tags
     tags = optional(object({
-      cluster_name = optional(string, "GCP-Cluster")
-      created_by   = optional(string, "EDB-terraform-GCP")
+      cluster_name = optional(string, "gcp-cluster")
+      created_by   = optional(string, "edb-terraform")
     }), {})
     ssh_user = optional(string)
     operating_system = optional(object({
@@ -84,6 +84,22 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
+
+  validation {
+    condition     = alltrue([
+      for key, value in var.spec.tags:
+        lower(key) == key && lower(value) == value
+    ])
+    error_message = <<-EOT
+Gcloud expects all tags(labels) to be lowercase
+Fix the following tags:
+%{for key, value in var.spec.tags}
+%{if !(lower(key) == key && lower(value) == value)}
+  ${key}: ${value}
+%{endif}
+%{endfor}
+    EOT
+  }
 
   validation {
     condition     = length(var.spec.machines) == 0 || var.spec.operating_system != null

--- a/edbterraform/data/terraform/gcloud/variables.tf
+++ b/edbterraform/data/terraform/gcloud/variables.tf
@@ -52,9 +52,3 @@ variable "subnet_tag" {
 variable "vpc_tag" {
   default = "edb-vpc"
 }
-
-variable "created_by" {
-  type        = string
-  description = "EDB terraform GCP"
-  default     = "EDB terraform GCP"
-}

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -364,8 +364,11 @@ def spec_compatability(infrastructure_variables, cloud_service_provider):
     spec_variables = infrastructure_variables[cloud_service_provider].copy()
     
     # Users were able to use 'cluster_name' at the same level as cloud_service_provider before
-    if 'cluster_name' not in spec_variables and 'cluster_name' in infrastructure_variables:
-        spec_variables['cluster_name'] = infrastructure_variables['cluster_name']
+    if 'tags' not in spec_variables:
+        spec_variables['tags'] = dict()
+    if 'cluster_name' not in spec_variables['tags'] and \
+        'cluster_name' in infrastructure_variables:
+        spec_variables['tags']['cluster_name'] = infrastructure_variables['cluster_name']
 
     replace_pairs = {
         # Modules used to expect azs and az

--- a/infrastructure-examples/alloy.yml
+++ b/infrastructure-examples/alloy.yml
@@ -1,5 +1,7 @@
 gcloud:
-  cluster_name: gcloud-infra
+  tags:
+    cluster_name: gcloud-infra
+    created_by: edb-terraform
   ssh_user: rocky
   operating_system:
     name: rocky-linux-8

--- a/infrastructure-examples/aurora.yml
+++ b/infrastructure-examples/aurora.yml
@@ -1,5 +1,6 @@
 aws:
-  cluster_name: test-aurora
+  tags:
+    cluster_name: test-aurora
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16

--- a/infrastructure-examples/aws-all.yml
+++ b/infrastructure-examples/aws-all.yml
@@ -1,5 +1,7 @@
 aws:
-  cluster_name: Demo-Infra
+  tags:
+    cluster_name: Demo-Infra
+    created_by: edb-terraform
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -37,6 +39,8 @@ aws:
         size_gb: 50
         iops: 5000
         encrypted: false
+      tags:
+        foo: bar
     dbt2-driver:
       type: dbt2-driver
       region: us-east-1
@@ -94,6 +98,8 @@ aws:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar
   aurora:
     mydb2:
       region: us-east-1
@@ -115,3 +121,5 @@ aws:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar

--- a/infrastructure-examples/az-aks.yml
+++ b/infrastructure-examples/az-aks.yml
@@ -1,6 +1,8 @@
 ---
-cluster_name: edb-k8s-aks
 azure:
+  tags:
+    cluster_name: edb-k8s-aks
+    created_by: edb-terraform
   ssh_user: rocky
   regions:
     westus:
@@ -9,15 +11,12 @@ azure:
         0: 10.1.20.0/24
   kubernetes:
     pg1:
-      aksServicePrincipalAppId: <yourserviceprincipalid>
-      aksServicePrincipalClientSecret: <yourserviceprincipalclientsecret>
-      nodeCount: 3
-      logAnalyticsWorkspaceSku: PerGB2018
+      node_count: 3
+      log_analytics_sku: PerGB2018
       tags:
         environment: Sandbox
-      solutionName: EDB K8s Cluster and Dashboard
-      publisherName: EDB
-      type: postgres
+        type: postgres
+      solution_name: EDB K8s Cluster and Dashboard
+      publisher_name: EDB
       region: westus
       instance_type: Standard_D2_v2
-      

--- a/infrastructure-examples/azure-vms.yml
+++ b/infrastructure-examples/azure-vms.yml
@@ -1,6 +1,8 @@
 ---
 azure:
-  cluster_name: azure-infra
+  tags:
+    cluster_name: azure-infra
+    created_by: edb-terraform
   ssh_user: rocky
   operating_system:
     publisher: "erockyenterprisesoftwarefoundationinc1653071250513"

--- a/infrastructure-examples/cloudsql.yml
+++ b/infrastructure-examples/cloudsql.yml
@@ -1,5 +1,7 @@
 gcloud:
-  cluster_name: gcloud-infra
+  tags:
+    cluster_name: gcloud-infra
+    created_by: edb-terraform
   ssh_user: rocky
   operating_system:
     name: rocky-linux-8

--- a/infrastructure-examples/compute-engine.yml
+++ b/infrastructure-examples/compute-engine.yml
@@ -1,5 +1,6 @@
 gcloud:
-  cluster_name: gcloud-infra
+  tags:
+    cluster_name: gcloud-infra
   ssh_user: rocky
   operating_system:
     name: rocky-linux-8

--- a/infrastructure-examples/gcloud-all.yml
+++ b/infrastructure-examples/gcloud-all.yml
@@ -1,5 +1,7 @@
 gcloud:
-  cluster_name: gcloud-infra
+  tags:
+    created_by: edb-terraform
+    cluster_name: gcloud-infra
   ssh_user: rocky
   operating_system:
     name: rocky-linux-8
@@ -35,6 +37,8 @@ gcloud:
       volume:
         type: pd-standard
         size_gb: 50
+      tags:
+        foo: bar
     dbt2-proxy:
       type: proxy
       region: us-west2
@@ -71,6 +75,8 @@ gcloud:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar
     mydb2:
       region: us-west2
       zone: us-west2-b
@@ -109,3 +115,5 @@ gcloud:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar

--- a/infrastructure-examples/gcp_gke.yml
+++ b/infrastructure-examples/gcp_gke.yml
@@ -1,5 +1,6 @@
 gcloud:
-  cluster_name: gcloud-gke
+  tags:
+    cluster_name: gcloud-gke
   regions:
     us-west2:
       cidr_block: 10.2.0.0/16
@@ -10,4 +11,4 @@ gcloud:
       region: us-west2
       zone: us-west2-b
       instance_type: "n1-standard-1"
-      cpu_count: 2
+      node_count: 3


### PR DESCRIPTION
Changes:
* `tags` added project wide and per resource type
  * `cluster_name` should be declared under `tags`, overrides changes made with it moving in #20
  * `created_by` available under project tags
  * project wide tags merged with resource type tags and adds a name tag as well in the spec module's output resources
  * project wide tags can be referenced individually from the spec output variable
* updates to aks/gke yaml/spec inputs and outputs