### PR TITLE
Support for `count` in each provider's spec

### DIFF
--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -12,11 +12,11 @@ output "region_zone_networks" {
 }
 
 locals {
-  # Extend machine's count as of list objects with an index in the name
+  # Extend machine's count as of list objects, with an index in the name only when count over 1
   machines_extended = flatten([
     for name, machine_spec in var.spec.machines : [
       for index in range(machine_spec.count) : {
-        name = "${name}-${index}"
+        name = machine_spec.count > 1 ? "${name}-${index}" : name
         spec = machine_spec
       }
     ]

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -14,8 +14,8 @@ output "region_zone_networks" {
 locals {
   # Extend machine's count as of list objects with an index in the name
   machines_extended = flatten([
-    for name, machine_spec in var.spec.machines: [
-      for index in range(machine_spec.count): {
+    for name, machine_spec in var.spec.machines : [
+      for index in range(machine_spec.count) : {
         name = "${name}-${index}"
         spec = machine_spec
       }
@@ -31,7 +31,8 @@ output "region_machines" {
         # spec project tags
         tags = merge(var.spec.tags, machine.spec.tags, {
           # machine module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, machine.name)
+          name = machine.name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -46,7 +47,8 @@ output "region_databases" {
         # spec project tags
         tags = merge(var.spec.tags, database_spec.tags, {
           # database module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -61,7 +63,8 @@ output "region_auroras" {
         # spec project tags
         tags = merge(var.spec.tags, aurora_spec.tags, {
           # aurora module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -26,6 +26,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = string
+      count         = optional(number, 1)
       region        = string
       zone          = string
       instance_type = string

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -12,11 +12,11 @@ output "region_zone_networks" {
 }
 
 locals {
-  # Extend machine's count as of list objects with an index in the name
+  # Extend machine's count as of list objects, with an index in the name only when count over 1
   machines_extended = flatten([
     for name, machine_spec in var.spec.machines : [
       for index in range(machine_spec.count) : {
-        name = "${name}-${index}"
+        name = machine_spec.count > 1 ? "${name}-${index}" : name
         spec = machine_spec
       }
     ]

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -14,8 +14,8 @@ output "region_zone_networks" {
 locals {
   # Extend machine's count as of list objects with an index in the name
   machines_extended = flatten([
-    for name, machine_spec in var.spec.machines: [
-      for index in range(machine_spec.count): {
+    for name, machine_spec in var.spec.machines : [
+      for index in range(machine_spec.count) : {
         name = "${name}-${index}"
         spec = machine_spec
       }
@@ -31,7 +31,8 @@ output "region_machines" {
         # spec project tags
         tags = merge(var.spec.tags, machine.spec.tags, {
           # machine module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, machine.name)
+          name = machine.name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -46,7 +47,8 @@ output "region_kubernetes" {
         # spec project tags
         tags = merge(var.spec.tags, spec.tags, {
           # kubernetes module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -30,6 +30,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = string
+      count         = optional(number, 1)
       region        = string
       zone          = number
       instance_type = string

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -12,11 +12,11 @@ output "region_zone_networks" {
 }
 
 locals {
-  # Extend machine's count as of list objects with an index in the name
+  # Extend machine's count as of list objects, with an index in the name only when count over 1
   machines_extended = flatten([
     for name, machine_spec in var.spec.machines : [
       for index in range(machine_spec.count) : {
-        name = "${name}-${index}"
+        name = machine_spec.count > 1 ? "${name}-${index}" : name
         spec = machine_spec
       }
     ]

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -14,8 +14,8 @@ output "region_zone_networks" {
 locals {
   # Extend machine's count as of list objects with an index in the name
   machines_extended = flatten([
-    for name, machine_spec in var.spec.machines: [
-      for index in range(machine_spec.count): {
+    for name, machine_spec in var.spec.machines : [
+      for index in range(machine_spec.count) : {
         name = "${name}-${index}"
         spec = machine_spec
       }
@@ -31,7 +31,8 @@ output "region_machines" {
         # spec project tags
         tags = merge(var.spec.tags, machine.spec.tags, {
           # machine module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, machine.name)
+          name = machine.name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -46,7 +47,8 @@ output "region_databases" {
         # spec project tags
         tags = merge(var.spec.tags, database_spec.tags, {
           # databases module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -61,7 +63,8 @@ output "region_alloys" {
         # spec project tags
         tags = merge(var.spec.tags, spec.tags, {
           # alloys module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...
@@ -76,7 +79,8 @@ output "region_kubernetes" {
         # spec project tags
         tags = merge(var.spec.tags, {
           # kubernetes module specific tags
-          name = format("%s-%s", var.spec.tags.cluster_name, name)
+          name = name
+          id   = random_id.apply.hex
         })
       })
     }...

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -25,6 +25,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = string
+      count         = optional(number, 1)
       region        = string
       zone          = string
       instance_type = string

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -250,38 +250,40 @@ def new_project_main():
             '''
     )
     env = parser.parse_args()
+    generate_terraform(env.infra_file, env.project_path, env.csp, env.run_validation)
 
+def generate_terraform(infra_file, project_path, csp, run_validation):
     # Load infrastructure variables from the YAML file that was passed
-    infra_vars = load_yaml_file(env.infra_file)
+    infra_vars = load_yaml_file(infra_file)
 
     # Duplicate terraform code into target project directory
-    create_project_dir(env.project_path, env.csp)
+    create_project_dir(project_path, csp)
 
     # Transform variables extracted from the infrastructure file into
     # terraform and templates variables.
     (terraform_vars, template_vars) = \
-        build_vars(env.csp, infra_vars, env.project_path)
+        build_vars(csp, infra_vars, project_path)
 
     # Save terraform vars file
     save_terraform_vars(
-        env.project_path, 'terraform.tfvars.json', terraform_vars
+        project_path, 'terraform.tfvars.json', terraform_vars
     )
 
     # Generate the main.tf and providers.tf files.
     tpl(
         'main.tf.j2',
-        env.project_path / 'main.tf',
-        env.csp,
+        project_path / 'main.tf',
+        csp,
         template_vars
     )
     tpl(
         'providers.tf.j2',
-        env.project_path / 'providers.tf',
-        env.csp,
+        project_path / 'providers.tf',
+        csp,
         template_vars
     )
 
-    run_terraform(env.project_path, env.run_validation)
+    run_terraform(project_path, run_validation)
 
 def run_terraform(cwd, validate):
     if validate:


### PR DESCRIPTION
Changes:
* `count` supported in specification module for machines under each provider
  * creates a list of objects for the amount of count and adds an index to its name to avoid modifying each provider's machine module with terraform's `count`
  * If not used by the user, it will default to 1
  * users should add a tag instead of relying on the name of the machine
    * we have `type` in outputs, but we should favor having users define `type` as a tag as those are output in `servers.yml` as well.