### PR TITLE
entry_point bug fix

### DIFF
--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -58,5 +58,5 @@ def main(args=None):
     return output_variable
 
 if __name__ == '__main__':
-    main()
+    result = main()
     exit(0)

--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -58,4 +58,5 @@ def main(args=None):
     return output_variable
 
 if __name__ == '__main__':
-    result = main()
+    main()
+    exit(0)

--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -57,6 +57,11 @@ def main(args=None):
     
     return output_variable
 
+'''
+Entry point made for setup.py to use
+'''
+def entry_point():
+    main()
+
 if __name__ == '__main__':
-    result = main()
-    exit(0)
+    entry_point()

--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -58,4 +58,4 @@ def main(args=None):
     return output_variable
 
 if __name__ == '__main__':
-    main()
+    result = main()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     url="https://github.com/EnterpriseDB/edb-terraform/",
     entry_points = {
         'console_scripts': [
-            'edb-terraform = edbterraform.__main__:main',
+            'edb-terraform = edbterraform.__main__:entry_point',
         ]
     },
     license="BSD",


### PR DESCRIPTION
When using setup tools, it uses the entry_point directly: `sys.exit(entry_point)`. If the entry_point returns anything but 0, it will cause scripts to error out. In our case, it return `servers` from `main()` so an `entry_point()` was made to call `main()` so scripts do not error out.