### PR TITLE
Volume script device name fallback

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -1,26 +1,3 @@
-variable "machine" {}
-variable "vpc_id" {}
-variable "cidr_block" {}
-variable "az" {}
-variable "ssh_user" {}
-variable "ssh_pub_key" {}
-variable "ssh_priv_key" {}
-variable "custom_security_group_id" {}
-variable "key_name" {}
-variable "operating_system" {}
-variable "tags" {
-  type    = map(string)
-  default = {}
-}
-
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2.7.0"
-    }
-  }
-}
 data "aws_ami" "default" {
   most_recent = true
 
@@ -77,24 +54,13 @@ resource "aws_ebs_volume" "ebs_volume" {
   tags = var.tags
 }
 
-locals {
-  linux_ebs_device_names = [
-    "/dev/sdf",
-    "/dev/sdg",
-    "/dev/sdh",
-    "/dev/sdi",
-    "/dev/sdj",
-    "/dev/sdk",
-    "/dev/sdl"
-  ]
-}
-
 resource "aws_volume_attachment" "attached_volume" {
   for_each = { for i, v in lookup(var.machine.spec, "additional_volumes", []) : i => v }
 
-  device_name = element(local.linux_ebs_device_names, tonumber(each.key))
+  device_name = element(local.linux_device_names, tonumber(each.key))[0]
   volume_id   = aws_ebs_volume.ebs_volume[each.key].id
   instance_id = aws_instance.machine.id
+  stop_instance_before_detaching = true
 
   depends_on = [
     aws_instance.machine,
@@ -133,7 +99,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.linux_ebs_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
     ]
 
     connection {

--- a/edbterraform/data/terraform/aws/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.7.0"
+    }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -56,11 +56,11 @@ if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
 fi
 
 # Mount point and volume creation
-sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
 sudo mkdir -p "${MOUNT_POINT}"
 # Get device UUID with blkid as exported format:
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}
+echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Expected EBS device path: /dev/sdX
-TARGET_EBS_DEVICE=$1
+# Expected EBS device paths: "/dev/sdX,/dev/sdY"
+IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
+
 # Mount point
 MOUNT_POINT=$2
 # Total number of nvme devices that should be present on the system
@@ -25,7 +26,7 @@ while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
 	COUNTER=$((COUNTER + 1))
 	if [ $COUNTER -ge 10 ]; then
 		echo "ERROR: unable to get the full list of NVME devices after 20s"
-		exit 2
+		break
 	fi
 done
 
@@ -33,14 +34,24 @@ done
 # NVME device.
 for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
 	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
-	if [ "$EBS_DEVICE" = "$TARGET_EBS_DEVICE" ]; then
+	if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
 		TARGET_NVME_DEVICE=${NVME_DEVICE}
 		break
 	fi
 done;
 
+# Fallback to device names
+for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
+	if [[ -e ${DEVICE_NAME} ]]; then
+		TARGET_NVME_DEVICE=${DEVICE_NAME}
+		echo "Warning: Falling back to device name"
+		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
+		break
+	fi
+done;
+
 if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
-	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICE}"
+	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
 	exit 2
 fi
 
@@ -49,6 +60,7 @@ sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
 sudo mkdir -p "${MOUNT_POINT}"
 # Get device UUID with blkid as exported format:
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
 echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
 sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -1,0 +1,37 @@
+variable "machine" {}
+variable "vpc_id" {}
+variable "cidr_block" {}
+variable "az" {}
+variable "ssh_user" {}
+variable "ssh_pub_key" {}
+variable "ssh_priv_key" {}
+variable "custom_security_group_id" {}
+variable "key_name" {}
+variable "operating_system" {}
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+locals {
+  # Create a list of possible device names
+  prefix = "/dev/"
+  base = ["sd", "xvd", "hd"]
+  letters = [
+    "f", "g", "h", "i", 
+    "j", "k", "l", "m", 
+    "n", "o", "p", "q"
+  ]
+  # List(List(String))
+  # [[ "/dev/sdf" , "/dev/xvdf", "/dev/hdf" ], ]
+  linux_device_names = [
+    for letter in local.letters:
+      formatlist("${local.prefix}%s${letter}", local.base)
+  ]
+  # List(String) with comma delimiter
+  # [ "/dev/sdf,/dev/xvdf,/dev/hdf" , ]
+  string_device_names = [
+    for names in local.linux_device_names:
+      format("%s,%s,%s", names...)
+  ]
+}

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -144,7 +144,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.linux_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
     ]
 
     # Requires firewall access to ssh port

--- a/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
@@ -56,11 +56,11 @@ if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
 fi
 
 # Mount point and volume creation
-sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
 sudo mkdir -p "${MOUNT_POINT}"
 # Get device UUID with blkid as exported format:
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}
+echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
@@ -1,20 +1,66 @@
 #!/bin/bash
 
-COUNTER=0
-DEVICE=$1
-MOUNTPOINT=$2
+# Expected EBS device paths: "/dev/sdX,/dev/sdY"
+IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
 
-while [ ! -b ${DEVICE} ]; do
-    sleep 2
-    COUNTER=$((COUNTER + 1))
-    if [ $COUNTER -ge 10 ]; then
-        exit 2
-    fi
+# Mount point
+MOUNT_POINT=$2
+# Total number of nvme devices that should be present on the system
+N_NVME_DEVICE=$3
+
+TARGET_NVME_DEVICE=""
+
+# Install nvme-cli
+if [ -f /etc/redhat-release ]; then
+	sudo yum install nvme-cli -y
+fi
+if [ -f /etc/debian_version ]; then
+	sudo apt update -y
+	sudo apt install nvme-cli -y
+fi
+
+# Wait for the availability of all the NVME devices that should be
+# present on the system.
+while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
+	sleep 2
+	COUNTER=$((COUNTER + 1))
+	if [ $COUNTER -ge 10 ]; then
+		echo "ERROR: unable to get the full list of NVME devices after 20s"
+		break
+	fi
 done
 
+# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+# NVME device.
+for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+	if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
+		TARGET_NVME_DEVICE=${NVME_DEVICE}
+		break
+	fi
+done;
 
-sudo mkfs.xfs "${DEVICE}"
-sudo mkdir -p "${MOUNTPOINT}"
-DEVICE_UUID="$(sudo /sbin/wipefs -i -O UUID ${DEVICE})"
-sudo mount -t xfs ${DEVICE} ${MOUNTPOINT}
-echo "UUID=${DEVICE_UUID} ${MOUNTPOINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
+# Fallback to device names
+for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
+	if [[ -e ${DEVICE_NAME} ]]; then
+		TARGET_NVME_DEVICE=${DEVICE_NAME}
+		echo "Warning: Falling back to device name"
+		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
+		break
+	fi
+done;
+
+if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
+	exit 2
+fi
+
+# Mount point and volume creation
+sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkdir -p "${MOUNT_POINT}"
+# Get device UUID with blkid as exported format:
+# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+echo "Warning: Will be mounted by UUID in /etc/fstab"
+UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -95,15 +95,25 @@ locals {
   ])
 
   # /dev/sda /dev/sdb are mounted by default
-  # azure automatically sets additional mount points starting with /dev/sdc
+  # device name start: /dev/sdc
+  prefix = "/dev/"
+  base = ["sd"]
+  letters = [
+    "c", "d", "e", "f", 
+    "g", "h", "i", "j", 
+    "k", "l", "m", "n",
+    "o", "p", "q", "r"
+  ]
+  # List(List(String))
+  # [[ "/dev/sdc" ], ]
   linux_device_names = [
-    "/dev/sdc",
-    "/dev/sdd",
-    "/dev/sde",
-    "/dev/sdf",
-    "/dev/sdg",
-    "/dev/sdh",
-    "/dev/sdi",
-    "/dev/sdj",
+    for letter in local.letters:
+      formatlist("${local.prefix}%s${letter}", local.base)
+  ]
+  # List(String) with comma delimiter
+  # [ "/dev/sdc" , ]
+  string_device_names = [
+    for names in local.linux_device_names:
+      format("%s", names...)
   ]
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -60,22 +60,10 @@ resource "google_compute_disk" "volumes" {
 
 }
 
-locals {
-  linux_device_names = [
-    "sdf",
-    "sdg",
-    "sdh",
-    "sdi",
-    "sdj",
-    "sdk",
-    "sdl"
-  ]
-}
-
 resource "google_compute_attached_disk" "attached_volumes" {
   for_each = { for i, v in lookup(var.machine.spec, "additional_volumes", []) : i => v }
 
-  device_name = element(local.linux_device_names, tonumber(each.key))
+  device_name = trimprefix(element(local.linux_device_names, tonumber(each.key))[0], local.prefix)
   disk        = google_compute_disk.volumes[each.key].id
   instance    = google_compute_instance.machine.id
 
@@ -112,7 +100,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh \"/dev/disk/by-id/google-${element(local.linux_device_names, tonumber(each.key))}\" ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
     ]
 
     # Requires firewall access to ssh port

--- a/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
@@ -56,11 +56,11 @@ if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
 fi
 
 # Mount point and volume creation
-sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
 sudo mkdir -p "${MOUNT_POINT}"
 # Get device UUID with blkid as exported format:
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}
+echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
@@ -1,20 +1,66 @@
 #!/bin/bash
 
-COUNTER=0
-DEVICE=$1
-MOUNTPOINT=$2
+# Expected EBS device paths: "/dev/sdX,/dev/sdY"
+IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
 
-while [ ! -b ${DEVICE} ]; do
-    sleep 2
-    COUNTER=$((COUNTER + 1))
-    if [ $COUNTER -ge 10 ]; then
-        exit 2
-    fi
+# Mount point
+MOUNT_POINT=$2
+# Total number of nvme devices that should be present on the system
+N_NVME_DEVICE=$3
+
+TARGET_NVME_DEVICE=""
+
+# Install nvme-cli
+if [ -f /etc/redhat-release ]; then
+	sudo yum install nvme-cli -y
+fi
+if [ -f /etc/debian_version ]; then
+	sudo apt update -y
+	sudo apt install nvme-cli -y
+fi
+
+# Wait for the availability of all the NVME devices that should be
+# present on the system.
+while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
+	sleep 2
+	COUNTER=$((COUNTER + 1))
+	if [ $COUNTER -ge 10 ]; then
+		echo "ERROR: unable to get the full list of NVME devices after 20s"
+		break
+	fi
 done
 
+# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+# NVME device.
+for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+	if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
+		TARGET_NVME_DEVICE=${NVME_DEVICE}
+		break
+	fi
+done;
 
-sudo mkfs.xfs "${DEVICE}"
-sudo mkdir -p "${MOUNTPOINT}"
-DEVICE_UUID="$(sudo /sbin/wipefs -i -O UUID ${DEVICE})"
-sudo mount -t xfs ${DEVICE} ${MOUNTPOINT}
-echo "UUID=${DEVICE_UUID} ${MOUNTPOINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
+# Fallback to device names
+for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
+	if [[ -e ${DEVICE_NAME} ]]; then
+		TARGET_NVME_DEVICE=${DEVICE_NAME}
+		echo "Warning: Falling back to device name"
+		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
+		break
+	fi
+done;
+
+if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
+	exit 2
+fi
+
+# Mount point and volume creation
+sudo mkfs.ext4 "${TARGET_NVME_DEVICE}"
+sudo mkdir -p "${MOUNT_POINT}"
+# Get device UUID with blkid as exported format:
+# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+echo "Warning: Will be mounted by UUID in /etc/fstab"
+UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+echo "${UUID} ${MOUNT_POINT} ext4 noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t ext4 -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -33,3 +33,25 @@ Fix the following tags:
     EOT
   }
 }
+
+locals {
+  prefix = "/dev/disk/by-id/google-"
+  base = ["sd"]
+  letters = [
+    "f", "g", "h", "i", 
+    "j", "k", "l", "m", 
+    "n", "o", "p", "q"
+  ]
+  # List(List(String))
+  # [[ "/dev/disk/by-id/google-sdf" ], ]
+  linux_device_names = [
+    for letter in local.letters:
+      formatlist("${local.prefix}%s${letter}", local.base)
+  ]
+  # List(String) with comma delimiter
+  # [ "/dev/disk/by-id/google-sdf" , ]
+  string_device_names = [
+    for names in local.linux_device_names:
+      format("%s", names...)
+  ]
+}


### PR DESCRIPTION
Changes:
* AWS volume script updated to allow fallback to device name instead of `nvme` tool
  * Device is still mounted with its `UUID` inside of `/etc/fstab`
    * Users need to update `/etc/fstab` if they reformat the device
* GCloud and Azure updated to match where possible