### PR TITLE
Fix: use of PyYAML 'safe_load' instead of 'CLoader'

### DIFF
--- a/edbterraform/data/terraform/aws/variables.tf
+++ b/edbterraform/data/terraform/aws/variables.tf
@@ -43,9 +43,3 @@ variable "vpc_id" {
   description = "VPC ID"
   default     = ""
 }
-
-variable "custom_security_group_ids" {
-  description = "Security Group assign to the instances. Example: 'sg-12345'."
-  type        = string
-  default     = ""
-}

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.backends import default_backend
 try:
     from edbterraform.utils.dict import change_keys
     from edbterraform.utils.files import load_yaml_file
-except:
+except ImportError:
     from utils.dict import change_keys
     from utils.files import load_yaml_file
 

--- a/edbterraform/utils/files.py
+++ b/edbterraform/utils/files.py
@@ -9,7 +9,7 @@ def load_yaml_file(file_path):
 
     try:
         with open(file_path) as f:
-            vars = yaml.load(f.read(), Loader=yaml.CLoader)
+            vars = yaml.safe_load(f.read())
             return vars
 
     except Exception as e:


### PR DESCRIPTION
Use `safe_load` instead of using `CLoader`, which depends on `libyaml` and might require a manual install with the use of `python setup.py --with-libyaml install` when using python virtual environments.

When manual install is skipped, the virtual environment might fail to detect `libyaml`, `CLoader` is then not available within `PyYAML` and fails with an `ImportError` if `CLoader` is imported.

Error message - `ERROR: could not read file /home/user/Projects/edb-terraform/infrastructure-examples/aws-all.yml (module 'yaml' has no attribute 'CLoader')`
Ref: https://github.com/yaml/pyyaml/issues/108

Other Changes:
* Removed unused `security_group_ids` variable from AWS modules root variable file
* added `ImportError` to `try/except` import