### PR TITLE
Allow AWS ports to be defined by machine

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -17,6 +17,9 @@ variable "tags" {
 }
 
 locals {
+  additional_volumes_length = length(lookup(var.machine.spec, "additional_volumes", []))
+  additional_volumes_count = local.additional_volumes_length > 0 ? 1 : 0
+  additional_volumes_map = { for i, v in lookup(var.machine.spec, "additional_volumes", []) : i => v }
   # Create a list of possible device names
   prefix = "/dev/"
   base = ["sd", "xvd", "hd"]

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -8,11 +8,7 @@ resource "aws_security_group" "rules" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  for_each = {
-    # preserve ordering
-    for index, values in var.ports:
-      format("0%.3d",index) => values
-  }
+  for_each = local.merged_rules
   security_group_id = aws_security_group.rules.id
   description = each.value.description
   type = "ingress"

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -10,3 +10,34 @@ variable "egress_cidrs" {
   type = list(string)
   default = [ "0.0.0.0/0" ]
 }
+
+locals {
+  # AWS will fail if there are duplicate ingress/egress defined for any protocol-port combination.
+  # Collapse duplicate rules so only one rule will be created
+  # Use protocol and port to create a key
+  # Use group_by to gather ingress_cidrs and description as a list
+  # Create mapping with new key and collapse protocol, port, description and ingress_cidrs
+  port_rules_cidr_blocks = {
+    for port in var.ports:
+      join("_", formatlist("%#v", [port.protocol, port.port])) 
+      => coalesce(port.ingress_cidrs, var.ingress_cidrs)...
+    }
+
+  port_rules_descriptions = {
+    for port in var.ports:
+      join("_", formatlist("%#v", [port.protocol, port.port])) 
+      => coalesce(port.description, "")...
+    }
+  port_rules_mapping = {
+    for port in var.ports:
+      join("_", formatlist("%#v", [port.protocol, port.port])) 
+       => port...
+  }
+  merged_rules = {
+    for name, ports in local.port_rules_mapping:
+      replace(name, "\"", "") => merge(ports[0], {
+        "ingress_cidrs": distinct(flatten(local.port_rules_cidr_blocks[name])),
+        "description": join(" _ ", distinct(local.port_rules_descriptions[name]))
+      })
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -28,20 +28,6 @@ locals {
           # assign zone from mapped names
           zone = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
           cidr = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].cidr
-          
-          # SSH will be set based on first valid port seen with the use of coalesce, which finds the first non-null value.
-          ssh_port = coalesce(
-            # Priority:
-            # 1. Grab machines set ssh_port
-            # 2. Grab first port with for_ssh=true from machine ports
-            # 3. Grab first port with for_ssh=true from service ports
-            # 4. Default to 22
-            machine_spec.ssh_port,
-            try([for port in machine_spec.ports: port.port if port.for_ssh][0], null),
-            try([for port in var.spec.regions[machine_spec.region].service_ports: port.port if port.for_ssh][0], null),
-            try([for port in var.spec.regions[machine_spec.region].region_ports: port.port if port.for_ssh][0], null),
-            22,
-          )
         })
       }
     ]

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -28,6 +28,20 @@ locals {
           # assign zone from mapped names
           zone = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].zone
           cidr = var.spec.regions[machine_spec.region].zones[machine_spec.zone_name].cidr
+          
+          # SSH will be set based on first valid port seen with the use of coalesce, which finds the first non-null value.
+          ssh_port = coalesce(
+            # Priority:
+            # 1. Grab machines set ssh_port
+            # 2. Grab first port with for_ssh=true from machine ports
+            # 3. Grab first port with for_ssh=true from service ports
+            # 4. Default to 22
+            machine_spec.ssh_port,
+            try([for port in machine_spec.ports: port.port if port.for_ssh][0], null),
+            try([for port in var.spec.regions[machine_spec.region].service_ports: port.port if port.for_ssh][0], null),
+            try([for port in var.spec.regions[machine_spec.region].region_ports: port.port if port.for_ssh][0], null),
+            22,
+          )
         })
       }
     ]

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -38,26 +38,36 @@ variable "spec" {
         cidr = optional(string)
       })), {})
       service_ports = optional(list(object({
+        for_ssh     = optional(bool, false)
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string)
         ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
         egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
+        for_ssh     = optional(bool, false)
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string)
         ingress_cidrs = optional(list(string))
         egress_cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({
-      skip_ssh_check = optional(bool, false)
       type          = optional(string)
       image_name    = string
       count         = optional(number, 1)
       region        = string
+      ssh_port      = optional(number)
+      ports         = optional(list(object({
+        for_ssh     = optional(bool, false)
+        port        = optional(number)
+        protocol    = string
+        description = optional(string)
+        ingress_cidrs = optional(list(string))
+        egress_cidrs = optional(list(string))
+      })), [])
       zone_name     = string
       instance_type = string
       volume = object({
@@ -120,31 +130,4 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
-
-  validation {
-    condition = (
-      alltrue([
-        for machine in var.spec.machines :
-        machine.skip_ssh_check ||
-        length(machine.additional_volumes) == 0 ||
-        anytrue([for service_port in var.spec.regions[machine.region].service_ports :
-          service_port.port == 22
-        ])
-      ])
-    )
-    error_message = (
-      <<-EOT
-When using machines with additional volumes, SSH must be open.
-Ensure each region listed below has port 22 open under service_ports.
-This check can be skipped by setting 'skip_ssh_check' to true under each machine with additional volumes.
-Region - Machine:
-%{for name, spec in var.spec.machines~}
-%{if length(spec.additional_volumes) != 0~}
-skip_ssh_check: ${spec.skip_ssh_check}
-  ${spec.region} - ${name}
-%{endif~}
-%{endfor~}
-EOT
-    )
-  }
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -38,7 +38,6 @@ variable "spec" {
         cidr = optional(string)
       })), {})
       service_ports = optional(list(object({
-        for_ssh     = optional(bool, false)
         port        = optional(number)
         protocol    = string
         description = optional(string)
@@ -46,7 +45,6 @@ variable "spec" {
         egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
-        for_ssh     = optional(bool, false)
         port        = optional(number)
         protocol    = string
         description = optional(string)
@@ -59,9 +57,8 @@ variable "spec" {
       image_name    = string
       count         = optional(number, 1)
       region        = string
-      ssh_port      = optional(number)
+      ssh_port      = optional(number, 22)
       ports         = optional(list(object({
-        for_ssh     = optional(bool, false)
         port        = optional(number)
         protocol    = string
         description = optional(string)


### PR DESCRIPTION
AWS Changes:
* machines can now define `ports` to define custom security groups
  * `skip_ssh_check` removed and associated validation check. It will now fail after creating the machine but before creating additional volumes so that volumes are not left in an unformatted state. If ssh is needed after a failed run, such as for machines with additional volumes, machines can add needed port rules and `terraform apply` can be re-run to continue provisioning resources.
* machines can now define `ssh_port` to define the default ssh port otherwise `22` is used.


AWS Fixes:
* machines create implicit dependencies instead of using `depends_on` as it can run out of order after initial runs. This is done with the use of variables and lifecycles.
* Handle duplicate security rules when using `cidr_blocks` as a single rule, otherwise security rule creation will fail.