### PR TITLE
Azure postgres database on flexible server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ describing the target cloud infrastructure.
 | GCloud   | AlloyDB                  |:white_check_mark:|
 | GCloud   | Google Kubernetes Engine |:white_check_mark:|
 | Azure    | VM                       |:white_check_mark:|
-| Azure    | Database - Flexible      |       :x:        |
-| Azure    | CosmoDB                 |       :x:        |
+| Azure    | Database - Flexible      |:white_check_mark:|
+| Azure    | CosmoDB                  |       :x:        |
 | Azure    | Azure Kubernetes Service |:white_check_mark:|
 
 ## Prerequisites and installation

--- a/edbterraform/data/templates/azure/database.tf.j2
+++ b/edbterraform/data/templates/azure/database.tf.j2
@@ -1,0 +1,35 @@
+module "database_{{ region_ }}" {
+  source = "./modules/database"
+
+  for_each = {
+    for rm in lookup(module.spec.region_databases, "{{ region }}", []) : 
+      rm.name => rm 
+    }
+
+  resource_name                   = module.vpc_{{ region_ }}.resource_name
+  region                          = each.value.spec.region
+  zone                            = each.value.spec.zone
+  engine                          = each.value.spec.engine
+  engine_version                  = each.value.spec.engine_version
+  instance_type                   = each.value.spec.instance_type
+  dbname                          = each.value.spec.dbname
+  settings                        = each.value.spec.settings
+  size_gb                         = each.value.spec.volume.size_gb
+  username                        = each.value.spec.username
+  password                        = each.value.spec.password
+  cluster_name                    = module.spec.base.tags.cluster_name
+  name                            = each.value.name
+  name_id                         = module.spec.hex_id
+  tags                            = each.value.spec.tags
+  public_access                   = each.value.spec.public_access
+
+  depends_on = [
+    module.security_{{ region_ }},
+    null_resource.validation,
+  ]
+
+  providers = {
+    azurerm = azurerm.{{ region_ }}
+  }
+
+}

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -14,8 +14,8 @@ module "machine_{{ region_ }}" {
   machine                         = each.value.spec
   additional_volumes              = each.value.spec.additional_volumes
   private_key                     = module.spec.private_key
+  public_key                      = module.spec.public_key
   use_agent                       = module.spec.base.ssh_key.use_agent
-  public_key_name                 = module.key_pair_{{ region_ }}.name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
 

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -19,6 +19,10 @@
 {%     include "machine.tf.j2" %}
 {%   endif %}
 
+{%   if has_databases %}
+{%     include "database.tf.j2" %}
+{%   endif %}
+
 {%   if has_kubernetes %}
 {%     include "kubernetes.tf.j2" %}
 {%   endif %}
@@ -40,6 +44,11 @@ servers:
     'active': has_machines,
     'regions': machine_regions,
     'module_base': 'module.machine_',
+  },
+  'databases': {
+    'active': has_databases,
+    'regions': database_regions,
+    'module_base': "module.database_",
   },
   'kubernetes': {
     'active': has_kubernetes,

--- a/edbterraform/data/terraform/azure/modules/database/main.tf
+++ b/edbterraform/data/terraform/azure/modules/database/main.tf
@@ -1,0 +1,64 @@
+resource "azurerm_postgresql_flexible_server" "instance" {
+  count = startswith(var.engine,"postgres") ? 1 : 0
+
+  name                   = format("%s-%s",
+    var.name,
+    var.name_id
+  )
+  resource_group_name    = var.resource_name
+  location               = var.region
+  zone                   = var.zone
+  version                = var.engine_version
+  administrator_login    = var.username
+  administrator_password = var.password
+  storage_mb             = local.size_mb
+  sku_name               = var.instance_type
+  tags                   = var.tags
+
+  create_mode = "Default"
+  geo_redundant_backup_enabled = false
+  authentication {
+    password_auth_enabled = true
+  }
+
+}
+
+/*
+https://learn.microsoft.com/en-us/rest/api/sql/2021-02-01-preview/firewall-rules/create-or-update?tabs=HTTP#firewallrule
+all Azure-internal IP addresses only, including client-made services
+*/
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure-services" {
+  name                   = format("%s-%s-azure-ips",
+    var.name,
+    var.name_id
+  )
+  server_id        = azurerm_postgresql_flexible_server.instance[0].id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "instance" {
+  count = var.public_access ? 1 : 0
+  name                   = format("%s-%s-public-access",
+    var.name,
+    var.name_id
+  )
+  server_id        = azurerm_postgresql_flexible_server.instance[0].id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "255.255.255.255"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "instance" {
+  count     = length(var.settings)
+  server_id = azurerm_postgresql_flexible_server.instance[0].id
+  name      = var.settings[count.index].name
+  value     = var.settings[count.index].value
+}
+
+resource "azurerm_postgresql_flexible_server_database" "instance" {
+  count     = length(var.dbname) > 0 ? 1 : 0
+  name      = var.dbname
+  server_id = azurerm_postgresql_flexible_server.instance[0].id
+  collation = "C"
+  charset   = "utf8"
+}

--- a/edbterraform/data/terraform/azure/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/database/outputs.tf
@@ -1,0 +1,36 @@
+output "instance_type" {
+  value = azurerm_postgresql_flexible_server.instance[0].sku_name
+}
+output "dbname" {
+  value = var.dbname
+}
+output "region" {
+  value = azurerm_postgresql_flexible_server.instance[0].location
+}
+output "domain" {
+  value = azurerm_postgresql_flexible_server.instance[0].fqdn
+}
+output "public_ip" {
+  value = (
+    azurerm_postgresql_flexible_server.instance[0].public_network_access_enabled ?
+      azurerm_postgresql_flexible_server.instance[0].fqdn : ""
+    )
+}
+output "private_ip" {
+  value = azurerm_postgresql_flexible_server.instance[0].fqdn
+}
+output "username" {
+  value = azurerm_postgresql_flexible_server.instance[0].administrator_login
+}
+output "password" {
+  value = azurerm_postgresql_flexible_server.instance[0].administrator_password
+}
+output "engine" {
+  value = var.engine
+}
+output "version" {
+  value = azurerm_postgresql_flexible_server.instance[0].version
+}
+output "tags" {
+  value = azurerm_postgresql_flexible_server.instance[0].tags
+}

--- a/edbterraform/data/terraform/azure/modules/database/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/database/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.37.0"
+    }
+  }
+  required_version = ">= 1.3.6"
+}

--- a/edbterraform/data/terraform/azure/modules/database/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/database/variables.tf
@@ -1,0 +1,72 @@
+variable "engine" {
+}
+variable "engine_version" { 
+}
+variable "instance_type" {
+}
+variable "settings" {
+}
+variable "cluster_name" {
+}
+variable "name" {
+  type = string
+}
+variable "resource_name" {
+  type = string
+}
+variable "dbname" {
+  type = string
+  default = ""
+  nullable = false
+}
+variable "region" {
+}
+variable "zone" {
+  type     = string
+  default  = null
+  nullable = true
+
+  validation {
+    condition = (
+      # try(..., false) must be used since var.location.zone might be null,
+      # null is not allowed in contains() function and fails during terraform plan
+      var.zone == null ||
+      try(contains(["1", "2", "3", ], var.zone), false)
+    )
+    error_message = <<-EOT
+    Zone must be: null, 1 - 3
+    EOT
+  }
+}
+variable "tags" {
+}
+variable "name_id" {
+}
+variable "username" {
+}
+variable "password" {
+}
+variable "public_access" {
+  type = bool
+  default = false
+}
+/*
+  sizes_mb = [
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+    2097152,
+    4194304,
+    8388608,
+    16777216,
+*/
+variable "size_gb" {
+  type = number
+  default = 0
+}
+locals {
+  size_mb = var.size_gb * 1024
+}

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -1,8 +1,10 @@
+/*
+https://github.com/hashicorp/terraform-provider-azurerm/issues/10167
 data "azurerm_ssh_public_key" "main" {
   name                = var.public_key_name
   resource_group_name = var.resource_name
 }
-
+*/
 resource "azurerm_public_ip" "main" {
   name                = "ip-${var.name}-${var.name_id}"
   resource_group_name = var.resource_name
@@ -38,7 +40,7 @@ resource "azurerm_linux_virtual_machine" "main" {
   admin_username = var.operating_system.ssh_user
   admin_ssh_key {
     username   = var.operating_system.ssh_user
-    public_key = data.azurerm_ssh_public_key.main.public_key
+    public_key = var.public_key
   }
   disable_password_authentication = true
   network_interface_ids           = [azurerm_network_interface.internal.id]

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -42,8 +42,8 @@ variable "name_id" {
   type = string
 }
 variable "subnet_id" {}
-variable "public_key_name" {}
 variable "private_key" {}
+variable "public_key" {}
 variable "use_agent" {
   default = false
 }

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -41,6 +41,25 @@ output "region_machines" {
   }
 }
 
+output "region_databases" {
+  value = {
+    for name, database_spec in var.spec.databases : database_spec.region => {
+      name = name
+      spec = merge(database_spec, {
+        # spec project tags
+        tags = merge(var.spec.tags, database_spec.tags, {
+          # databases module specific tags
+          name = name
+          id   = random_id.apply.hex
+        })
+        # assign zone from mapped names
+        # Handle 0 as null to represent a region with no zones available
+        zone = tostring(database_spec.zone) == "0" ? null : database_spec.zone
+      })
+    }...
+  }
+}
+
 output "region_kubernetes" {
   value = {
     for name, spec in var.spec.kubernetes : spec.region => {

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -74,6 +74,25 @@ variable "spec" {
       })), [])
       tags = optional(map(string), {})
     })), {})
+    databases = optional(map(object({
+      region         = string
+      zone           = optional(string)
+      dbname         = optional(string)
+      engine         = string
+      engine_version = number
+      instance_type  = string
+      username       = string
+      password       = string
+      volume = object({
+        size_gb   = optional(number)
+      })
+      settings = optional(list(object({
+        name  = string
+        value = number
+      })), [])
+      tags = optional(map(string), {})
+      public_access = optional(bool, false)
+    })), {})
     kubernetes = optional(map(object({
       region                  = string
       ssh_user                = optional(string)

--- a/infrastructure-examples/azure-database.yml
+++ b/infrastructure-examples/azure-database.yml
@@ -1,0 +1,50 @@
+---
+azure:
+  tags:
+    cluster_name: flexible-servers
+    created_by: edb-terraform
+  regions:
+    westus:
+      cidr_block: 10.2.0.0/16
+      zones:
+        main:
+          zone: 0
+          cidr: 10.2.20.0/24
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+      region_ports:
+        - protocol: icmp
+          description: "ping"
+  images:
+    rocky_8_7_0:
+      publisher: erockyenterprisesoftwarefoundationinc1653071250513
+      offer: rockylinux
+      sku: free
+      version: 8.7.0
+      ssh_user: rocky
+  machines:
+    dbt2-driver:
+      image_name: rocky_8_7_0
+      region: westus
+      zone_name: main
+      instance_type: Standard_D2as_v4
+      volume:
+        type: StandardSSD_LRS
+        size_gb: 50
+      tags:
+        type: dbt2-driver
+  databases:
+    postgres:
+      region: westus
+      engine: postgresql
+      engine_version: 14
+      username: postgres
+      password: asdfavu899fnvoabnsviob
+      instance_type: GP_Standard_D4s_v3
+      volume:
+        size_gb: 32
+      tags:
+        environment: Sandbox
+        type: postgres


### PR DESCRIPTION
Support for Azure PostgreSQL Database on Flexible Server
      * Firewall allows for all azure internal services to connect, including virtual machines and non-owned virtual machines within the azure network
      * `public_access` can be used to open the firewall to all traffic outside of azure's network
    * README update
    * Example placed under `infrastructure-examples/azure-database.yml`

```yaml
---
azure:
  tags:
    cluster_name: flexible-server
    created_by: edb-terraform
  regions:
    westus:
      cidr_block: 10.2.0.0/16
   databases:
    postgres:
      region: westus
      engine: postgresql
      engine_version: 14
      username: postgres
      password: asdfavu899fnvoabnsviob
      instance_type: GP_Standard_D4s_v3
      volume:
        size_gb: 32
      tags:
        environment: Sandbox
        type: postgres
```

Fix: Azure linux machines would fail to decode data source's public key.