### PR TITLE
Fix: AWS image owners type

### DIFF
--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -28,7 +28,7 @@ variable "spec" {
     }), {})
     images = optional(map(object({
       name = optional(string)
-      owner = optional(number)
+      owner = optional(string)
       ssh_user = optional(string)
     })))
     regions = map(object({


### PR DESCRIPTION
Issue:
Image owner is defined as `owner: 099720109477` but `0` is dropped as shown in the following error message.
`Error: reading EC2 AMIs: InvalidUserID.Malformed: Invalid user id: "99720109477"`

Cause:
owner is of type `number`

Fix:
`owner` in specification changed to type `string`

Ref: https://github.com/EnterpriseDB/edb-terraform/pull/22