### PR TITLE
Fix: AWS security group limits

### DIFF
--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -5,6 +5,7 @@ module "machine_{{ region_ }}" {
 
   operating_system         = each.value.spec.operating_system
   vpc_id                   = module.vpc_{{ region_ }}.vpc_id
+  subnet_id                = module.network_{{ region_ }}[each.value.spec.zone_name].subnet_id
   cidr_block               = each.value.spec.cidr
   az                       = each.value.spec.zone
   machine                  = each.value

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -14,18 +14,11 @@ data "aws_ami" "default" {
   owners = ["${var.operating_system.owner}"]
 }
 
-
-data "aws_subnet" "selected" {
-  vpc_id            = var.vpc_id
-  availability_zone = var.az
-  cidr_block        = var.cidr_block
-}
-
 resource "aws_instance" "machine" {
   ami                    = data.aws_ami.default.id
   instance_type          = var.machine.spec.instance_type
   key_name               = var.key_name
-  subnet_id              = data.aws_subnet.selected.id
+  subnet_id              = var.subnet_id
   vpc_security_group_ids = var.custom_security_group_ids
 
   root_block_device {
@@ -36,6 +29,12 @@ resource "aws_instance" "machine" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    # AMI is ignored because the data source
+    # forces the resource to be re-created when apply is used again
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_ebs_volume" "ebs_volume" {

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -1,5 +1,6 @@
 variable "machine" {}
 variable "vpc_id" {}
+variable "subnet_id" {}
 variable "cidr_block" {}
 variable "az" {}
 variable "ssh_pub_key" {}

--- a/edbterraform/data/terraform/aws/modules/network/main.tf
+++ b/edbterraform/data/terraform/aws/modules/network/main.tf
@@ -22,3 +22,7 @@ resource "aws_subnet" "public_subnets" {
     Name = format("%s_%s_%s", var.public_subnet_tag, var.availability_zone, var.cidr_block)
   }
 }
+
+output "subnet_id" {
+  value = aws_subnet.public_subnets.id
+}

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -1,40 +1,37 @@
 resource "aws_security_group" "rules" {
+  name = format("%s_%s", var.project_tag, var.cluster_name)
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name = format("%s_%s", var.project_tag, var.cluster_name)
+  }
+}
+
+resource "aws_security_group_rule" "ingress" {
   for_each = {
     # preserve ordering
     for index, values in var.ports:
       format("0%.3d",index) => values
   }
-  name = format("%s_%s_%s_%s", var.project_tag, var.cluster_name, each.value.protocol, each.key)
+  security_group_id = aws_security_group.rules.id
   description = each.value.description
-  vpc_id = var.vpc_id
-  ingress {
-      from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
-      to_port     = each.value.port != null && each.value.protocol != "icmp"  ? each.value.port : -1
-      protocol    = each.value.protocol
-      cidr_blocks = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
-  }
+  type = "ingress"
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    cidr_blocks = each.value.egress_cidrs != null ? each.value.egress_cidrs : var.egress_cidrs
-  }
-
-  tags = {
-    Name = format("%s_%s_%s_%s", var.project_tag, var.cluster_name, each.value.protocol, each.key)
-  }
+  from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
+  to_port     = each.value.port != null && each.value.protocol != "icmp"  ? each.value.port : -1
+  protocol    = each.value.protocol
+  cidr_blocks = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
 }
 
 # Default is removed from VPC when this resource is used
 # Manually add it back to allow instances to have outbound access
 # Should be moved to network tags so machines can specify if they need public access
-resource "aws_security_group" "OUTBOUND_ACCESS" {
-  vpc_id = var.vpc_id
-  egress {
-    from_port = 0
-    to_port = 0
-    protocol = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "OUTBOUND_ACCESS" {
+  security_group_id = aws_security_group.rules.id
+  description = "OUTBOUND access"
+  type = "egress"
+  from_port = 0
+  to_port = 0
+  protocol = -1
+  cidr_blocks = ["0.0.0.0/0"]
 }

--- a/edbterraform/data/terraform/aws/modules/security/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/security/outputs.tf
@@ -1,6 +1,3 @@
 output "security_group_ids" {
-  value = flatten([aws_security_group.OUTBOUND_ACCESS.id ,[
-    for key, values in aws_security_group.rules:
-      values.id
-  ]])
+  value = [aws_security_group.rules.id]
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -53,6 +53,7 @@ variable "spec" {
       })), [])
     }))
     machines = optional(map(object({
+      skip_ssh_check = optional(bool, false)
       type          = optional(string)
       image_name    = string
       count         = optional(number, 1)
@@ -124,6 +125,7 @@ variable "spec" {
     condition = (
       alltrue([
         for machine in var.spec.machines :
+        machine.skip_ssh_check ||
         length(machine.additional_volumes) == 0 ||
         anytrue([for service_port in var.spec.regions[machine.region].service_ports :
           service_port.port == 22
@@ -134,9 +136,11 @@ variable "spec" {
       <<-EOT
 When using machines with additional volumes, SSH must be open.
 Ensure each region listed below has port 22 open under service_ports.
+This check can be skipped by setting 'skip_ssh_check' to true under each machine with additional volumes.
 Region - Machine:
 %{for name, spec in var.spec.machines~}
 %{if length(spec.additional_volumes) != 0~}
+skip_ssh_check: ${spec.skip_ssh_check}
   ${spec.region} - ${name}
 %{endif~}
 %{endfor~}


### PR DESCRIPTION
Issue:
AWS quota limit hit when using too many security groups
PR: https://github.com/EnterpriseDB/edb-terraform/pull/34

Causes:
VPC Security Group limit per instance
VPC security Groups limit per elastic network interface
Ref: https://repost.aws/questions/QUragGhbTXSqSKO4B1zIJUGw/quot-exceeded-quot-vpc-security-groups-limit-when-launching-instances-with-one-sg

Fix:
Use `aws_security_group_rules` with pre-set `aws_security_group`'s.
This is also a workaround for the issue where an `aws_instance` is force recreated when a security group is added or removed.

Other Fixes:
* `subnet_id` grabbed from the network module since the data source output forces `aws_resource` to be re-created
* ignore `ami` output changes as it forces `aws_instance` to be recreated
* `cluster_identifier_prefix`, `identifier_prefix`, `availability_zones` changes ignored as it forces `aws_rds_cluster` and `aws_rds_cluster_instance` to be re-created
* allow skipping of ssh validation with 'skip_ssh_check' under each machine