### PR TITLE
AWS egress default and spec output fix

### DIFF
--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -124,4 +124,5 @@ output "{{output_name}}" {
 
 output "spec" {
   value = module.spec[*]
+  sensitive = true
 }

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -109,4 +109,5 @@ output "{{output_name}}" {
 
 output "spec" {
   value = module.spec[*]
+  sensitive = true
 }

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -5,7 +5,10 @@ variable "az" {}
 variable "ssh_user" {}
 variable "ssh_pub_key" {}
 variable "ssh_priv_key" {}
-variable "custom_security_group_id" {}
+variable "use_agent" {
+  default = false
+}
+variable "custom_security_group_ids" {}
 variable "key_name" {}
 variable "operating_system" {}
 variable "tags" {

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "rules" {
   description = each.value.description
   vpc_id = var.vpc_id
   ingress {
-      from_port   = each.value.protocol == "icmp" ? 8 : -1
+      from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
       to_port     = each.value.port != null && each.value.protocol != "icmp"  ? each.value.port : -1
       protocol    = each.value.protocol
       cidr_blocks = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
@@ -23,5 +23,18 @@ resource "aws_security_group" "rules" {
 
   tags = {
     Name = format("%s_%s_%s_%s", var.project_tag, var.cluster_name, each.value.protocol, each.key)
+  }
+}
+
+# Default is removed from VPC when this resource is used
+# Manually add it back to allow instances to have outbound access
+# Should be moved to network tags so machines can specify if they need public access
+resource "aws_security_group" "OUTBOUND_ACCESS" {
+  vpc_id = var.vpc_id
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = -1
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/edbterraform/data/terraform/aws/modules/security/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/security/outputs.tf
@@ -1,6 +1,6 @@
 output "security_group_ids" {
-  value = flatten([
-    for key, values in merge(aws_security_group.rules):
+  value = flatten([aws_security_group.OUTBOUND_ACCESS.id ,[
+    for key, values in aws_security_group.rules:
       values.id
-  ])
+  ]])
 }


### PR DESCRIPTION
Fixes:
* AWS default egress for outbound access set in firewall rules
* AWS icmp fix
* `sensitive=true` was re-added if missing from `main.tf.j2`

PR: https://github.com/EnterpriseDB/edb-terraform/pull/34