### PR TITLE
Update AWS security rules

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -20,7 +20,7 @@ module "machine_ports" {
   vpc_id           = var.vpc_id
   project_tag      = "machine_rules"
   cluster_name     = var.machine.name
-  ports            = var.machine.spec.ports
+  ports            = local.machine_ports
 }
 
 resource "aws_instance" "machine" {

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -1,4 +1,12 @@
 variable "machine" {}
+locals {
+  # Allow machine default outbound access if no egress is defined
+  egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])
+  machine_ports = concat(var.machine.spec.ports, 
+      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "description": "Default Egress if not defined"}])
+    )
+}
+
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "cidr_block" {}

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -21,7 +21,7 @@ resource "aws_security_group_rule" "rule" {
   lifecycle {
     precondition {
       condition     = each.value.type == "ingress" || each.value.type == "egress"
-      error_message = "${each.key} has type ${each.type}. Must be ingress or egress."
+      error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
     }
   }
 }

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -7,27 +7,21 @@ resource "aws_security_group" "rules" {
   }
 }
 
-resource "aws_security_group_rule" "ingress" {
+resource "aws_security_group_rule" "rule" {
   for_each = local.merged_rules
   security_group_id = aws_security_group.rules.id
   description = each.value.description
-  type = "ingress"
+  type = each.value.type
 
   from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
   to_port     = each.value.port != null && each.value.protocol != "icmp"  ? each.value.port : -1
   protocol    = each.value.protocol
-  cidr_blocks = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
-}
+  cidr_blocks = each.value.cidrs
 
-# Default is removed from VPC when this resource is used
-# Manually add it back to allow instances to have outbound access
-# Should be moved to network tags so machines can specify if they need public access
-resource "aws_security_group_rule" "OUTBOUND_ACCESS" {
-  security_group_id = aws_security_group.rules.id
-  description = "OUTBOUND access"
-  type = "egress"
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  cidr_blocks = ["0.0.0.0/0"]
+  lifecycle {
+    precondition {
+      condition     = each.value.type == "ingress" || each.value.type == "egress"
+      error_message = "${each.key} has type ${each.type}. Must be ingress or egress."
+    }
+  }
 }

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -14,29 +14,29 @@ variable "egress_cidrs" {
 locals {
   # AWS will fail if there are duplicate ingress/egress defined for any protocol-port combination.
   # Collapse duplicate rules so only one rule will be created
-  # Use protocol and port to create a key
-  # Use group_by to gather ingress_cidrs and description as a list
+  # Use protocol, port and type to create a key
+  # Use group_by to gather cidrs and description as a list
   # Create mapping with new key and collapse protocol, port, description and ingress_cidrs
   port_rules_cidr_blocks = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port])) 
-      => coalesce(port.ingress_cidrs, var.ingress_cidrs)...
+      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
+      => coalesce(port.cidrs, var.ingress_cidrs)...
     }
 
   port_rules_descriptions = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port])) 
+      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
       => coalesce(port.description, "")...
     }
   port_rules_mapping = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port])) 
+      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
        => port...
   }
   merged_rules = {
     for name, ports in local.port_rules_mapping:
       replace(name, "\"", "") => merge(ports[0], {
-        "ingress_cidrs": distinct(flatten(local.port_rules_cidr_blocks[name])),
+        "cidrs": distinct(flatten(local.port_rules_cidr_blocks[name])),
         "description": join(" _ ", distinct(local.port_rules_descriptions[name]))
       })
   }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -64,12 +64,7 @@ variable "spec" {
         description = optional(string)
         type = optional(string, "ingress")
         cidrs = optional(list(string))
-        })), [{
-        protocol = "-1",
-        description="OUTBOUND_ACCESS_DEFAULT",
-        type="egress",
-        cidrs=["0.0.0.0/0"]
-        }]
+        })), []
       )
       zone_name     = string
       instance_type = string

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -41,15 +41,15 @@ variable "spec" {
         port        = optional(number)
         protocol    = string
         description = optional(string)
-        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
         description = optional(string)
-        ingress_cidrs = optional(list(string))
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({
@@ -62,9 +62,15 @@ variable "spec" {
         port        = optional(number)
         protocol    = string
         description = optional(string)
-        ingress_cidrs = optional(list(string))
-        egress_cidrs = optional(list(string))
-      })), [])
+        type = optional(string, "ingress")
+        cidrs = optional(list(string))
+        })), [{
+        protocol = "-1",
+        description="OUTBOUND_ACCESS_DEFAULT",
+        type="egress",
+        cidrs=["0.0.0.0/0"]
+        }]
+      )
       zone_name     = string
       instance_type = string
       volume = object({

--- a/infrastructure-examples/aws-all.yml
+++ b/infrastructure-examples/aws-all.yml
@@ -33,7 +33,7 @@ aws:
       type: dbt2-client
       region: us-east-1
       zone: us-east-1b
-      instance_type: c5.18xlarge
+      instance_type: c5.4xlarge
       volume:
         type: gp2
         size_gb: 50
@@ -44,8 +44,8 @@ aws:
     dbt2-driver:
       type: dbt2-driver
       region: us-east-1
-      zone: us-east-1b
-      instance_type: c5.18xlarge
+      zone: us-east-1c
+      instance_type: c5.4xlarge
       volume:
         type: gp2
         size_gb: 50
@@ -54,7 +54,7 @@ aws:
     pg1:
       type: postgres
       region: us-east-1
-      zone: us-east-1b
+      zone: us-east-1c
       instance_type: c5.4xlarge
       volume:
         type: gp2

--- a/infrastructure-examples/aws-ec2-v2.yml
+++ b/infrastructure-examples/aws-ec2-v2.yml
@@ -21,10 +21,7 @@ aws:
         main:
           zone: us-east-1b
           cidr: 10.2.30.0/24
-      service_ports:
-        - port: 22
-          protocol: tcp
-          description: "SSH"
+      service_ports: []
       region_ports:
         - protocol: icmp
           description: "ping"
@@ -45,6 +42,10 @@ aws:
       image_name: rocky
       region: us-east-1
       zone_name: main
+      ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
       instance_type: c5.4xlarge
       volume:
         type: gp2


### PR DESCRIPTION
AWS security rules should be defined with `type` to allow control of ingress and egress since we no longer define security rules as groups but a set of rules within a security group.

Changes:
* AWS: each port rule can use `type` to define connection direction, defaults to `ingress`.
* AWS: `ingress_cidrs`/`egress_cidrs` replaced with `cidrs`.
* AWS: machines create an egress port rule for outbound access if no egress port is defined.
* AWS: infrastructure examples updated