### PR TITLE
UUIDs available in machine outputs

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/get_uuid.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/get_uuid.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Grab stdin with 'jq', which is the form of type map(string)
+# decode values (needed to use anything besides strings) and 
+# insert into an associative array
+TERRAFORM_INPUT=$(jq '.')
+declare -A INPUT_MAPPING
+for key in $(echo "${TERRAFORM_INPUT}" | jq -r 'keys_unsorted|.[]'); do
+    INPUT_MAPPING["$key"]=$(echo "$TERRAFORM_INPUT" | jq -r .[\"$key\"] | base64 -d)
+done
+
+# Wait for SSH to become available
+MAX_TRYS=20
+SLEEP=30
+ATTEMPTS=0
+while ((ATTEMPTS<MAX_TRYS)); do
+    ssh-keyscan -p 22 "${INPUT_MAPPING["ip_address"]}" 2>/dev/null | grep ssh-rsa > /dev/null
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    ((ATTEMPTS++))
+    sleep $SLEEP
+done
+if ((ATTEMPTS >= MAX_TRYS)); then
+  echo "Error: SSH not available: ATTEMPTS $ATTEMPTS" >&2
+  exit 1
+fi
+
+
+# Grab UUIDs from remote machine
+cmds="blkid"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+UUIDS=$(echo "$ssh_out" | grep ' UUID')
+
+# Grab mountpoints from remote machine
+cmds="[[ -e /etc/mtab ]] && cat /etc/mtab || cat /proc/mounts"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+MOUNT_POINTS=$ssh_out
+
+# Create mapping of mount_point => uuid
+declare -A MOUNT_UUIDS
+while read -r uuid_line; do
+    uuid=$(echo "$uuid_line" | awk -F ' UUID=' '{print $2}' | awk -F '"' '{print $2}')
+    device_name=$(echo "$uuid_line" | awk -F ':' '{print $1}')
+    mount_point=$(awk -v device=$device_name '$1==device {print $2}' <<< $MOUNT_POINTS)
+    MOUNT_UUIDS["$mount_point"]="$uuid"
+done < <(echo "$UUIDS")
+
+# Create JSON object from MOUNT_UUIDS mapping
+# type of map(string) expected in stdout by external resource
+json='{}'
+for key in "${!MOUNT_UUIDS[@]}"; do
+    json=$( jq -n --arg json "$json" \
+                  --arg key "$key" \
+                  --arg value "${MOUNT_UUIDS["$key"]}" \
+                  '$json | fromjson + { ($key): ($value) }' )
+done
+echo "$json"

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -31,7 +31,10 @@ output "tags" {
 }
 
 output "additional_volumes" {
-  value = var.machine.spec.additional_volumes
+  value = {
+    for k,v in local.mapped_volumes:
+      k=>length(toolbox_external.get_uuid) > 0 ? merge(v,{"uuid":toolbox_external.get_uuid.0.result[k]}) : v
+  }
 }
 
 output "operating_system" {

--- a/edbterraform/data/terraform/aws/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/providers.tf
@@ -4,5 +4,8 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.7.0"
     }
+    toolbox = {
+      source  = "bryan-bar/toolbox"
+    }
   }
 }

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -16,6 +16,16 @@ variable "tags" {
 }
 
 locals {
+  additional_volumes = {
+    for key, value in lookup(var.machine.spec, "additional_volumes", []) :
+      key => value
+  }
+  mapped_volumes = {
+    for volume in lookup(var.machine.spec, "additional_volumes", []):
+      volume.mount_point => { for k,v in volume: k=>v }
+  }
+  volume_script_count = length(lookup(var.machine.spec, "additional_volumes", [])) > 0 ? 1 : 0
+
   # Create a list of possible device names
   prefix = "/dev/"
   base = ["sd", "xvd", "hd"]

--- a/edbterraform/data/terraform/aws/modules/specification/files.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/files.tf
@@ -7,6 +7,8 @@ locals {
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0
   )
+  private_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  public_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
 }
 
 resource "tls_private_key" "default" {
@@ -18,7 +20,7 @@ resource "tls_private_key" "default" {
 resource "local_sensitive_file" "default_private" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   content         = tls_private_key.default[0].private_key_openssh
 }
@@ -26,7 +28,7 @@ resource "local_sensitive_file" "default_private" {
 resource "local_file" "default_public" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   content         = tls_private_key.default[0].public_key_openssh
 }
@@ -34,7 +36,7 @@ resource "local_file" "default_public" {
 resource "local_sensitive_file" "private_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   source          = var.spec.ssh_key.private_path
 
@@ -59,7 +61,7 @@ resource "local_sensitive_file" "private_key" {
 resource "local_file" "public_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   source          = var.spec.ssh_key.public_path
 

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -28,6 +28,7 @@ locals {
           # assign zone from mapped names
           zone = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
           cidr = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].cidr
+          private_key_path = local.private_filename
         })
       }
     ]

--- a/edbterraform/data/terraform/azure/modules/machine/get_uuid.sh
+++ b/edbterraform/data/terraform/azure/modules/machine/get_uuid.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Grab stdin with 'jq', which is the form of type map(string)
+# decode values (needed to use anything besides strings) and 
+# insert into an associative array
+TERRAFORM_INPUT=$(jq '.')
+declare -A INPUT_MAPPING
+for key in $(echo "${TERRAFORM_INPUT}" | jq -r 'keys_unsorted|.[]'); do
+    INPUT_MAPPING["$key"]=$(echo "$TERRAFORM_INPUT" | jq -r .[\"$key\"] | base64 -d)
+done
+
+# Wait for SSH to become available
+MAX_TRYS=20
+SLEEP=30
+ATTEMPTS=0
+while ((ATTEMPTS<MAX_TRYS)); do
+    ssh-keyscan -p 22 "${INPUT_MAPPING["ip_address"]}" 2>/dev/null | grep ssh-rsa > /dev/null
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    ((ATTEMPTS++))
+    sleep $SLEEP
+done
+if ((ATTEMPTS >= MAX_TRYS)); then
+  echo "Error: SSH not available: ATTEMPTS $ATTEMPTS" >&2
+  exit 1
+fi
+
+
+# Grab UUIDs from remote machine
+cmds="blkid"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+UUIDS=$(echo "$ssh_out" | grep ' UUID')
+
+# Grab mountpoints from remote machine
+cmds="[[ -e /etc/mtab ]] && cat /etc/mtab || cat /proc/mounts"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+MOUNT_POINTS=$ssh_out
+
+# Create mapping of mount_point => uuid
+declare -A MOUNT_UUIDS
+while read -r uuid_line; do
+    uuid=$(echo "$uuid_line" | awk -F ' UUID=' '{print $2}' | awk -F '"' '{print $2}')
+    device_name=$(echo "$uuid_line" | awk -F ':' '{print $1}')
+    mount_point=$(awk -v device=$device_name '$1==device {print $2}' <<< $MOUNT_POINTS)
+    MOUNT_UUIDS["$mount_point"]="$uuid"
+done < <(echo "$UUIDS")
+
+# Create JSON object from MOUNT_UUIDS mapping
+# type of map(string) expected in stdout by external resource
+json='{}'
+for key in "${!MOUNT_UUIDS[@]}"; do
+    json=$( jq -n --arg json "$json" \
+                  --arg key "$key" \
+                  --arg value "${MOUNT_UUIDS["$key"]}" \
+                  '$json | fromjson + { ($key): ($value) }' )
+done
+echo "$json"

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -162,3 +162,19 @@ resource "null_resource" "setup_volume" {
     null_resource.copy_setup_volume_script
   ]
 }
+
+resource "toolbox_external" "get_uuid" {
+  count = local.volume_script_count
+  program = split(" ",
+  "bash ${path.module}/get_uuid.sh"
+  )
+
+  query = {
+    "mount_points" = base64encode(jsonencode(var.additional_volumes[*].mount_point))
+    "ssh_user"     = base64encode(var.operating_system.ssh_user)
+    "ip_address"   = base64encode(azurerm_linux_virtual_machine.main.public_ip_address)
+    "key_path"     = base64encode(var.machine.private_key_path)
+  }
+
+  depends_on = [ null_resource.setup_volume ]
+}

--- a/edbterraform/data/terraform/azure/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/outputs.tf
@@ -21,7 +21,10 @@ output "tags" {
 }
 
 output "additional_volumes" {
-  value = var.additional_volumes
+  value = {
+    for k,v in local.mapped_volumes:
+      k=>length(toolbox_external.get_uuid) > 0 ? merge(v,{"uuid":toolbox_external.get_uuid.0.result[k]}) : v
+  }
 }
 
 output "operating_system" {

--- a/edbterraform/data/terraform/azure/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/providers.tf
@@ -4,6 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.37.0"
     }
+    toolbox = {
+      source  = "bryan-bar/toolbox"
+    }
   }
   required_version = ">= 1.3.6"
 }

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -24,6 +24,7 @@ variable "machine" {
       size_gb = number
       type    = string
     })
+    private_key_path = string
   })
 }
 variable "tags" {
@@ -88,7 +89,10 @@ locals {
     for key, value in var.additional_volumes :
     key => value
   }
-
+  mapped_volumes = {
+    for volume in var.additional_volumes:
+      volume.mount_point => { for k,v in volume: k=>v }
+  }
   volume_script_count = length(var.additional_volumes) > 0 ? 1 : 0
 
   premium_ssd = {

--- a/edbterraform/data/terraform/azure/modules/specification/files.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/files.tf
@@ -7,6 +7,8 @@ locals {
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0
   )
+  private_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  public_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
 }
 
 resource "tls_private_key" "default" {
@@ -18,7 +20,7 @@ resource "tls_private_key" "default" {
 resource "local_sensitive_file" "default_private" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   content         = tls_private_key.default[0].private_key_openssh
 }
@@ -26,7 +28,7 @@ resource "local_sensitive_file" "default_private" {
 resource "local_file" "default_public" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   content         = tls_private_key.default[0].public_key_openssh
 }
@@ -34,7 +36,7 @@ resource "local_file" "default_public" {
 resource "local_sensitive_file" "private_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   source          = var.spec.ssh_key.private_path
 
@@ -59,7 +61,7 @@ resource "local_sensitive_file" "private_key" {
 resource "local_file" "public_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   source          = var.spec.ssh_key.public_path
 

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -28,6 +28,7 @@ locals {
           # assign zone from mapped names
           # Handle 0 as null to represent a region with no zones available
           zone = tostring(var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone) == "0" ? null : var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
+          private_key_path = local.private_filename
         })
       }
     ]

--- a/edbterraform/data/terraform/gcloud/modules/machine/get_uuid.sh
+++ b/edbterraform/data/terraform/gcloud/modules/machine/get_uuid.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Grab stdin with 'jq', which is the form of type map(string)
+# decode values (needed to use anything besides strings) and 
+# insert into an associative array
+TERRAFORM_INPUT=$(jq '.')
+declare -A INPUT_MAPPING
+for key in $(echo "${TERRAFORM_INPUT}" | jq -r 'keys_unsorted|.[]'); do
+    INPUT_MAPPING["$key"]=$(echo "$TERRAFORM_INPUT" | jq -r .[\"$key\"] | base64 -d)
+done
+
+# Wait for SSH to become available
+MAX_TRYS=20
+SLEEP=30
+ATTEMPTS=0
+while ((ATTEMPTS<MAX_TRYS)); do
+    ssh-keyscan -p 22 "${INPUT_MAPPING["ip_address"]}" 2>/dev/null | grep ssh-rsa > /dev/null
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    ((ATTEMPTS++))
+    sleep $SLEEP
+done
+if ((ATTEMPTS >= MAX_TRYS)); then
+  echo "Error: SSH not available: ATTEMPTS $ATTEMPTS" >&2
+  exit 1
+fi
+
+
+# Grab UUIDs from remote machine
+cmds="blkid"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+UUIDS=$(echo "$ssh_out" | grep ' UUID')
+
+# Grab mountpoints from remote machine
+cmds="[[ -e /etc/mtab ]] && cat /etc/mtab || cat /proc/mounts"
+ssh_out=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${INPUT_MAPPING["ssh_user"]}@${INPUT_MAPPING["ip_address"]} -i ${INPUT_MAPPING["key_path"]} "$cmds")
+MOUNT_POINTS=$ssh_out
+
+# Create mapping of mount_point => uuid
+declare -A MOUNT_UUIDS
+while read -r uuid_line; do
+    uuid=$(echo "$uuid_line" | awk -F ' UUID=' '{print $2}' | awk -F '"' '{print $2}')
+    device_name=$(echo "$uuid_line" | awk -F ':' '{print $1}')
+    mount_point=$(awk -v device=$device_name '$1==device {print $2}' <<< $MOUNT_POINTS)
+    MOUNT_UUIDS["$mount_point"]="$uuid"
+done < <(echo "$UUIDS")
+
+# Create JSON object from MOUNT_UUIDS mapping
+# type of map(string) expected in stdout by external resource
+json='{}'
+for key in "${!MOUNT_UUIDS[@]}"; do
+    json=$( jq -n --arg json "$json" \
+                  --arg key "$key" \
+                  --arg value "${MOUNT_UUIDS["$key"]}" \
+                  '$json | fromjson + { ($key): ($value) }' )
+done
+echo "$json"

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -20,7 +20,10 @@ output "tags" {
   value = google_compute_instance.machine.labels
 }
 output "additional_volumes" {
-  value = var.machine.spec.additional_volumes
+  value = {
+    for k,v in local.mapped_volumes:
+      k=>length(toolbox_external.get_uuid) > 0 ? merge(v,{"uuid":toolbox_external.get_uuid.0.result[k]}) : v
+  }
 }
 output "operating_system" {
   value = var.operating_system

--- a/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
@@ -3,6 +3,9 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
+    toolbox = {
+      source  = "bryan-bar/toolbox"
+    }
   }
   required_version = ">= 1.3.6"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -51,6 +51,16 @@ Fix the following tags:
 }
 
 locals {
+  additional_volumes = {
+    for key, value in lookup(var.machine.spec, "additional_volumes", []):
+      key => value
+  }
+  mapped_volumes = {
+    for volume in lookup(var.machine.spec, "additional_volumes", []):
+      volume.mount_point => { for k,v in volume: k=>v }
+  }
+  volume_script_count = length(lookup(var.machine.spec, "additional_volumes", [])) > 0 ? 1 : 0
+
   prefix = "/dev/disk/by-id/google-"
   base = ["sd"]
   letters = [

--- a/edbterraform/data/terraform/gcloud/modules/specification/files.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/files.tf
@@ -7,6 +7,8 @@ locals {
     var.spec.ssh_key.public_path != null ||
     var.spec.ssh_key.private_path != null ? 1 : 0
   )
+  private_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  public_filename = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
 }
 
 resource "tls_private_key" "default" {
@@ -18,7 +20,7 @@ resource "tls_private_key" "default" {
 resource "local_sensitive_file" "default_private" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   content         = tls_private_key.default[0].private_key_openssh
 }
@@ -26,7 +28,7 @@ resource "local_sensitive_file" "default_private" {
 resource "local_file" "default_public" {
   count = local.ssh_user_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   content         = tls_private_key.default[0].public_key_openssh
 }
@@ -34,7 +36,7 @@ resource "local_file" "default_public" {
 resource "local_sensitive_file" "private_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}"
+  filename        = local.private_filename
   file_permission = "0600"
   source          = var.spec.ssh_key.private_path
 
@@ -59,7 +61,7 @@ resource "local_sensitive_file" "private_key" {
 resource "local_file" "public_key" {
   count = local.ssh_keys_count
 
-  filename        = "${abspath(path.root)}/${var.spec.ssh_key.output_name}.pub"
+  filename        = local.public_filename
   file_permission = "0644"
   source          = var.spec.ssh_key.public_path
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -27,6 +27,7 @@ locals {
           operating_system = var.spec.images[machine_spec.image_name]
           # assign zone from mapped names
           zone = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
+          private_key_path = local.private_filename
         })
       }
     ]


### PR DESCRIPTION
We currently use UUIDs with a mount point in the fstab file in-case of a re-mount by the system/provider.
With these changes, we can see the systems uuids in the `additional_volumes` output from each machine. It currently only runs when a volume is added or changed due to how the `toolbox_external` resource is implemented.

This is also the introduction of the `toolbox` provider (possible renaming) in order to allow us to have custom entry points which do not run after every `terraform apply`. This also allows for other possible use cases such as cli entry points to mimic a native terraform plugin as we can use the results from the computed outputs. This is last resort for situations where needed functionality is not yet implemented by a maintained provider.

[toolbox provider with external resource](https://registry.terraform.io/providers/bryan-bar/toolbox/latest) which will be moved over to an EnterpriseDB repo/terraform registry soon.

Below is a snippet of a servers.yml and a machines additional volumes:
```yaml
pg1:
    additional_volumes: {"/opt/pg_data":{"encrypted":"false","iops":"5000","mount_point":"/opt/pg_data","size_gb":"20","type":"io2","uuid":"d2d42cf2-efe4-40e4-bfb5-49403145a070"},"/opt/pg_wal":{"encrypted":"false","iops":"5000","mount_point":"/opt/pg_wal","size_gb":"20","type":"io2","uuid":"f92cf637-a8a6-4255-aa08-5563013a610d"}}
```

Reference PR: https://github.com/EnterpriseDB/edb-terraform/issues/30