### PR TITLE
Region zone mappings

### DIFF
--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -5,7 +5,7 @@ module "machine_{{ region_ }}" {
 
   operating_system         = each.value.spec.operating_system
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
-  cidr_block               = lookup(lookup(module.spec.region_zone_networks, "{{ region }}", null), each.value.spec.zone, null)
+  cidr_block               = each.value.spec.cidr
   az                       = each.value.spec.zone
   machine                  = each.value
   custom_security_group_ids = module.security_{{ region_ }}.security_group_ids

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -1,7 +1,7 @@
 module "vpc_{{ region_ }}" {
   source = "./modules/vpc"
 
-  vpc_cidr_block = lookup(lookup(module.spec.base.regions, "{{ region }}"), "cidr_block")
+  vpc_cidr_block = try(module.spec.base.regions["{{ region }}"].cidr_block, null)
   vpc_tag        = var.vpc_tag
   name_id        = module.spec.hex_id
 
@@ -19,8 +19,8 @@ module "network_{{ region_ }}" {
 
   vpc_id             = module.vpc_{{ region_ }}.vpc_id
   public_subnet_tag  = var.public_subnet_tag
-  cidr_block         = each.value
-  availability_zone  = each.key
+  cidr_block         = each.value.cidr
+  availability_zone  = each.value.zone
 
   depends_on = [module.vpc_{{ region_ }}]
 

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -7,7 +7,7 @@ module "machine_{{ region_ }}" {
     }
 
   resource_name                   = module.vpc_{{ region_ }}.resource_name
-  subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone].subnet_id
+  subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone_name].subnet_id
   operating_system                = each.value.spec.operating_system
   cluster_name                    = module.spec.base.tags.cluster_name
   name                            = each.value.name

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -20,8 +20,8 @@ module "network_{{ region_ }}" {
   resource_name   = module.vpc_{{ region_ }}.resource_name
   network_name    = module.vpc_{{ region_ }}.network_name
   region          = module.vpc_{{ region_ }}.region
-  zone            = tostring(each.key) == "0" ? null : each.key
-  ip_cidr_range   = [ each.value ]
+  zone            = each.value.zone
+  ip_cidr_range   = [ each.value.cidr ]
   name            = "{{region}}-${each.key}-${module.spec.hex_id}"
 
   depends_on = [module.vpc_{{ region_ }}]

--- a/edbterraform/data/templates/gcloud/kubernetes.tf.j2
+++ b/edbterraform/data/templates/gcloud/kubernetes.tf.j2
@@ -9,11 +9,11 @@ module "kubernetes_{{ region_ }}" {
   cluster_name                    = module.spec.base.tags.cluster_name
   region                          = each.value.spec.region
   machine                         = each.value
-  subnetwork                      = module.network_{{ region_ }}[each.value.spec.zone].name
+  subnetwork                      = module.network_{{ region_ }}[each.value.spec.zone_name].name
   network                         = module.vpc_{{ region_ }}.name
   name_id                         = module.spec.hex_id
   node_count                      = each.value.spec.node_count
-  tags = each.value.spec.tags
+  tags                            = each.value.spec.tags
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -13,7 +13,7 @@ module "machine_{{ region_ }}" {
   ssh_priv_key                    = module.spec.private_key
   ssh_pub_key                     = module.spec.public_key
   use_agent                       = module.spec.base.ssh_key.use_agent
-  subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone].name
+  subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone_name].name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
 

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -16,7 +16,7 @@ module "network_{{ region_ }}" {
   for_each = lookup(module.spec.region_zone_networks, "{{ region }}", null)
 
   network_name    = module.vpc_{{ region_ }}.vpc_id
-  ip_cidr_range   = each.value
+  ip_cidr_range   = each.value.cidr
   name            = "{{region}}-${each.key}-${module.spec.hex_id}"
 
   depends_on = [module.vpc_{{ region_ }}]

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -33,7 +33,10 @@ variable "spec" {
     })))
     regions = map(object({
       cidr_block = string
-      zones      = optional(map(string), {})
+      zones      = optional(map(object({
+        zone = optional(string)
+        cidr = optional(string)
+      })), {})
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
@@ -54,7 +57,7 @@ variable "spec" {
       image_name    = string
       count         = optional(number, 1)
       region        = string
-      zone          = string
+      zone_name     = string
       instance_type = string
       volume = object({
         type      = string

--- a/edbterraform/data/terraform/aws/modules/validation/main.tf
+++ b/edbterraform/data/terraform/aws/modules/validation/main.tf
@@ -18,17 +18,17 @@ data "aws_availability_zones" "zone_check" {
   lifecycle {
     postcondition {
       condition = alltrue([
-        for zone in keys(var.zones) :
-        contains(self.names, zone)
+        for name, values in var.zones :
+        contains(self.names, values.zone)
       ])
       error_message = (
         <<-EOT
 Region:
   ${var.region}
 Invalid Zones:
-%{for zone in keys(var.zones)~}
-%{if !contains(self.names, zone)~}
-  ${zone}
+%{for name, values in var.zones~}
+%{if !contains(self.names, values.zone)~}
+  ${values.zone}
 %{endif~}
 %{endfor~}
 Valid Zone options:

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_linux_virtual_machine" "main" {
   name                = format("%s-%s-%s", var.cluster_name, var.name, var.name_id)
   resource_group_name = var.resource_name
   location            = var.machine.region
-  zone                = local.zone
+  zone                = var.machine.zone
   size                = var.machine.instance_type
 
   admin_username = var.operating_system.ssh_user
@@ -77,7 +77,7 @@ resource "azurerm_managed_disk" "volume" {
   name                 = format("%s-%s-%s-%s", var.name, var.cluster_name, var.name_id, each.key)
   resource_group_name  = var.resource_name
   location             = var.machine.region
-  zone                 = local.zone
+  zone                 = var.machine.zone
   storage_account_type = each.value.type
   create_option        = "Empty"
   disk_size_gb         = each.value.size_gb

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -32,10 +32,8 @@ variable "tags" {
 }
 variable "cluster_name" {}
 locals {
-  # 0 is used to represent no zone but azure expects null
-  zone = tostring(var.machine.zone) == "0" ? null : var.machine.zone
-  zones         = local.zone == null ? null : [local.zone]
-  public_ip_sku = local.zone == null ? "Basic" : "Standard"
+  zones         = var.machine.zone == null ? null : [var.machine.zone]
+  public_ip_sku = var.machine.zone == null ? "Basic" : "Standard"
 }
 variable "resource_name" {
   type = string

--- a/edbterraform/data/terraform/azure/modules/network/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/network/variables.tf
@@ -40,7 +40,7 @@ variable "zone" {
       try(contains(["1", "2", "3", ], var.zone), false)
     )
     error_message = <<-EOT
-    Zone must be: 1 - 3
+    Zone must be: null, 1 - 3
     EOT
   }
 }

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -10,15 +10,6 @@ output "public_key" {
   value = var.spec.ssh_key.public_path != null ? file(var.spec.ssh_key.public_path) : tls_private_key.default[0].public_key_openssh
 }
 
-output "region_zone_networks" {
-  value = {
-    for region, region_spec in var.spec.regions : region => {
-      for zone, network in region_spec.zones :
-      zone => network
-    }
-  }
-}
-
 locals {
   # Extend machine's count as of list objects, with an index in the name only when count over 1
   machines_extended = flatten([
@@ -34,6 +25,9 @@ locals {
           })
           # assign operating system from mapped names
           operating_system = var.spec.images[machine_spec.image_name]
+          # assign zone from mapped names
+          # Handle 0 as null to represent a region with no zones available
+          zone = tostring(var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone) == "0" ? null : var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
         })
       }
     ]
@@ -71,13 +65,21 @@ output "pet_name" {
   value = random_pet.name.id
 }
 
+output "region_zone_networks" {
+  value = {
+    for region, region_spec in var.spec.regions : region => {
+      for name, values in region_spec.zones :
+        # Handle 0 as null to represent a region with no zones available
+        name => merge(values, {zone = tostring(values.zone) == "0" ? null : values.zone})
+    }
+  }
+}
+
 output "region_cidrblocks" {
   description = "list of all cidrs from each defined zone"
   value = flatten([
-    for region, values in var.spec.regions: [
-      for zone, cidr in values.zones:
-        cidr
-    ]
+    for region, values in var.spec.regions:
+      values.cidr_block
   ])
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -36,7 +36,10 @@ variable "spec" {
     })))
     regions = map(object({
       cidr_block = string
-      zones      = optional(map(string), {})
+      zones      = optional(map(object({
+        zone = optional(string)
+        cidr = optional(string)
+      })), {})
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
@@ -57,7 +60,7 @@ variable "spec" {
       image_name    = string
       count         = optional(number, 1)
       region        = string
-      zone          = number
+      zone_name     = string
       instance_type = string
       volume = object({
         type    = string

--- a/edbterraform/data/terraform/gcloud/modules/specification/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/main.tf
@@ -29,7 +29,7 @@ data "google_compute_regions" "unavailable" {
     postcondition {
       # Check if any region is an unavailable region
       condition = alltrue([
-        for region in keys(var.spec.regions) :
+        for region in keys(var.spec.regions):
         !contains(self.names, region)
       ])
       error_message = <<-EOT
@@ -55,16 +55,16 @@ data "google_compute_zones" "region" {
     postcondition {
       # Check for all zones in a region to be valid options
       condition = alltrue([
-        for zone in keys(each.value.zones) :
-        contains(self.names, zone)
+        for name, values in each.value.zones:
+        contains(self.names, values.zone)
       ])
       error_message = <<-EOT
 Region:
     ${each.key}
 Invalid Zones Set:
-%{for zone in keys(each.value.zones)~}
-%{if !contains(self.names, zone)~}
-    ${zone}
+%{for name, values in each.value.zones~}
+%{if !contains(self.names, values.zone)~}
+    ${name}: ${values.zone}
 %{endif~}
 %{endfor~}
 Valid Zone Options:
@@ -84,16 +84,16 @@ data "google_compute_zones" "unavailable" {
     postcondition {
       # Check if any zone is an unavailable zone
       condition = alltrue([
-        for zone in keys(each.value.zones) :
-        !contains(self.names, zone)
+        for name, values in each.value.zones:
+        !contains(self.names, values.zone)
       ])
       error_message = <<-EOT
 Region:
     ${each.key}
 Unavailable Zones Set:
-%{for zone in keys(each.value.zones)~}
-%{if contains(self.names, zone)~}
-    ${zone}
+%{for name, values in each.value.zones~}
+%{if contains(self.names, values.zone)~}
+    ${values.zone}
 %{endif~}
 %{endfor~}
 Available Zone Options:

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -10,15 +10,6 @@ output "public_key" {
   value = var.spec.ssh_key.public_path != null ? file(var.spec.ssh_key.public_path) : tls_private_key.default[0].public_key_openssh
 }
 
-output "region_zone_networks" {
-  value = {
-    for region, region_spec in var.spec.regions : region => {
-      for zone, network in region_spec.zones :
-      zone => network
-    }
-  }
-}
-
 locals {
   # Extend machine's count as of list objects, with an index in the name only when count over 1
   machines_extended = flatten([
@@ -34,6 +25,8 @@ locals {
           })
           # assign operating system from mapped names
           operating_system = var.spec.images[machine_spec.image_name]
+          # assign zone from mapped names
+          zone = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
         })
       }
     ]
@@ -103,13 +96,20 @@ output "pet_name" {
   value = random_pet.name.id
 }
 
+output "region_zone_networks" {
+  value = {
+    for region, region_spec in var.spec.regions : region => {
+      for name, values in region_spec.zones :
+        name => values
+    }
+  }
+}
+
 output "region_cidrblocks" {
   description = "list of all cidrs from each defined zone"
   value = flatten([
-    for region, values in var.spec.regions: [
-      for zone, cidr in values.zones:
-        cidr
-    ]
+    for region, values in var.spec.regions:
+      values.cidr_block
   ])
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -34,7 +34,10 @@ variable "spec" {
     })))
     regions = map(object({
       cidr_block = string
-      zones      = optional(map(string), {})
+      zones      = optional(map(object({
+        zone = optional(string)
+        cidr = optional(string)
+      })), {})
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
@@ -55,7 +58,7 @@ variable "spec" {
       image_name    = string
       count         = optional(number, 1)
       region        = string
-      zone          = string
+      zone_name     = string
       instance_type = string
       ip_forward    = optional(bool)
       volume = object({
@@ -107,7 +110,7 @@ variable "spec" {
     })), {})
     kubernetes = optional(map(object({
       region        = string
-      zone          = string
+      zone_name     = string
       node_count    = number
       instance_type = string
       tags          = optional(map(string), {})

--- a/infrastructure-examples/aws-ec2-v2.yml
+++ b/infrastructure-examples/aws-ec2-v2.yml
@@ -13,18 +13,26 @@ aws:
       ssh_user: admin
   regions:
     us-east-1:
-      cidr_block: 10.0.0.0/16
+      cidr_block: 10.2.0.0/16
       zones:
-        us-east-1b: 10.0.0.0/24
+        proxy:
+          zone: us-east-1b
+          cidr: 10.2.20.0/24
+        main:
+          zone: us-east-1b
+          cidr: 10.2.30.0/24
       service_ports:
         - port: 22
           protocol: tcp
           description: "SSH"
+      region_ports:
+        - protocol: icmp
+          description: "ping"
   machines:
     dbt2-driver:
       image_name: debian
       region: us-east-1
-      zone: us-east-1b
+      zone_name: proxy
       instance_type: c5.4xlarge
       volume:
         type: gp2
@@ -36,7 +44,7 @@ aws:
     pg1:
       image_name: rocky
       region: us-east-1
-      zone: us-east-1b
+      zone_name: main
       instance_type: c5.4xlarge
       volume:
         type: gp2

--- a/infrastructure-examples/azure-vms-v2.yml
+++ b/infrastructure-examples/azure-vms-v2.yml
@@ -18,19 +18,26 @@ azure:
       ssh_user: rocky
   regions:
     westus:
-      cidr_block: 10.1.0.0/16
+      cidr_block: 10.2.0.0/16
       zones:
-        0: 10.1.20.0/24
+        proxy:
+          zone: 0
+          cidr: 10.2.20.0/24
+        main:
+          zone: 0
+          cidr: 10.2.30.0/24
       service_ports:
-        - name: ssh_access
-          port: 22
+        - port: 22
           protocol: tcp
           description: "SSH"
+      region_ports:
+        - protocol: icmp
+          description: "ping"
   machines:
     dbt2-driver:
       image_name: rocky_8_7_0
       region: westus
-      zone: 0
+      zone_name: proxy
       instance_type: Standard_D2s_v3
       volume:
         type: StandardSSD_LRS
@@ -40,7 +47,7 @@ azure:
     pg1:
       image_name: rocky
       region: westus
-      zone: 0
+      zone_name: main
       instance_type: Standard_D2s_v3
       volume:
         type: StandardSSD_LRS

--- a/infrastructure-examples/compute-engine-v2.yml
+++ b/infrastructure-examples/compute-engine-v2.yml
@@ -13,16 +13,24 @@ gcloud:
     us-west4:
       cidr_block: 10.2.0.0/16
       zones:
-        us-west4-b: 10.2.20.0/24
+        proxy:
+          zone: us-west4-b
+          cidr: 10.2.20.0/24
+        main:
+          zone: us-west4-b
+          cidr: 10.2.30.0/24
       service_ports:
         - port: 22
           protocol: tcp
           description: "SSH"
+      region_ports:
+        - protocol: icmp
+          description: "ping"
   machines:
     dbt2-driver:
       image_name: debian
       region: us-west4
-      zone: us-west4-b
+      zone_name: proxy
       instance_type: e2-standard-4
       volume:
         type: pd-standard
@@ -32,7 +40,7 @@ gcloud:
     pg1:
       image_name: rocky
       region: us-west4
-      zone: us-west4-b
+      zone_name: main
       instance_type: e2-standard-4
       volume:
         type: pd-standard


### PR DESCRIPTION
* To support multiple defined zones of the same zone within a region, we move from a mapping of strings, `optional(map(string))`, to a mapping of objects, `optional(map(object({zone = string, cidr = string})))`.
* Machines and google kubernetes can reference their desired zone by using `zone_name` to reference one of the defined `zones`
* Backwards compatibility added