### PR TITLE
terraform output updated for direct use

### DIFF
--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -88,3 +88,36 @@ output "{{type}}" {
   sensitive = true
 }
 {% endfor %}
+
+output "{{output_name}}" {
+  description = <<-EOT
+  Use 'terraform output -json' for the following output and other info such as types:
+  servers:
+    value:
+      machines:
+        machine_name:
+          instance_type: <instance_type>
+      databases:
+        database_name:
+          instance_type: <instance_type>
+
+  Use 'terraform output -json servers' for the following output:
+  machines:
+    machine_name:
+      instance_type: <instance_type>
+  databases:
+    database_name:
+      instance_type: <instance_type>
+  EOT
+  value = {
+{% for type, attributes in boxes.items() if attributes["active"] %}
+    "{{type}}" = merge(
+{%   for region in attributes["regions"] -%}
+{%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
+    tomap([for key, values in {{module}}[*]: values]...),
+{%   endfor %}
+    )
+{% endfor %}
+  }
+  sensitive = true
+}

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -74,3 +74,35 @@ output "{{type}}" {
 }
 {% endfor %}
 
+output "{{output_name}}" {
+  description = <<-EOT
+  Use 'terraform output -json' for the following output and other info such as types:
+  servers:
+    value:
+      machines:
+        machine_name:
+          instance_type: <instance_type>
+      databases:
+        database_name:
+          instance_type: <instance_type>
+
+  Use 'terraform output -json servers' for the following output:
+  machines:
+    machine_name:
+      instance_type: <instance_type>
+  databases:
+    database_name:
+      instance_type: <instance_type>
+  EOT
+  value = {
+{% for type, attributes in boxes.items() if attributes["active"] %}
+    "{{type}}" = merge(
+{%   for region in attributes["regions"] -%}
+{%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
+    tomap([for key, values in {{module}}[*]: values]...),
+{%   endfor %}
+    )
+{% endfor %}
+  }
+  sensitive = true
+}

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -84,3 +84,36 @@ output "{{type}}" {
   sensitive = true
 }
 {% endfor %}
+
+output "{{output_name}}" {
+  description = <<-EOT
+  Use 'terraform output -json' for the following output and other info such as types:
+  servers:
+    value:
+      machines:
+        machine_name:
+          instance_type: <instance_type>
+      databases:
+        database_name:
+          instance_type: <instance_type>
+
+  Use 'terraform output -json servers' for the following output:
+  machines:
+    machine_name:
+      instance_type: <instance_type>
+  databases:
+    database_name:
+      instance_type: <instance_type>
+  EOT
+  value = {
+{% for type, attributes in boxes.items() if attributes["active"] %}
+    "{{type}}" = merge(
+{%   for region in attributes["regions"] -%}
+{%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
+    tomap([for key, values in {{module}}[*]: values]...),
+{%   endfor %}
+    )
+{% endfor %}
+  }
+  sensitive = true
+}

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -25,7 +25,7 @@ variable "spec" {
       })), [])
     }))
     machines = optional(map(object({
-      type          = string
+      type          = optional(string)
       count         = optional(number, 1)
       region        = string
       zone          = string

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -29,7 +29,7 @@ variable "spec" {
       })), [])
     }))
     machines = optional(map(object({
-      type          = string
+      type          = optional(string)
       count         = optional(number, 1)
       region        = string
       zone          = number

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -24,7 +24,7 @@ variable "spec" {
       })), [])
     }))
     machines = optional(map(object({
-      type          = string
+      type          = optional(string)
       count         = optional(number, 1)
       region        = string
       zone          = string

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -219,68 +219,11 @@ def build_vars(csp, infra_vars, project_path, terraform_output_name):
 Generates the terraform files from jinja templates and terraform modules and
 saves the files into a project_directory for use with 'terraform' commands
 
-<<<<<<< HEAD
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        'project_path',
-        metavar='PROJECT_PATH',
-        type=Path,
-        help="Project path.",
-    )
-    parser.add_argument(
-        'infra_file',
-        metavar='INFRA_FILE_YAML',
-        type=Path,
-        help="CSP infrastructure (YAML format) file path."
-    )
-    parser.add_argument(
-        '--cloud-service-provider', '-c',
-        metavar='CLOUD_SERVICE_PROVIDER',
-        dest='csp',
-        choices=['aws', 'gcloud', 'azure'],
-        default='aws',
-        help="Cloud Service Provider. Default: %(default)s"
-    )
-    parser.add_argument(
-        '--validate',
-        dest='run_validation',
-        action='store_true',
-        required=False,
-        help='''
-            Requires terraform >= 1.3.6
-            Validates the generated files by running:
-            `terraform apply -target=null_resource.validation`
-            If invalid, error will be displayed and project directory destroyed
-            Default: %(default)s
-            '''
-    )
-    env = parser.parse_args()
-    output_variable = generate_terraform(env.infra_file, env.project_path, env.csp, env.run_validation)
-    sys.stdout.write(f'''
-    Success!
-    You can use now use terraform and see info about your boxes after creation:
-    * cd {env.project_path}
-    * terraform apply
-    * terraform output -json {output_variable}
-    \n
-    ''')
-
-"""
-Generates the terraform files from jinja templates and terraform modules and
-saves the files into a project_directory for use with 'terraform' commands
-
 Returns terraform_output_name which is used to create a terraform output to the various
 type of boxes (virtual machines/dbaas/kubernetes) outputs after a user uses 'terraform apply' 
 """
 def generate_terraform(infra_file, project_path, csp, run_validation) -> str:
 
-=======
-Returns terraform_output_name which is used to create a terraform output to the various
-type of boxes (virtual machines/dbaas/kubernetes) outputs after a user uses 'terraform apply' 
-"""
-def generate_terraform(infra_file, project_path, csp, run_validation) -> str:
-
->>>>>>> main
     TERRAFORM_OUTPUT_NAME = 'servers'
     # Load infrastructure variables from the YAML file that was passed
     infra_vars = load_yaml_file(infra_file)


### PR DESCRIPTION
Changes:
* terraform root level output updated to better match `servers.yml` for direct use
  * `terraform output -json | python -m json.tool`
  * `terraform output -json servers | python -m json.tool`
* `servers` output put in a variable, passed to jinja and user given a message of how to use it
* Specification module for all providers: machines `type` optional as user can pass it as a `tag` and reference it from the outputs with their own conditional checks.