### PR TITLE
`additional_volumes` added to each provider's machine outputs

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -29,3 +29,7 @@ output "public_dns" {
 output "tags" {
   value = aws_instance.machine.tags_all
 }
+
+output "additional_volumes" {
+  value = var.machine.spec.additional_volumes
+}

--- a/edbterraform/data/terraform/azure/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/outputs.tf
@@ -19,3 +19,7 @@ output "private_ip" {
 output "tags" {
   value = azurerm_linux_virtual_machine.main.tags
 }
+
+output "additional_volumes" {
+  value = var.additional_volumes
+}

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -19,3 +19,6 @@ output "private_ip" {
 output "tags" {
   value = google_compute_instance.machine.labels
 }
+output "additional_volumes" {
+  value = var.machine.spec.additional_volumes
+}


### PR DESCRIPTION
`additional_volumes` is passed through so user can further modify their volumes if needed. We make the initial mount point tied to the `UUID` set during the filesystem formatting and add it to `/etc/fstab` so that it can be tracked. 

This is needed due to differences in how the providers handle device names and mounting order.
When volumes are modified, the user should take care to track the new `uuid`, or use an alternative method, and modify `/etc/fstab` accordingly.