### PR TITLE
Fix: allow public access of gcloud-sql

### DIFF
--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -97,6 +97,7 @@ variable "spec" {
         value = number
       })), [])
       tags = optional(map(string), {})
+      public_access = optional(bool, false)
     })), {})
     alloy = optional(map(object({
       region    = string


### PR DESCRIPTION
Messed up the branches:
https://github.com/EnterpriseDB/edb-terraform/pull/51
https://github.com/EnterpriseDB/edb-terraform/pull/52