### PR TITLE
Allow user-supplied SSH Keys

### DIFF
--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -44,18 +44,24 @@ class Arguments:
         )
 
 def main(args=None):
+    """ 
+    args: can either be None or a list of arguments to be passed into parse_args
+
+    Returns the dictionary from generate_terraform()
+    """
     env = Arguments().parser.parse_args(args)
-    output_variable = generate_terraform(env.infra_file, env.project_path, env.csp, env.run_validation)
+    outputs = generate_terraform(env.infra_file, env.project_path, env.csp, env.run_validation)
     sys.stdout.write(f'''
     Success!
     You can use now use terraform and see info about your boxes after creation:
     * cd {env.project_path}
     * terraform apply
-    * terraform output -json {output_variable}
+    * terraform output -json {outputs['terraform_output']}
+    * ssh {outputs['ssh_user']}@<ip-address> -i {outputs['ssh_filename']}
     \n
     ''')
     
-    return output_variable
+    return outputs
 
 '''
 Entry point made for setup.py to use

--- a/edbterraform/data/templates/aws/aurora.tf.j2
+++ b/edbterraform/data/templates/aws/aurora.tf.j2
@@ -7,7 +7,7 @@ module "aurora_{{ region_ }}" {
   aurora                   = each.value
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
   name_id                  = module.spec.hex_id
-  cluster_name             = module.spec.value.tags.cluster_name
+  cluster_name             = module.spec.base.tags.cluster_name
   tags                     = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]

--- a/edbterraform/data/templates/aws/key_pair.tf.j2
+++ b/edbterraform/data/templates/aws/key_pair.tf.j2
@@ -1,8 +1,9 @@
 module "key_pair_{{ region_ }}" {
   source = "./modules/key_pair"
 
-  key_name = module.spec.value.tags.cluster_name
-  ssh_pub_key  = var.ssh_pub_key
+  key_name = module.spec.base.tags.cluster_name
+  ssh_pub_key = module.spec.public_key
+
   name_id = module.spec.hex_id
 
   providers = {

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -5,7 +5,7 @@ module "kubernetes_{{ region_ }}" {
 
   region                  = each.value.spec.region
   desiredCapacity         = each.value.spec.node_count
-  vpcAndClusterPrefix     = "${module.spec.value.tags.cluster_name}-${module.spec.pet_name}"  
+  vpcAndClusterPrefix     = "${module.spec.base.tags.cluster_name}-${module.spec.pet_name}"  
   instanceType            = each.value.spec.instance_type
 
   providers = {

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -3,15 +3,16 @@ module "machine_{{ region_ }}" {
 
   for_each = { for rm in lookup(module.spec.region_machines, "{{ region }}", []) : rm.name => rm }
 
-  operating_system         = module.spec.value.operating_system
+  operating_system         = module.spec.base.operating_system
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
   cidr_block               = lookup(lookup(module.spec.region_zone_networks, "{{ region }}", null), each.value.spec.zone, null)
   az                       = each.value.spec.zone
   machine                  = each.value
   custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
-  ssh_pub_key              = var.ssh_pub_key
-  ssh_priv_key             = var.ssh_priv_key
-  ssh_user                 = module.spec.value.ssh_user
+  ssh_user                 = module.spec.base.ssh_user
+  ssh_pub_key              = module.spec.public_key
+  ssh_priv_key             = module.spec.private_key
+  use_agent                = module.spec.base.ssh_key.use_agent
   key_name                 = module.key_pair_{{ region_ }}.key_pair_id
   tags                     = each.value.spec.tags
 

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -1,4 +1,4 @@
-# All modules should reference module.spec.value.<attribute> as it will hold all the values from the yaml file
+# All modules should reference module.spec.base.<attribute> as it will hold all the values from the yaml file
 # All modules should depend_on null_resource.validation to ensure all validations complete before continuing
 # Run directly by using terraform apply -target null_resource.validation
 {% include "validation.tf.j2" %}

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -1,7 +1,7 @@
 module "vpc_{{ region_ }}" {
   source = "./modules/vpc"
 
-  vpc_cidr_block = lookup(lookup(module.spec.value.regions, "{{ region }}"), "cidr_block")
+  vpc_cidr_block = lookup(lookup(module.spec.base.regions, "{{ region }}"), "cidr_block")
   vpc_tag        = var.vpc_tag
   name_id        = module.spec.hex_id
 
@@ -36,7 +36,7 @@ module "routes_{{ region_ }}" {
   vpc_id             = module.vpc_{{ region_ }}.vpc_id
   project_tag        = var.project_tag
   public_cidrblock   = var.public_cidrblock
-  cluster_name       = module.spec.value.tags.cluster_name
+  cluster_name       = module.spec.base.tags.cluster_name
 
   depends_on = [module.network_{{ region_ }}]
 
@@ -51,12 +51,12 @@ module "security_{{ region_ }}" {
   vpc_id           = module.vpc_{{ region_ }}.vpc_id
   public_cidrblock = var.public_cidrblock
   project_tag      = var.project_tag
-  service_ports    = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "service_ports", [])
-  cluster_name     = module.spec.value.tags.cluster_name
+  service_ports    = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
+  cluster_name     = module.spec.base.tags.cluster_name
   region_cidrblocks = ([ for k, v 
-                      in lookup(lookup(module.spec.value.regions, "{{ region }}", null), "azs", [])
+                      in lookup(lookup(module.spec.base.regions, "{{ region }}", null), "azs", [])
                       : v ])
-  region_ports = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "region_ports", [])
+  region_ports = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
   
   depends_on = [module.routes_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/validation.tf.j2
+++ b/edbterraform/data/templates/aws/validation.tf.j2
@@ -17,7 +17,7 @@ module "validation_{{ region_ }}" {
   source = "./modules/validation"
   
   region = "{{ region }}"
-  zones = module.spec.value.regions["{{ region }}"].zones
+  zones = module.spec.base.regions["{{ region }}"].zones
   
   providers = {
     aws = aws.{{ region_ }}

--- a/edbterraform/data/templates/azure/agreements.tf.j2
+++ b/edbterraform/data/templates/azure/agreements.tf.j2
@@ -1,9 +1,9 @@
 module "agreements" {
   source = "./modules/agreement"
 
-  publisher = module.spec.value.operating_system.publisher
-  offer     = module.spec.value.operating_system.offer
-  plan      = module.spec.value.operating_system.sku
+  publisher = module.spec.base.operating_system.publisher
+  offer     = module.spec.base.operating_system.offer
+  plan      = module.spec.base.operating_system.sku
 
-  depends_on = [module.spec]
+  depends_on = [ null_resource.validation ]
 }

--- a/edbterraform/data/templates/azure/key_pair.tf.j2
+++ b/edbterraform/data/templates/azure/key_pair.tf.j2
@@ -4,7 +4,7 @@ module "key_pair_{{ region_ }}" {
   name          = "{{ region }}-${module.spec.hex_id}"
   resource_name = module.vpc_{{ region_ }}.resource_name
   region        = module.vpc_{{ region_ }}.region
-  public_key    = var.ssh_pub_key
+  public_key    = module.spec.public_key
 
   depends_on = [module.vpc_{{ region_ }}, null_resource.validation ]
 

--- a/edbterraform/data/templates/azure/kubernetes.tf.j2
+++ b/edbterraform/data/templates/azure/kubernetes.tf.j2
@@ -7,17 +7,17 @@ module "kubernetes_{{ region_ }}" {
     })
 
   nodeCount                       = each.value.spec.node_count
-  cluster_name                    = module.spec.value.tags.cluster_name
+  cluster_name                    = module.spec.base.tags.cluster_name
   logAnalyticsWorkspaceLocation   = each.value.spec.log_analytics_location
-  logAnalyticsWorkspaceName       = "${replace(module.spec.value.tags.cluster_name,"-","")}${module.spec.pet_name}Workspace"
+  logAnalyticsWorkspaceName       = "${replace(module.spec.base.tags.cluster_name,"-","")}${module.spec.pet_name}Workspace"
   logAnalyticsWorkspaceSku        = each.value.spec.log_analytics_sku
   resourceGroupLocation           = each.value.spec.resource_group_location
-  resourceGroupName               = "${module.spec.value.tags.cluster_name}-RG-${module.spec.pet_name}"
+  resourceGroupName               = "${module.spec.base.tags.cluster_name}-RG-${module.spec.pet_name}"
   vmSize                          = each.value.spec.instance_type
   solutionName                    = each.value.spec.solution_name
   publisherName                   = each.value.spec.publisher_name
-  ssh_user                        = module.spec.value.ssh_user
-  sshPublicKey                    = var.ssh_pub_key  
+  ssh_user                        = module.spec.base.ssh_user
+  sshPublicKey                    = module.spec.public_key  
   tags                            = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -8,8 +8,8 @@ module "machine_{{ region_ }}" {
 
   resource_name                   = module.vpc_{{ region_ }}.resource_name
   subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone].subnet_id
-  operating_system                = module.spec.value.operating_system
-  cluster_name                    = module.spec.value.tags.cluster_name
+  operating_system                = module.spec.base.operating_system
+  cluster_name                    = module.spec.base.tags.cluster_name
   machine                         = (
     merge(
       each.value.spec,
@@ -18,8 +18,9 @@ module "machine_{{ region_ }}" {
     )
   )
   additional_volumes              = each.value.spec.additional_volumes
-  ssh_user                        = module.spec.value.ssh_user
-  private_key                     = var.ssh_priv_key
+  ssh_user                        = module.spec.base.ssh_user
+  private_key                     = module.spec.private_key
+  use_agent                       = module.spec.base.ssh_key.use_agent
   public_key_name                 = module.key_pair_{{ region_ }}.name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -2,7 +2,7 @@ module "vpc_{{ region_ }}"{
   source = "./modules/vpc"
 
   name          = "${var.vpc_tag}-{{ region }}-${module.spec.hex_id}"
-  cidr_blocks = [ lookup(lookup(module.spec.value.regions, "{{ region }}"), "cidr_block") ]
+  cidr_blocks = [ lookup(lookup(module.spec.base.regions, "{{ region }}"), "cidr_block") ]
   region = "{{ region }}"
 
   providers = {
@@ -40,12 +40,12 @@ module "security_{{ region_ }}" {
   region            = module.vpc_{{ region_ }}.region
   resource_name     = module.vpc_{{ region_ }}.resource_name
   service_name      = "service-{{ region }}-${each.key}-${module.spec.hex_id}"
-  service_ports     = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "service_ports", [])
+  service_ports     = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
   public_cidrblock  = var.public_cidrblock
   region_name       = "region-{{ region }}-${each.key}-${module.spec.hex_id}"
-  region_ports      = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "region_ports", [])
+  region_ports      = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
   region_cidrblocks = flatten([
-    for region in try(module.spec.value.regions, []) : [
+    for region in try(module.spec.base.regions, []) : [
       for ip_cidr in try(region.zones, []) : ip_cidr
       ] 
     ])

--- a/edbterraform/data/templates/gcloud/key_pair.tf.j2
+++ b/edbterraform/data/templates/gcloud/key_pair.tf.j2
@@ -1,9 +1,9 @@
 module "key_pair_{{ region_ }}" {
   source = "./modules/key_pair"
 
-  ssh_user = module.spec.value.ssh_user
+  ssh_user = module.spec.base.ssh_user
   key_name = "ssh-keys-{{ region }}-${module.spec.hex_id}"
-  public_keys  = var.ssh_pub_key
+  public_keys  = module.spec.public_key
 
   providers = {
     google = google.{{ region_ }}

--- a/edbterraform/data/templates/gcloud/kubernetes.tf.j2
+++ b/edbterraform/data/templates/gcloud/kubernetes.tf.j2
@@ -6,7 +6,7 @@ module "kubernetes_{{ region_ }}" {
       rm.name => rm 
     })
 
-  cluster_name                    = module.spec.value.tags.cluster_name
+  cluster_name                    = module.spec.base.tags.cluster_name
   region                          = each.value.spec.region
   machine                         = each.value
   subnetwork                      = module.network_{{ region_ }}[each.value.spec.zone].name

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -6,13 +6,13 @@ module "machine_{{ region_ }}" {
       rm.name => rm 
     })
 
-  operating_system                = module.spec.value.operating_system
-  cluster_name                    = module.spec.value.tags.cluster_name
+  operating_system                = module.spec.base.operating_system
+  cluster_name                    = module.spec.base.tags.cluster_name
   zone                            = each.value.spec.zone
   machine                         = each.value
-  ssh_user                        = module.spec.value.ssh_user
-  ssh_pub_key                     = var.ssh_pub_key
-  ssh_priv_key                    = var.ssh_priv_key
+  ssh_user                        = module.spec.base.ssh_user
+  ssh_priv_key                    = module.spec.private_key
+  use_agent                       = module.spec.base.ssh_key.use_agent
   ssh_metadata                    = module.key_pair_{{ region_ }}.keys
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone].name
   name_id                         = module.spec.hex_id

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -59,13 +59,13 @@ module "security_{{ region_ }}" {
   network_name  = module.vpc_{{ region_ }}.vpc_id
 
   service_name = "service-{{ region }}-${module.spec.hex_id}"
-  service_ports    = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "service_ports", [])
+  service_ports    = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
   public_cidrblock = var.public_cidrblock
 
   region_name = "region-{{ region }}-${module.spec.hex_id}"
-  region_ports = lookup(lookup(module.spec.value.regions, "{{ region }}", null), "region_ports", [])
+  region_ports = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
   region_cidrblocks = flatten([
-    for region in try(module.spec.value.regions, []) : [
+    for region in try(module.spec.base.regions, []) : [
       for ip_cidr in try(region.zones, []) : ip_cidr
       ] 
     ])

--- a/edbterraform/data/terraform/aws/modules/key_pair/main.tf
+++ b/edbterraform/data/terraform/aws/modules/key_pair/main.tf
@@ -13,5 +13,5 @@ terraform {
 
 resource "aws_key_pair" "key_pair" {
   key_name   = "${var.key_name}-${var.name_id}"
-  public_key = file(var.ssh_pub_key)
+  public_key = var.ssh_pub_key
 }

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -5,6 +5,9 @@ variable "az" {}
 variable "ssh_user" {}
 variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
+variable "use_agent" {
+  default = false
+}
 variable "custom_security_group_id" {}
 variable "key_name" {}
 variable "operating_system" {}
@@ -59,10 +62,6 @@ resource "aws_instance" "machine" {
   }
 
   tags = var.tags
-
-  connection {
-    private_key = file(var.ssh_pub_key)
-  }
 }
 
 resource "aws_ebs_volume" "ebs_volume" {
@@ -114,7 +113,8 @@ resource "null_resource" "copy_setup_volume_script" {
       type        = "ssh"
       user        = var.ssh_user
       host        = aws_instance.machine.public_ip
-      private_key = file(var.ssh_priv_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.ssh_priv_key
     }
   }
 
@@ -140,7 +140,8 @@ resource "null_resource" "setup_volume" {
       type        = "ssh"
       user        = var.ssh_user
       host        = aws_instance.machine.public_ip
-      private_key = file(var.ssh_priv_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.ssh_priv_key
     }
   }
 }

--- a/edbterraform/data/terraform/aws/modules/specification/files.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/files.tf
@@ -1,0 +1,78 @@
+# Create default keys when ssh_user is supplied.
+# If ssh_key.public_path and ssh_key.private_path are defined,
+# overwrite the default keys.
+locals {
+  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_keys_count = (
+    var.spec.ssh_key.public_path != null ||
+    var.spec.ssh_key.private_path != null ? 1 : 0
+  )
+}
+
+resource "tls_private_key" "default" {
+  count     = local.ssh_user_count
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_sensitive_file" "default_private" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  content         = tls_private_key.default[0].private_key_openssh
+}
+
+resource "local_file" "default_public" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  content         = tls_private_key.default[0].public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  source          = var.spec.ssh_key.private_path
+
+  lifecycle {
+    precondition {
+      condition     = var.spec.ssh_key.public_path != var.spec.ssh_key.private_path
+      error_message = "private_path and private_path cannot be the same"
+    }
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.private_path)
+      error_message = "Unable to find or access the private key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.public_path != null
+      error_message = "public_path must be defined when using private_path"
+    }
+  }
+
+  depends_on = [local_sensitive_file.private_key]
+}
+
+resource "local_file" "public_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  source          = var.spec.ssh_key.public_path
+
+  lifecycle {
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.public_path)
+      error_message = "Unable to access the public key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.private_path != null
+      error_message = "private_path must be defined when using public_path"
+    }
+  }
+
+  depends_on = [local_file.public_key]
+}

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -1,5 +1,13 @@
-output "value" {
+output "base" {
   value = var.spec
+}
+
+output "private_key" {
+  value = var.spec.ssh_key.private_path != null ? file(var.spec.ssh_key.private_path) : tls_private_key.default[0].private_key_openssh
+}
+
+output "public_key" {
+  value = var.spec.ssh_key.public_path != null ? file(var.spec.ssh_key.public_path) : tls_private_key.default[0].public_key_openssh
 }
 
 output "region_zone_networks" {

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -5,7 +5,13 @@ variable "spec" {
       cluster_name = optional(string, "AWS-Cluster")
       created_by   = optional(string, "EDB-Terraform-AWS")
     }), {})
-    ssh_user = string
+    ssh_user = optional(string)
+    ssh_key = optional(object({
+      public_path  = optional(string)
+      private_path = optional(string)
+      output_name  = optional(string, "ssh-id_rsa")
+      use_agent    = optional(bool, false)
+    }), {})
     operating_system = optional(object({
       name  = string
       owner = number
@@ -84,11 +90,11 @@ variable "spec" {
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
-      region                  = string
-      node_count              = number
-      instance_type           = string
-      tags                    = optional(map(string), {})
-    })), {})    
+      region        = string
+      node_count    = number
+      instance_type = string
+      tags          = optional(map(string), {})
+    })), {})
   })
 
   validation {
@@ -121,5 +127,4 @@ Region - Machine:
 EOT
     )
   }
-
 }

--- a/edbterraform/data/terraform/aws/variables.tf
+++ b/edbterraform/data/terraform/aws/variables.tf
@@ -2,8 +2,6 @@ variable "spec" {
   description = "Variable is meant to represent the yaml input file handled through python and is meant to be passed through to module/specification var.spec"
   nullable    = false
 }
-variable "ssh_priv_key" {}
-variable "ssh_pub_key" {}
 
 # VPC
 variable "public_cidrblock" {

--- a/edbterraform/data/terraform/azure/modules/key_pair/main.tf
+++ b/edbterraform/data/terraform/azure/modules/key_pair/main.tf
@@ -2,5 +2,5 @@ resource "azurerm_ssh_public_key" "main" {
   name                = var.name
   resource_group_name = var.resource_name
   location            = var.region
-  public_key          = file(var.public_key)
+  public_key          = var.public_key
 }

--- a/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     admin_username = var.ssh_user
 
     ssh_key {
-      key_data = file(var.sshPublicKey)
+      key_data = var.sshPublicKey
     }
   }
   network_profile {

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -128,7 +128,8 @@ resource "null_resource" "copy_setup_volume_script" {
       type        = "ssh"
       user        = var.ssh_user
       host        = azurerm_linux_virtual_machine.main.public_ip_address
-      private_key = file(var.private_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.private_key
     }
   }
 
@@ -152,7 +153,8 @@ resource "null_resource" "setup_volume" {
       type        = "ssh"
       user        = var.ssh_user
       host        = azurerm_linux_virtual_machine.main.public_ip_address
-      private_key = file(var.private_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.private_key
     }
   }
 

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -39,6 +39,9 @@ variable "subnet_id" {}
 variable "ssh_user" {}
 variable "public_key_name" {}
 variable "private_key" {}
+variable "use_agent" {
+  default = false
+}
 variable "additional_volumes" {
   type = list(object({
     mount_point = string

--- a/edbterraform/data/terraform/azure/modules/specification/files.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/files.tf
@@ -1,0 +1,78 @@
+# Create default keys when ssh_user is supplied.
+# If ssh_key.public_path and ssh_key.private_path are defined,
+# overwrite the default keys.
+locals {
+  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_keys_count = (
+    var.spec.ssh_key.public_path != null ||
+    var.spec.ssh_key.private_path != null ? 1 : 0
+  )
+}
+
+resource "tls_private_key" "default" {
+  count     = local.ssh_user_count
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_sensitive_file" "default_private" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  content         = tls_private_key.default[0].private_key_openssh
+}
+
+resource "local_file" "default_public" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  content         = tls_private_key.default[0].public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  source          = var.spec.ssh_key.private_path
+
+  lifecycle {
+    precondition {
+      condition     = var.spec.ssh_key.public_path != var.spec.ssh_key.private_path
+      error_message = "private_path and private_path cannot be the same"
+    }
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.private_path)
+      error_message = "Unable to find or access the private key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.public_path != null
+      error_message = "public_path must be defined when using private_path"
+    }
+  }
+
+  depends_on = [local_sensitive_file.private_key]
+}
+
+resource "local_file" "public_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  source          = var.spec.ssh_key.public_path
+
+  lifecycle {
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.public_path)
+      error_message = "Unable to access the public key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.private_path != null
+      error_message = "private_path must be defined when using public_path"
+    }
+  }
+
+  depends_on = [local_file.public_key]
+}

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -1,5 +1,13 @@
-output "value" {
+output "base" {
   value = var.spec
+}
+
+output "private_key" {
+  value = var.spec.ssh_key.private_path != null ? file(var.spec.ssh_key.private_path) : tls_private_key.default[0].private_key_openssh
+}
+
+output "public_key" {
+  value = var.spec.ssh_key.public_path != null ? file(var.spec.ssh_key.public_path) : tls_private_key.default[0].public_key_openssh
 }
 
 output "region_zone_networks" {

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -6,6 +6,12 @@ variable "spec" {
       created_by   = optional(string, "EDB-Terraform-Azure")
     }), {})
     ssh_user = optional(string)
+    ssh_key = optional(object({
+      public_path  = optional(string)
+      private_path = optional(string)
+      output_name  = optional(string, "ssh-id_rsa")
+      use_agent    = optional(bool, false)
+    }), {})
     operating_system = optional(object({
       publisher = string
       offer     = string

--- a/edbterraform/data/terraform/azure/variables.tf
+++ b/edbterraform/data/terraform/azure/variables.tf
@@ -2,8 +2,6 @@ variable "spec" {
   description = "Variable is meant to represent the yaml input file handled through python and is meant to be passed through to module/specification var.spec"
   nullable    = false
 }
-variable "ssh_pub_key" {}
-variable "ssh_priv_key" {}
 
 variable "source_ranges" {
   default = "0.0.0.0/0"

--- a/edbterraform/data/terraform/gcloud/modules/key_pair/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/key_pair/main.tf
@@ -1,4 +1,4 @@
 resource "google_compute_project_metadata_item" "key_pair" {
   key   = var.key_name
-  value = "${var.ssh_user}:${file(var.public_keys)}"
+  value = "${var.ssh_user}:${var.public_keys}"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -96,7 +96,8 @@ resource "null_resource" "copy_setup_volume_script" {
       type        = "ssh"
       user        = var.ssh_user
       host        = google_compute_instance.machine.network_interface.0.access_config.0.nat_ip
-      private_key = file(var.ssh_priv_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.ssh_priv_key
     }
   }
 
@@ -120,7 +121,8 @@ resource "null_resource" "setup_volume" {
       type        = "ssh"
       user        = var.ssh_user
       host        = google_compute_instance.machine.network_interface.0.access_config.0.nat_ip
-      private_key = file(var.ssh_priv_key)
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.ssh_priv_key
     }
   }
 

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -1,13 +1,15 @@
 variable "machine" {}
 variable "zone" {}
 variable "ssh_user" {}
-variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
 variable "ssh_metadata" {}
 variable "cluster_name" {}
 variable "operating_system" {}
 variable "subnet_name" {}
 variable "name_id" { default = "0" }
+variable "use_agent" {
+  default = false
+}
 variable "ip_forward" {
   type     = bool
   default  = false

--- a/edbterraform/data/terraform/gcloud/modules/specification/files.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/files.tf
@@ -1,0 +1,78 @@
+# Create default keys when ssh_user is supplied.
+# If ssh_key.public_path and ssh_key.private_path are defined,
+# overwrite the default keys.
+locals {
+  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_keys_count = (
+    var.spec.ssh_key.public_path != null ||
+    var.spec.ssh_key.private_path != null ? 1 : 0
+  )
+}
+
+resource "tls_private_key" "default" {
+  count     = local.ssh_user_count
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_sensitive_file" "default_private" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  content         = tls_private_key.default[0].private_key_openssh
+}
+
+resource "local_file" "default_public" {
+  count = local.ssh_user_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  content         = tls_private_key.default[0].public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  file_permission = "0600"
+  source          = var.spec.ssh_key.private_path
+
+  lifecycle {
+    precondition {
+      condition     = var.spec.ssh_key.public_path != var.spec.ssh_key.private_path
+      error_message = "private_path and private_path cannot be the same"
+    }
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.private_path)
+      error_message = "Unable to find or access the private key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.public_path != null
+      error_message = "public_path must be defined when using private_path"
+    }
+  }
+
+  depends_on = [local_sensitive_file.private_key]
+}
+
+resource "local_file" "public_key" {
+  count = local.ssh_keys_count
+
+  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  file_permission = "0644"
+  source          = var.spec.ssh_key.public_path
+
+  lifecycle {
+    precondition {
+      condition     = fileexists(var.spec.ssh_key.public_path)
+      error_message = "Unable to access the public key"
+    }
+    precondition {
+      condition     = var.spec.ssh_key.private_path != null
+      error_message = "private_path must be defined when using public_path"
+    }
+  }
+
+  depends_on = [local_file.public_key]
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -1,5 +1,13 @@
-output "value" {
+output "base" {
   value = var.spec
+}
+
+output "private_key" {
+  value = var.spec.ssh_key.private_path != null ? file(var.spec.ssh_key.private_path) : tls_private_key.default[0].private_key_openssh
+}
+
+output "public_key" {
+  value = var.spec.ssh_key.public_path != null ? file(var.spec.ssh_key.public_path) : tls_private_key.default[0].public_key_openssh
 }
 
 output "region_zone_networks" {

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -6,6 +6,12 @@ variable "spec" {
       created_by   = optional(string, "edb-terraform")
     }), {})
     ssh_user = optional(string)
+    ssh_key = optional(object({
+      public_path  = optional(string)
+      private_path = optional(string)
+      output_name  = optional(string, "ssh-id_rsa")
+      use_agent    = optional(bool, false)
+    }), {})
     operating_system = optional(object({
       name = string
     }))
@@ -116,5 +122,4 @@ Region - Machine:
 EOT
     )
   }
-
 }

--- a/edbterraform/data/terraform/gcloud/variables.tf
+++ b/edbterraform/data/terraform/gcloud/variables.tf
@@ -2,8 +2,6 @@ variable "spec" {
   description = "Variable is meant to represent the yaml input file handled through python and is meant to be passed through to module/specification var.spec"
   nullable    = false
 }
-variable "ssh_pub_key" {}
-variable "ssh_priv_key" {}
 
 variable "source_ranges" {
   default = "0.0.0.0/0"

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -319,7 +319,7 @@ def spec_compatability(infrastructure_variables, cloud_service_provider):
     if 'ssh_user' in spec_variables and \
         'ssh_key' not in spec_variables:
         spec_variables['ssh_key'] = dict()
-    if 'ssh_key' in spec_variables and 'output_name' in spec_variables['ssh_key']:
+    if 'ssh_key' in spec_variables and 'output_name' not in spec_variables['ssh_key']:
         spec_variables['ssh_key']['output_name'] = SSH_OUT_FILENAME
 
 


### PR DESCRIPTION
Changes:
* Allow user to pass their own ssh keys
  * Copies supplied keys into project directory when `terraform apply` is called
  * If `ssh_key` is omitted and `ssh_user` is supplied, an ssh key will be created when `terraform apply` is called.
  * `output_name` is changed to `ssh-id_rsa` if user does not supply one to keep backwards compatibility
  * `use_agent` - `true` is required if using password-protected keys and setting up of `ssh-agent`
```yaml
ssh_key: # optional
  public_path: <path> # optional
  private_path: <path> # optional
  use_agent: false # default
  output_name: 'ssh-id_rsa' # default
```
* Restrict permissions for project directory to `0750` and `terraform.tfstate` to `0600` since it may contain secrets
  * Will allow for volume script to eventually move out of `edb-terraform` so it can be handled as a configuration step instead of during provisioning. Then we can remove `use_agent` and `remote_exec` since direct ssh will NOT be needed by Terraform.
* Output name used for the specification variable has been changed to `base` in each provider. `module.spec.value` -> `module.spec.base` since `each.value` is used by terraform for looping with `for_each` and can cause confusion of what is being referenced.