### PR TITLE
Allow instance specific OS and user

### DIFF
--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -57,7 +57,7 @@ def main(args=None):
     * cd {env.project_path}
     * terraform apply
     * terraform output -json {outputs['terraform_output']}
-    * ssh {outputs['ssh_user']}@<ip-address> -i {outputs['ssh_filename']}
+    * ssh <ssh_user>@<ip-address> -i {outputs['ssh_filename']}
     \n
     ''')
     

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -3,13 +3,12 @@ module "machine_{{ region_ }}" {
 
   for_each = { for rm in lookup(module.spec.region_machines, "{{ region }}", []) : rm.name => rm }
 
-  operating_system         = module.spec.base.operating_system
+  operating_system         = each.value.spec.operating_system
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
   cidr_block               = lookup(lookup(module.spec.region_zone_networks, "{{ region }}", null), each.value.spec.zone, null)
   az                       = each.value.spec.zone
   machine                  = each.value
   custom_security_group_ids = module.security_{{ region_ }}.security_group_ids
-  ssh_user                 = module.spec.base.ssh_user
   ssh_pub_key              = module.spec.public_key
   ssh_priv_key             = module.spec.private_key
   use_agent                = module.spec.base.ssh_key.use_agent

--- a/edbterraform/data/templates/azure/agreements.tf.j2
+++ b/edbterraform/data/templates/azure/agreements.tf.j2
@@ -1,9 +1,12 @@
 module "agreements" {
   source = "./modules/agreement"
 
-  publisher = module.spec.base.operating_system.publisher
-  offer     = module.spec.base.operating_system.offer
-  plan      = module.spec.base.operating_system.sku
+  for_each = module.spec.base.images
+
+  publisher = each.value.publisher
+  offer     = each.value.offer
+  plan      = each.value.sku
+  accept    = each.value.accept
 
   depends_on = [ null_resource.validation ]
 }

--- a/edbterraform/data/templates/azure/kubernetes.tf.j2
+++ b/edbterraform/data/templates/azure/kubernetes.tf.j2
@@ -16,7 +16,7 @@ module "kubernetes_{{ region_ }}" {
   vmSize                          = each.value.spec.instance_type
   solutionName                    = each.value.spec.solution_name
   publisherName                   = each.value.spec.publisher_name
-  ssh_user                        = module.spec.base.ssh_user
+  ssh_user                        = each.value.spec.ssh_user
   sshPublicKey                    = module.spec.public_key  
   tags                            = each.value.spec.tags
 

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -8,17 +8,11 @@ module "machine_{{ region_ }}" {
 
   resource_name                   = module.vpc_{{ region_ }}.resource_name
   subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone].subnet_id
-  operating_system                = module.spec.base.operating_system
+  operating_system                = each.value.spec.operating_system
   cluster_name                    = module.spec.base.tags.cluster_name
-  machine                         = (
-    merge(
-      each.value.spec,
-      {name = each.value.name},
-      {zone = tostring(each.value.spec.zone) == "0" ? null : each.value.spec.zone},
-    )
-  )
+  name                            = each.value.name
+  machine                         = each.value.spec
   additional_volumes              = each.value.spec.additional_volumes
-  ssh_user                        = module.spec.base.ssh_user
   private_key                     = module.spec.private_key
   use_agent                       = module.spec.base.ssh_key.use_agent
   public_key_name                 = module.key_pair_{{ region_ }}.name

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -6,19 +6,18 @@ module "machine_{{ region_ }}" {
       rm.name => rm 
     })
 
-  operating_system                = module.spec.base.operating_system
+  operating_system                = each.value.spec.operating_system
   cluster_name                    = module.spec.base.tags.cluster_name
   zone                            = each.value.spec.zone
   machine                         = each.value
-  ssh_user                        = module.spec.base.ssh_user
   ssh_priv_key                    = module.spec.private_key
+  ssh_pub_key                     = module.spec.public_key
   use_agent                       = module.spec.base.ssh_key.use_agent
-  ssh_metadata                    = module.key_pair_{{ region_ }}.keys
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone].name
   name_id                         = module.spec.hex_id
-  tags = each.value.spec.tags
+  tags                            = each.value.spec.tags
 
-  depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
+  depends_on = [module.security_{{ region_ }}]
 
   providers = {
     google = google.{{ region_ }}

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -8,8 +8,6 @@
 {%   endif %}
 
 {%   if has_machines %}
-{%     include "key_pair.tf.j2" %}
-
 {%     include "machine.tf.j2" %}
 {%   endif %}
 

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -74,7 +74,7 @@ resource "null_resource" "copy_setup_volume_script" {
 
     connection {
       type        = "ssh"
-      user        = var.ssh_user
+      user        = var.operating_system.ssh_user
       host        = aws_instance.machine.public_ip
       agent       = var.use_agent # agent and private_key conflict
       private_key = var.use_agent ? null : var.ssh_priv_key
@@ -101,7 +101,7 @@ resource "null_resource" "setup_volume" {
 
     connection {
       type        = "ssh"
-      user        = var.ssh_user
+      user        = var.operating_system.ssh_user
       host        = aws_instance.machine.public_ip
       agent       = var.use_agent # agent and private_key conflict
       private_key = var.use_agent ? null : var.ssh_priv_key

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -33,3 +33,7 @@ output "tags" {
 output "additional_volumes" {
   value = var.machine.spec.additional_volumes
 }
+
+output "operating_system" {
+  value = var.operating_system
+}

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -2,7 +2,6 @@ variable "machine" {}
 variable "vpc_id" {}
 variable "cidr_block" {}
 variable "az" {}
-variable "ssh_user" {}
 variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
 variable "use_agent" {

--- a/edbterraform/data/terraform/aws/modules/specification/files.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/files.tf
@@ -2,7 +2,7 @@
 # If ssh_key.public_path and ssh_key.private_path are defined,
 # overwrite the default keys.
 locals {
-  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_user_count = var.spec.images != null ? 1 : 0
   ssh_keys_count = (
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -20,17 +20,17 @@ variable "spec" {
       cluster_name = optional(string, "AWS-Cluster")
       created_by   = optional(string, "EDB-Terraform-AWS")
     }), {})
-    ssh_user = optional(string)
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)
       output_name  = optional(string, "ssh-id_rsa")
       use_agent    = optional(bool, false)
     }), {})
-    operating_system = optional(object({
-      name  = string
-      owner = number
-    }))
+    images = optional(map(object({
+      name = optional(string)
+      owner = optional(number)
+      ssh_user = optional(string)
+    })))
     regions = map(object({
       cidr_block = string
       zones      = optional(map(string), {})
@@ -51,6 +51,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = optional(string)
+      image_name    = string
       count         = optional(number, 1)
       region        = string
       zone          = string
@@ -115,13 +116,6 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
-
-  validation {
-    condition     = length(var.spec.machines) == 0 || var.spec.operating_system != null
-    error_message = <<-EOT
-    operating_system key must be defined within spec when machines are used
-    EOT
-  }
 
   validation {
     condition = (

--- a/edbterraform/data/terraform/azure/modules/agreement/main.tf
+++ b/edbterraform/data/terraform/azure/modules/agreement/main.tf
@@ -1,4 +1,14 @@
-resource "azurerm_marketplace_agreement" "image" {
+data "azurerm_marketplace_agreement" "reference" {
+  count = var.accept ? 0 : 1
+
+  publisher = var.publisher
+  offer     = var.offer
+  plan      = var.plan
+}
+
+resource "azurerm_marketplace_agreement" "agreement" {
+  count = var.accept ? 1 : 0
+
   publisher = var.publisher
   offer     = var.offer
   plan      = var.plan

--- a/edbterraform/data/terraform/azure/modules/agreement/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/agreement/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.37.0"
+      version = ">= 3.38.0"
     }
   }
   required_version = ">= 1.3.6"

--- a/edbterraform/data/terraform/azure/modules/agreement/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/agreement/variables.tf
@@ -1,3 +1,9 @@
 variable "publisher" {}
 variable "offer" {}
 variable "plan" {}
+variable "accept" {
+  description = "Auto-approve new image use, must only be accepted once"
+  type = bool
+  default = false
+  nullable = false
+}

--- a/edbterraform/data/terraform/azure/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/outputs.tf
@@ -23,3 +23,7 @@ output "tags" {
 output "additional_volumes" {
   value = var.additional_volumes
 }
+
+output "operating_system" {
+  value = var.operating_system
+}

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -1,14 +1,20 @@
+variable "name" {
+  type = string
+  default = "default_name"
+}
 variable "operating_system" {
+  description = "operating system and default user"
   type = object({
     sku       = string
     offer     = string
     publisher = string
     version   = string
+    ssh_user  = string
   })
 }
 variable "machine" {
+  description = "cloud resources needed"
   type = object({
-    name          = string
     type          = string
     region        = string
     zone          = optional(string)
@@ -26,8 +32,10 @@ variable "tags" {
 }
 variable "cluster_name" {}
 locals {
-  zones         = var.machine.zone == null ? null : [var.machine.zone]
-  public_ip_sku = var.machine.zone == null ? "Basic" : "Standard"
+  # 0 is used to represent no zone but azure expects null
+  zone = tostring(var.machine.zone) == "0" ? null : var.machine.zone
+  zones         = local.zone == null ? null : [local.zone]
+  public_ip_sku = local.zone == null ? "Basic" : "Standard"
 }
 variable "resource_name" {
   type = string
@@ -36,7 +44,6 @@ variable "name_id" {
   type = string
 }
 variable "subnet_id" {}
-variable "ssh_user" {}
 variable "public_key_name" {}
 variable "private_key" {}
 variable "use_agent" {

--- a/edbterraform/data/terraform/azure/modules/specification/files.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/files.tf
@@ -2,7 +2,7 @@
 # If ssh_key.public_path and ssh_key.private_path are defined,
 # overwrite the default keys.
 locals {
-  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_user_count = var.spec.kubernetes != null || var.spec.images != null ? 1 : 0
   ssh_keys_count = (
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -25,7 +25,16 @@ locals {
     for name, machine_spec in var.spec.machines : [
       for index in range(machine_spec.count) : {
         name = machine_spec.count > 1 ? "${name}-${index}" : name
-        spec = machine_spec
+        spec = merge(machine_spec, {
+          # spec project tags
+          tags = merge(var.spec.tags, machine_spec.tags, {
+            # machine module specific tags
+            name = machine_spec.count > 1 ? "${name}-${index}" : name
+            id   = random_id.apply.hex
+          })
+          # assign operating system from mapped names
+          operating_system = var.spec.images[machine_spec.image_name]
+        })
       }
     ]
   ])
@@ -33,17 +42,8 @@ locals {
 
 output "region_machines" {
   value = {
-    for machine in local.machines_extended : machine.spec.region => {
-      name = machine.name
-      spec = merge(machine.spec, {
-        # spec project tags
-        tags = merge(var.spec.tags, machine.spec.tags, {
-          # machine module specific tags
-          name = machine.name
-          id   = random_id.apply.hex
-        })
-      })
-    }...
+    for machine in local.machines_extended :
+      machine.spec.region => machine...
   }
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -20,19 +20,20 @@ variable "spec" {
       cluster_name = optional(string, "Azure-Cluster")
       created_by   = optional(string, "EDB-Terraform-Azure")
     }), {})
-    ssh_user = optional(string)
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)
       output_name  = optional(string, "ssh-id_rsa")
       use_agent    = optional(bool, false)
     }), {})
-    operating_system = optional(object({
-      publisher = string
-      offer     = string
-      sku       = string
-      version   = string
-    }))
+    images = optional(map(object({
+      publisher = optional(string)
+      offer     = optional(string)
+      sku       = optional(string)
+      version   = optional(string)
+      accept    = optional(bool)
+      ssh_user  = optional(string)
+    })))
     regions = map(object({
       cidr_block = string
       zones      = optional(map(string), {})
@@ -53,6 +54,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = optional(string)
+      image_name    = string
       count         = optional(number, 1)
       region        = string
       zone          = number
@@ -71,6 +73,7 @@ variable "spec" {
     })), {})
     kubernetes = optional(map(object({
       region                  = string
+      ssh_user                = optional(string)
       resource_group_location = optional(string)
       log_analytics_location  = optional(string)
       node_count              = number
@@ -81,23 +84,6 @@ variable "spec" {
       tags                    = optional(map(string), {})
     })), {})
   })
-
-  validation {
-    condition     = length(var.spec.machines) == 0 || var.spec.operating_system != null
-    error_message = <<-EOT
-    operating_system key must be defined within spec when machines are used
-    EOT
-  }
-
-  validation {
-    condition = (
-      (length(var.spec.machines) == 0 && length(var.spec.kubernetes) == 0) ||
-      var.spec.ssh_user != null
-    )
-    error_message = <<-EOT
-    ssh_user key must be defined within spec when machines or kubernetes is used
-    EOT
-  }
 
   validation {
     condition = (

--- a/edbterraform/data/terraform/gcloud/modules/key_pair/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/key_pair/main.tf
@@ -1,4 +1,0 @@
-resource "google_compute_project_metadata_item" "key_pair" {
-  key   = var.key_name
-  value = "${var.ssh_user}:${var.public_keys}"
-}

--- a/edbterraform/data/terraform/gcloud/modules/key_pair/output.tf
+++ b/edbterraform/data/terraform/gcloud/modules/key_pair/output.tf
@@ -1,7 +1,0 @@
-output "key_pair_id" {
-  value = google_compute_project_metadata_item.key_pair.id
-}
-
-output "keys" {
-  value = google_compute_project_metadata_item.key_pair.value
-}

--- a/edbterraform/data/terraform/gcloud/modules/key_pair/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/key_pair/providers.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google"
-    }
-  }
-  required_version = ">= 0.13"
-}

--- a/edbterraform/data/terraform/gcloud/modules/key_pair/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/key_pair/variables.tf
@@ -1,3 +1,0 @@
-variable "public_keys" {}
-variable "ssh_user" {}
-variable "key_name" {}

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -22,3 +22,6 @@ output "tags" {
 output "additional_volumes" {
   value = var.machine.spec.additional_volumes
 }
+output "operating_system" {
+  value = var.operating_system
+}

--- a/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/google"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.6"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -1,10 +1,24 @@
 variable "machine" {}
 variable "zone" {}
-variable "ssh_user" {}
 variable "ssh_priv_key" {}
-variable "ssh_metadata" {}
+variable "ssh_pub_key" {}
 variable "cluster_name" {}
-variable "operating_system" {}
+variable "operating_system" {
+  type = object({
+    name = optional(string)
+    family = optional(string)
+    project = optional(string)
+    ssh_user = string
+  })
+
+  validation {
+    condition = (
+      (var.operating_system.name == null ? 0 : 1) + 
+      (var.operating_system.family == null ? 0 : 1) == 1
+    )
+    error_message = "only one, name or family must be defined"
+  }
+}
 variable "subnet_name" {}
 variable "name_id" { default = "0" }
 variable "use_agent" {

--- a/edbterraform/data/terraform/gcloud/modules/specification/files.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/files.tf
@@ -2,7 +2,7 @@
 # If ssh_key.public_path and ssh_key.private_path are defined,
 # overwrite the default keys.
 locals {
-  ssh_user_count = var.spec.ssh_user != null ? 1 : 0
+  ssh_user_count = var.spec.images != null ? 1 : 0
   ssh_keys_count = (
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -25,7 +25,16 @@ locals {
     for name, machine_spec in var.spec.machines : [
       for index in range(machine_spec.count) : {
         name = machine_spec.count > 1 ? "${name}-${index}" : name
-        spec = machine_spec
+        spec = merge(machine_spec, {
+          # spec project tags
+          tags = merge(var.spec.tags, machine_spec.tags, {
+            # machine module specific tags
+            name = machine_spec.count > 1 ? "${name}-${index}" : name
+            id   = random_id.apply.hex
+          })
+          # assign operating system from mapped names
+          operating_system = var.spec.images[machine_spec.image_name]
+        })
       }
     ]
   ])
@@ -33,17 +42,8 @@ locals {
 
 output "region_machines" {
   value = {
-    for machine in local.machines_extended : machine.spec.region => {
-      name = machine.name
-      spec = merge(machine.spec, {
-        # spec project tags
-        tags = merge(var.spec.tags, machine.spec.tags, {
-          # machine module specific tags
-          name = machine.name
-          id   = random_id.apply.hex
-        })
-      })
-    }...
+    for machine in local.machines_extended:
+      machine.spec.region => machine... 
   }
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -20,16 +20,18 @@ variable "spec" {
       cluster_name = optional(string, "gcp-cluster")
       created_by   = optional(string, "edb-terraform")
     }), {})
-    ssh_user = optional(string)
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)
       output_name  = optional(string, "ssh-id_rsa")
       use_agent    = optional(bool, false)
     }), {})
-    operating_system = optional(object({
-      name = string
-    }))
+    images = optional(map(object({
+      name = optional(string)
+      family = optional(string)
+      project = optional(string)
+      ssh_user = optional(string)
+    })))
     regions = map(object({
       cidr_block = string
       zones      = optional(map(string), {})
@@ -50,6 +52,7 @@ variable "spec" {
     }))
     machines = optional(map(object({
       type          = optional(string)
+      image_name    = string
       count         = optional(number, 1)
       region        = string
       zone          = string
@@ -110,13 +113,6 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
-
-  validation {
-    condition     = length(var.spec.machines) == 0 || var.spec.operating_system != null
-    error_message = <<-EOT
-    operating_system key must be defined within spec when machines are used
-    EOT
-  }
 
   validation {
     condition = (

--- a/infrastructure-examples/aws-ec2-v2.yml
+++ b/infrastructure-examples/aws-ec2-v2.yml
@@ -1,0 +1,58 @@
+aws:
+  tags:
+    cluster_name: Demo-Infra
+    created_by: edb-terraform
+  images:
+    rocky:
+      name: Rocky-8-ec2-8.6-20220515.0.x86_64
+      owner: 679593333241
+      ssh_user: rocky
+    debian:
+      name: debian-10-amd64
+      owner: 136693071363
+      ssh_user: admin
+  regions:
+    us-east-1:
+      cidr_block: 10.0.0.0/16
+      zones:
+        us-east-1b: 10.0.0.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+  machines:
+    dbt2-driver:
+      image_name: debian
+      region: us-east-1
+      zone: us-east-1b
+      instance_type: c5.4xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      tags:
+        type: dbt2-driver
+    pg1:
+      image_name: rocky
+      region: us-east-1
+      zone: us-east-1b
+      instance_type: c5.4xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      additional_volumes:
+        - mount_point: /opt/pg_data
+          size_gb: 20
+          type: io2
+          iops: 5000
+          encrypted: false
+        - mount_point: /opt/pg_wal
+          size_gb: 20
+          type: io2
+          iops: 5000
+          encrypted: false
+      tags:
+        type: postgres

--- a/infrastructure-examples/aws-ec2.yml
+++ b/infrastructure-examples/aws-ec2.yml
@@ -1,0 +1,61 @@
+aws:
+  tags:
+    cluster_name: Demo-Infra
+    created_by: edb-terraform
+  ssh_user: rocky
+  operating_system:
+    name: Rocky-8-ec2-8.6-20220515.0.x86_64
+    owner: 679593333241
+  regions:
+    us-east-1:
+      cidr_block: 10.0.0.0/16
+      zones:
+        us-east-1b: 10.0.0.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+  machines:
+    dbt2-client:
+      type: dbt2-client
+      region: us-east-1
+      zone: us-east-1b
+      instance_type: c5.4xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      tags:
+        foo: bar
+    dbt2-driver:
+      type: dbt2-driver
+      region: us-east-1
+      zone: us-east-1b
+      instance_type: c5.4xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+    pg1:
+      type: postgres
+      region: us-east-1
+      zone: us-east-1b
+      instance_type: c5.4xlarge
+      volume:
+        type: gp2
+        size_gb: 50
+        iops: 5000
+        encrypted: false
+      additional_volumes:
+        - mount_point: /opt/pg_data
+          size_gb: 20
+          type: io2
+          iops: 5000
+          encrypted: false
+        - mount_point: /opt/pg_wal
+          size_gb: 20
+          type: io2
+          iops: 5000
+          encrypted: false

--- a/infrastructure-examples/azure-vms-v2.yml
+++ b/infrastructure-examples/azure-vms-v2.yml
@@ -1,0 +1,58 @@
+---
+azure:
+  tags:
+    cluster_name: azure-infra
+    created_by: edb-terraform
+  images:
+    rocky:
+      publisher: erockyenterprisesoftwarefoundationinc1653071250513
+      offer: rockylinux
+      sku: free
+      version: 8.6.0
+      ssh_user: rocky
+    rocky_8_7_0:
+      publisher: erockyenterprisesoftwarefoundationinc1653071250513
+      offer: rockylinux
+      sku: free
+      version: 8.7.0
+      ssh_user: rocky
+  regions:
+    westus:
+      cidr_block: 10.1.0.0/16
+      zones:
+        0: 10.1.20.0/24
+      service_ports:
+        - name: ssh_access
+          port: 22
+          protocol: tcp
+          description: "SSH"
+  machines:
+    dbt2-driver:
+      image_name: rocky_8_7_0
+      region: westus
+      zone: 0
+      instance_type: Standard_D2s_v3
+      volume:
+        type: StandardSSD_LRS
+        size_gb: 50
+      tags:
+        type: dbt2-driver
+    pg1:
+      image_name: rocky
+      region: westus
+      zone: 0
+      instance_type: Standard_D2s_v3
+      volume:
+        type: StandardSSD_LRS
+        size_gb: 50
+      additional_volumes:
+        - mount_point: /opt/pg_data
+          type: UltraSSD_LRS
+          size_gb: 50
+          iops: 1000
+        - mount_point: /opt/pg_wal
+          type: UltraSSD_LRS
+          size_gb: 50
+          iops: 1000
+      tags:
+        type: postgres

--- a/infrastructure-examples/compute-engine-v2.yml
+++ b/infrastructure-examples/compute-engine-v2.yml
@@ -1,0 +1,50 @@
+gcloud:
+  tags:
+    cluster_name: gcloud-infra
+  images:
+    rocky:
+      name: rocky-linux-8
+      ssh_user: rocky
+    debian:
+      family: debian-11
+      project: debian-cloud
+      ssh_user: debian
+  regions:
+    us-west4:
+      cidr_block: 10.2.0.0/16
+      zones:
+        us-west4-b: 10.2.20.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+  machines:
+    dbt2-driver:
+      image_name: debian
+      region: us-west4
+      zone: us-west4-b
+      instance_type: e2-standard-4
+      volume:
+        type: pd-standard
+        size_gb: 50
+      tags:
+        type: dbt-driver
+    pg1:
+      image_name: rocky
+      region: us-west4
+      zone: us-west4-b
+      instance_type: e2-standard-4
+      volume:
+        type: pd-standard
+        size_gb: 50
+      additional_volumes:
+        - mount_point: /opt/pg_data
+          type: pd-ssd
+          size_gb: 50
+          iops: null
+        - mount_point: /opt/pg_wal
+          type: pd-ssd
+          size_gb: 50
+          iops: null
+      tags:
+        type: postgres


### PR DESCRIPTION
Changes:
* `operating_system` and `ssh_user` depreciated at the top level but still supported for `machines` and `kubernetes`
* `images` added to replace `operating_system`, which is a mapping of operating system configurations and can be referenced under each machine with `image_name`.
  * dynamically grabs image and assigns it to `operating_system` for each machine within spec module
  * `ssh_user` should be defined under each image as the initial user might vary between images
* examples added under `infrastructure-examples/*-v2.yml`
* Azure
  * fix for market agreement as we only need to agree to the terms once
    * use `accept: true` under each `images` mapping if used for the first time with the current subscription
    * Additional agreement configuration might be needed by user with enterprise admin privileges: https://github.com/microsoft/PartsUnlimitedMRP/issues/160#issuecomment-984821361 

Reference: https://github.com/EnterpriseDB/ebac/pull/29#issuecomment-1432048486