### PR TITLE
Allow modified CIDR ranges

### DIFF
--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -8,7 +8,7 @@ module "machine_{{ region_ }}" {
   cidr_block               = lookup(lookup(module.spec.region_zone_networks, "{{ region }}", null), each.value.spec.zone, null)
   az                       = each.value.spec.zone
   machine                  = each.value
-  custom_security_group_id = module.security_{{ region_ }}.aws_security_group_id
+  custom_security_group_ids = module.security_{{ region_ }}.security_group_ids
   ssh_user                 = module.spec.base.ssh_user
   ssh_pub_key              = module.spec.public_key
   ssh_priv_key             = module.spec.private_key

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -121,3 +121,7 @@ output "{{output_name}}" {
   }
   sensitive = true
 }
+
+output "spec" {
+  value = module.spec[*]
+}

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -49,15 +49,12 @@ module "security_{{ region_ }}" {
   source = "./modules/security"
 
   vpc_id           = module.vpc_{{ region_ }}.vpc_id
-  public_cidrblock = var.public_cidrblock
   project_tag      = var.project_tag
-  service_ports    = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
   cluster_name     = module.spec.base.tags.cluster_name
-  region_cidrblocks = ([ for k, v 
-                      in lookup(lookup(module.spec.base.regions, "{{ region }}", null), "azs", [])
-                      : v ])
-  region_ports = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
-  
+  ports            = try(module.spec.region_ports["{{ region }}"], [])
+  ingress_cidrs    = module.spec.region_cidrblocks
+  egress_cidrs     = module.spec.region_cidrblocks
+
   depends_on = [module.routes_{{ region_ }}]
 
   providers = {

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -106,3 +106,7 @@ output "{{output_name}}" {
   }
   sensitive = true
 }
+
+output "spec" {
+  value = module.spec[*]
+}

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -37,18 +37,13 @@ module "security_{{ region_ }}" {
   for_each = lookup(module.spec.region_zone_networks, "{{ region }}", null)
 
   subnet_id         = module.network_{{ region_ }}[each.key].subnet_id
+  zone              = each.key
+  name_id           = module.spec.hex_id
   region            = module.vpc_{{ region_ }}.region
   resource_name     = module.vpc_{{ region_ }}.resource_name
-  service_name      = "service-{{ region }}-${each.key}-${module.spec.hex_id}"
-  service_ports     = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
-  public_cidrblock  = var.public_cidrblock
-  region_name       = "region-{{ region }}-${each.key}-${module.spec.hex_id}"
-  region_ports      = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
-  region_cidrblocks = flatten([
-    for region in try(module.spec.base.regions, []) : [
-      for ip_cidr in try(region.zones, []) : ip_cidr
-      ] 
-    ])
+  ports             = try(module.spec.region_ports["{{ region }}"], [])
+  ingress_cidrs     = module.spec.region_cidrblocks
+  egress_cidrs      = module.spec.region_cidrblocks
 
   depends_on = [module.network_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -117,3 +117,8 @@ output "{{output_name}}" {
   }
   sensitive = true
 }
+
+output "spec" {
+  value = module.spec[*]
+  sensitive = true
+}

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -57,18 +57,11 @@ module "security_{{ region_ }}" {
   source = "./modules/security"
 
   network_name  = module.vpc_{{ region_ }}.vpc_id
-
-  service_name = "service-{{ region }}-${module.spec.hex_id}"
-  service_ports    = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "service_ports", [])
-  public_cidrblock = var.public_cidrblock
-
-  region_name = "region-{{ region }}-${module.spec.hex_id}"
-  region_ports = lookup(lookup(module.spec.base.regions, "{{ region }}", null), "region_ports", [])
-  region_cidrblocks = flatten([
-    for region in try(module.spec.base.regions, []) : [
-      for ip_cidr in try(region.zones, []) : ip_cidr
-      ] 
-    ])
+  ports         = try(module.spec.region_ports["{{ region }}"], [])
+  ingress_cidrs = module.spec.region_cidrblocks
+  egress_cidrs  = module.spec.region_cidrblocks
+  region        = "{{ region }}"
+  name_id       = module.spec.hex_id
 
   depends_on = [module.service_connection_{{ region_ }}]
 

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "machine" {
   instance_type          = var.machine.spec.instance_type
   key_name               = var.key_name
   subnet_id              = data.aws_subnet.selected.id
-  vpc_security_group_ids = [var.custom_security_group_id]
+  vpc_security_group_ids = var.custom_security_group_ids
 
   root_block_device {
     delete_on_termination = "true"

--- a/edbterraform/data/terraform/aws/modules/security/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/security/outputs.tf
@@ -1,3 +1,6 @@
-output "aws_security_group_id" {
-  value = aws_security_group.rules.id
+output "security_group_ids" {
+  value = flatten([
+    for key, values in merge(aws_security_group.rules):
+      values.id
+  ])
 }

--- a/edbterraform/data/terraform/aws/modules/security/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/security/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.7.0"
+    }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -1,0 +1,12 @@
+variable "vpc_id" {}
+variable "project_tag" {}
+variable "ports" {}
+variable "cluster_name" {}
+variable "ingress_cidrs" {
+  type = list(string)
+  default = [ "0.0.0.0/0" ]
+}
+variable "egress_cidrs" {
+  type = list(string)
+  default = [ "0.0.0.0/0" ]
+}

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -101,3 +101,21 @@ output "region_kubernetes" {
     }...
   }
 }
+
+output "region_cidrblocks" {
+  description = "list of all cidrs from each defined zone"
+  value = flatten([
+    for region, values in var.spec.regions: [
+      for zone, cidr in values.zones:
+        cidr
+    ]
+  ])
+}
+
+output "region_ports" {
+  description = "mapping of region to its list of port rules"
+  value = {
+    for region, values in var.spec.regions:
+      region => flatten([values.service_ports, values.region_ports])
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -1,4 +1,19 @@
 variable "spec" {
+  description = <<-EOT
+  Object meant to represent inputs needed to get a valid configuration
+  for use with the rest of the cloud provider module collection.
+  In most cases:
+  * optional() should be used so that null is passed further down for the module to handle
+    * Module require null to be handled:
+      * set a default if desired: optional(type,default) 
+    * Need to set a default after the initial object is set:
+      * dynamically set variables with the use of locals and null_resource
+      * set an output variable for use with other modules
+  * sibling modules should handle most errors with variable validations and preconditions
+    so they are caught during terraform plan
+  * provider implementations vary and errors might need to be caught eariler, as last resort, 
+    use validations and preconditions here for use with terraform plan or postconditions with terraform apply
+  EOT
   type = object({
     # Project Level Tags to be merged with other tags
     tags = optional(object({
@@ -23,11 +38,15 @@ variable "spec" {
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
+        egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string))
+        egress_cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -1,54 +1,37 @@
 resource "azurerm_network_security_group" "firewall" {
-  name                = var.service_name
+  name                = "${var.region}-${var.zone}-${var.name_id}"
   resource_group_name = var.resource_name
   location            = var.region
 }
 
-resource "azurerm_network_security_rule" "services" {
-  count = length(var.service_ports)
-
-  resource_group_name         = var.resource_name
-  network_security_group_name = azurerm_network_security_group.firewall.name
-
-  name                       = var.service_ports[count.index].name
-  description                = var.service_ports[count.index].description
-  # First letter must be uppercase
-  protocol                   = title(var.service_ports[count.index].protocol)
-  destination_port_range     = var.service_ports[count.index].port != null ? var.service_ports[count.index].port : "*"
-  destination_address_prefix = "*"
-  source_port_range          = "*"
-  source_address_prefix      = "*"
-  access                     = "Allow"
-  direction                  = "Inbound"
-  priority                   = 100 + count.index
-}
-
-resource "azurerm_network_security_rule" "regions" {
-  count = length(var.region_ports)
-
-  resource_group_name         = var.resource_name
-  network_security_group_name = azurerm_network_security_group.firewall.name
-
-  name                         = var.region_ports[count.index].name
-  description                  = var.region_ports[count.index].description
-  # First letter must be uppercase
-  protocol                     = title(var.region_ports[count.index].protocol)
-  destination_port_range       = var.region_ports[count.index].port != null ? var.region_ports[count.index].port : "*"
-  destination_address_prefixes = var.region_cidrblocks
-  source_port_range            = "*"
-  source_address_prefixes      = var.region_cidrblocks
-  access                       = "Allow"
-  direction                    = "Inbound"
-  priority                     = 200 + count.index
-}
-
 resource "azurerm_subnet_network_security_group_association" "firewall" {
-  count = length(var.service_ports) > 0 || length(var.region_ports) > 0 ? 1 : 0
-
   subnet_id                 = var.subnet_id
   network_security_group_id = azurerm_network_security_group.firewall.id
 
   depends_on = [
     azurerm_network_security_group.firewall
   ]
+}
+
+resource "azurerm_network_security_rule" "rules" {
+  for_each = {
+    # preserve ordering
+    for index, values in var.ports:
+      format("0%.3d",index) => values
+  }
+
+  resource_group_name         = var.resource_name
+  network_security_group_name = azurerm_network_security_group.firewall.name
+
+  name                       = "${each.value.protocol}-${var.region}-${var.zone}-${var.name_id}-${each.key}"
+  description                = each.value.description
+  # First letter must be uppercase
+  protocol                   = title(each.value.protocol)
+  destination_port_range     = each.value.port != null ? each.value.port : "*"
+  destination_address_prefixes = each.value.egress_cidrs != null ? each.value.egress_cidrs : var.egress_cidrs
+  source_port_range          = "*"
+  source_address_prefixes    = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
+  access                     = "Allow"
+  direction                  = "Inbound"
+  priority                   = 100 + tonumber(each.key)
 }

--- a/edbterraform/data/terraform/azure/modules/security/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/security/variables.tf
@@ -1,9 +1,16 @@
 variable "subnet_id" {}
+variable "zone" {}
 variable "resource_name" {}
 variable "region" {}
-variable "service_name" {}
-variable "service_ports" {}
-variable "region_name" {}
-variable "public_cidrblock" {}
-variable "region_ports" {}
-variable "region_cidrblocks" {}
+variable "ports" {
+    type = list
+}
+variable "ingress_cidrs" {
+    type = list(string)
+}
+variable "egress_cidrs" {
+    type = list(string)
+}
+variable "name_id" {
+    type = string
+}

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -70,3 +70,21 @@ output "hex_id" {
 output "pet_name" {
   value = random_pet.name.id
 }
+
+output "region_cidrblocks" {
+  description = "list of all cidrs from each defined zone"
+  value = flatten([
+    for region, values in var.spec.regions: [
+      for zone, cidr in values.zones:
+        cidr
+    ]
+  ])
+}
+
+output "region_ports" {
+  description = "mapping of region to its list of port rules"
+  value = {
+    for region, values in var.spec.regions:
+      region => flatten([values.service_ports, values.region_ports])
+  }
+}

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -1,4 +1,19 @@
 variable "spec" {
+  description = <<-EOT
+  Object meant to represent inputs needed to get a valid configuration
+  for use with the rest of the cloud provider module collection.
+  In most cases:
+  * optional() should be used so that null is passed further down for the module to handle
+    * Module require null to be handled:
+      * set a default if desired: optional(type,default) 
+    * Need to set a default after the initial object is set:
+      * dynamically set variables with the use of locals and null_resource
+      * set an output variable for use with other modules
+  * sibling modules should handle most errors with variable validations and preconditions
+    so they are caught during terraform plan
+  * provider implementations vary and errors might need to be caught eariler, as last resort, 
+    use validations and preconditions here for use with terraform plan or postconditions with terraform apply
+  EOT
   type = object({
     # Project Level Tags to be merged with other tags
     tags = optional(object({
@@ -22,16 +37,18 @@ variable "spec" {
       cidr_block = string
       zones      = optional(map(string), {})
       service_ports = optional(list(object({
-        name        = string
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
+        egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
-        name        = string
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string))
+        egress_cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -7,6 +7,9 @@ data "google_compute_subnetwork" "selected" {
   name   = var.subnet_name
 }
 
+# TODO: Data source is causes instance to be replaced
+# due to terraform thinking the image has changed
+# Use 'initialize_params.image' in instance and remove/move data source out of module
 data "google_compute_image" "image" {
   name = var.operating_system.name
 }
@@ -40,7 +43,7 @@ resource "google_compute_instance" "machine" {
   }
 
   lifecycle {
-    ignore_changes = [attached_disk]
+    ignore_changes = [attached_disk, ]
   }
 
   metadata = { ssh-keys = var.ssh_metadata }

--- a/edbterraform/data/terraform/gcloud/modules/security/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/variables.tf
@@ -1,7 +1,10 @@
 variable "network_name" {}
-variable "public_cidrblock" {}
-variable "service_ports" {}
-variable "service_name" {}
-variable "region_ports" {}
-variable "region_name" {}
-variable "region_cidrblocks" {}
+variable "name_id" {}
+variable "region" {}
+variable "ports" {}
+variable "ingress_cidrs" {
+  type = list(string)
+}
+variable "egress_cidrs" {
+  type = list(string)
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -102,3 +102,21 @@ output "hex_id" {
 output "pet_name" {
   value = random_pet.name.id
 }
+
+output "region_cidrblocks" {
+  description = "list of all cidrs from each defined zone"
+  value = flatten([
+    for region, values in var.spec.regions: [
+      for zone, cidr in values.zones:
+        cidr
+    ]
+  ])
+}
+
+output "region_ports" {
+  description = "mapping of region to its list of port rules"
+  value = {
+    for region, values in var.spec.regions:
+      region => flatten([values.service_ports, values.region_ports])
+  }
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -1,4 +1,19 @@
 variable "spec" {
+  description = <<-EOT
+  Object meant to represent inputs needed to get a valid configuration
+  for use with the rest of the cloud provider module collection.
+  In most cases:
+  * optional() should be used so that null is passed further down for the module to handle
+    * Module require null to be handled:
+      * set a default if desired: optional(type,default) 
+    * Need to set a default after the initial object is set:
+      * dynamically set variables with the use of locals and null_resource
+      * set an output variable for use with other modules
+  * sibling modules should handle most errors with variable validations and preconditions
+    so they are caught during terraform plan
+  * provider implementations vary and errors might need to be caught eariler, as last resort, 
+    use validations and preconditions here for use with terraform plan or postconditions with terraform apply
+  EOT
   type = object({
     # Project Level Tags to be merged with other tags
     tags = optional(object({
@@ -22,11 +37,15 @@ variable "spec" {
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
+        egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
         description = string
+        ingress_cidrs = optional(list(string))
+        egress_cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({


### PR DESCRIPTION
Allow user to specify list of cidrs under each defined `region_ports` and `service_ports`:
* `ingress_cidrs` available: list of strings that represent a cidr range
  * `service_ports` defaults to `["0.0.0.0/0"]`
* `egress_cidrs` available: list of strings that represent a cidr range
  * `service_ports` and `region_ports` defaults to `region_cidrblocks` if not defined
* `region_cidrblocks` specification output is a list of cidrs of from all regions
* `region_ports` specification output is a mapping of region name to a list of service and region ports
* `spec` output available through the root module for inspection

Reference: Organizations can block `0.0.0.0/0` from direct use.