### PR TITLE
`generate` and `setup` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ Once the infrastructure file has been created we can to proceed with cloud
 resources creation:
 
   1. We can attempt to setup a compatable version of Terraform.
-    This directory will be inside of ~/.edb-terraform/bin
-    Logs can be found inside of ~/.edb-terraform/logs
-    ```shell
-    $ edb-terraform setup
-    ```
+     This directory will be inside of `~/.edb-terraform/bin`
+     Logs can be found inside of `~/.edb-terraform/logs`
+    
+     ```shell
+     $ edb-terraform setup
+     ```
+
   2. A new Terraform *project* must be created with the help of the
      `edb-terraform` script. This script is in charge of creating a dedicated
      directory for the *project*, generating SSH keys, building Terraform

--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ $ pip3 install . --upgrade
 Once the infrastructure file has been created we can to proceed with cloud
 resources creation:
 
-  1. A new Terraform *project* must be created with the help of the
+  1. We can attempt to setup a compatable version of Terraform.
+    This directory will be inside of ~/.edb-terraform/bin
+    Logs can be found inside of ~/.edb-terraform/logs
+    ```shell
+    $ edb-terraform setup
+    ```
+  2. A new Terraform *project* must be created with the help of the
      `edb-terraform` script. This script is in charge of creating a dedicated
      directory for the *project*, generating SSH keys, building Terraform
      configuration based on the infrastructure file, copying Terraform modules
@@ -100,7 +106,7 @@ resources creation:
      
      Defaults to `aws` if not used
      ```shell
-     $ edb-terraform ~/my_project -c aws my_infrastructure.yml
+     $ edb-terraform generate ~/my_project -c aws my_infrastructure.yml
      ```
 
       b. Step 2 can be skipped if using option `--validate`,
@@ -110,7 +116,7 @@ resources creation:
       * terraform `>= 1.3.6` 
       * CLI from chosen provider setup already (authenticated, export needed variables/files)
      ```shell
-     $ edb-terraform ~/my_project -c aws my_infrastructure.yml --validate
+     $ edb-terraform generate ~/my_project -c aws my_infrastructure.yml --validate
      ```
 
 <p align="center">

--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -129,7 +129,7 @@ def binary_path(name, bin_path=None):
 class TerraformCLI:
     binary_name = 'terraform'
     min_version = Version(1, 3, 6)
-    max_version = Version(1, 4, 0)
+    max_version = Version(1, 4, 6)
     arch_alias = {
         'x86_64': 'amd64',
     }

--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -1,0 +1,275 @@
+import platform
+from collections import namedtuple
+import sys
+import os
+from pathlib import Path
+import subprocess
+from tempfile import mkstemp
+import stat
+import json
+import textwrap
+
+from edbterraform import __project_name__
+from edbterraform.Logger import logger
+
+Version = namedtuple('Version', ['major', 'minor', 'patch'])
+
+def parse_version(version, separator):
+    return Version(*[int(x) for x in version.split(separator)])
+
+def join_version(version, separator):
+    return separator.join(map(str, version))
+
+def execute_shell(args, environment=os.environ, cwd=None):
+    logger.info("Executing command: %s", ' '.join(args))
+    logger.debug("environment=%s", environment)
+    try:
+        process = subprocess.check_output(
+            ' '.join(args),
+            stderr=subprocess.STDOUT,
+            shell=True,
+            cwd=cwd,
+            env=environment,
+        )
+        return process
+    
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to execute the command: %s", e.cmd)
+        logger.error("Return code is: %s", e.returncode)
+        logger.error("Output: %s", e.output)
+        raise Exception(
+            "executable seems to be missing. Please install it "
+            "or check your PATH variable"
+        )
+
+
+def execute_live_shell(args, environment=os.environ, cwd=None):
+    logger.info("Executing command: %s", ' '.join(args))
+    logger.debug("environment=%s", environment)
+    process = subprocess.Popen(
+        ' '.join(args),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=cwd,
+        env=environment
+    )
+
+    rc = 0
+    while True:
+        output = process.stdout.readline()
+        if output:
+            logger.info(output.decode("utf-8").strip())
+        rc = process.poll()
+        if rc is not None:
+            break
+
+    return rc
+
+def build_temporary_script(content):
+    """
+    Generate the installation script as an executable tempfile and returns its
+    path.
+    """
+    script_handle, script_name = mkstemp(suffix='.sh')
+    try:
+        with open(script_handle, 'w') as f:
+            f.write(content)
+        st = os.stat(script_name)
+        os.chmod(script_name, st.st_mode | stat.S_IEXEC)
+        return script_name
+    except Exception as e:
+        logger.error("Unable to generate the installation script")
+        logger.exception(str(e))
+        raise Exception("Unable to generate the installation script")
+
+def execute_temporary_script(script_name):
+    """
+    Execute an installation script
+    """
+    try:
+        output = execute_shell(['/bin/bash', script_name])
+        result = output.decode("utf-8")
+        os.unlink(script_name)
+        logger.debug("Command output: %s", result)
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to execute the command: %s", e.cmd)
+        logger.error("Return code is: %s", e.returncode)
+        logger.error("Output: %s", e.output)
+        raise Exception(
+            "Failed to execute the following command, please check the "
+            "logs for details: %s" % e.cmd
+        )
+
+def binary_path(name, bin_path=None):
+    """Returns the first seen binary
+
+    Order:
+    1. bin_path + name if it exists
+    2. PATH + name if it exists
+    3. Empty string
+
+    :param name: name of the binary
+    :param path: path to the binary
+    """
+    if bin_path and os.path.exists(bin_path):
+        binary_path = os.path.join(bin_path, name)
+        if os.path.exists(binary_path) and os.access(binary_path, os.X_OK):
+            return binary_path
+        
+    paths = os.getenv("PATH",'').split(os.pathsep)
+    for path in paths:
+        binary_path = os.path.join(path, name)
+        if os.path.exists(binary_path) and os.access(binary_path, os.X_OK):
+            return binary_path    
+    
+    return ''
+
+
+class TerraformCLI:
+    binary_name = 'terraform'
+    min_version = Version(1, 3, 6)
+    max_version = Version(1, 4, 0)
+    arch_alias = {
+        'x86_64': 'amd64',
+    }
+    DEFAULT_PATH=f'{Path.home()}/.{__project_name__}'
+
+    def __init__(self, binary_dir=None):
+        self.bin_dir = binary_dir if binary_dir else TerraformCLI.DEFAULT_PATH
+        self.bin_path = os.path.join(self.bin_dir, 'bin')
+        self.binary_full_path = os.path.join(self.bin_path, TerraformCLI.binary_name)
+        self.architecture = TerraformCLI.arch_alias.get(platform.machine().lower(),platform.machine().lower())
+        self.operating_system = platform.system().lower()
+
+    def get_terraform_binary(self):
+        return binary_path(TerraformCLI.binary_name, self.bin_path)
+
+    def get_compatible_terraform(self):
+        version = self.check_version()
+        binary = self.get_terraform_binary()
+
+        if self.min_version > version \
+            or version > self.max_version:
+            raise subprocess.CalledProcessError(
+                cmd=binary,
+                output=textwrap.dedent('''
+                No compatible version found.
+                Min: {min}
+                Max: {max}
+                Version: {current}
+                Binary: {binary}
+                ''').format(
+                    min = join_version(self.min_version, '.'),
+                    max = join_version(self.max_version, '.'),
+                    current = join_version(version, '.'),
+                    binary = binary
+                ),
+                returncode=1
+            )
+        return binary
+
+    def check_version(self):
+        try:
+            version_keyname = 'terraform_version'
+            terraform_path = self.get_terraform_binary()
+            command = [terraform_path, '--version', '-json']
+            output = execute_shell(
+                args=command,
+                environment=os.environ.copy(),
+            )
+            result = json.loads(output.decode("utf-8"))
+
+            version = parse_version(result[version_keyname], '.')
+            return version
+        except KeyError as e:
+            raise e(f'version keyname was not found')
+    
+    def init_command(self, cwd):
+        try:
+            terraform_path = self.get_compatible_terraform()
+            command = [
+                terraform_path,
+                'init',
+            ]
+            output = execute_shell(
+                args=command,
+                environment=os.environ.copy(),
+                cwd=cwd,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f'Error: ({e.output})')
+            raise e
+
+    def plan_command(self, cwd):
+        try:
+            terraform_path = self.get_compatible_terraform()
+            command = [
+                terraform_path,
+                'plan',
+                '-input=false',
+            ]
+            output = execute_shell(
+                    args=command,
+                    environment=os.environ.copy(),
+                    cwd=cwd,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f'Error: ({e.output})')
+            raise e
+
+    def apply_target_command(self, cwd):
+        try:
+            terraform_path = self.get_compatible_terraform()
+            command = [
+                terraform_path,
+                'apply',
+                '-input=false',
+                '-target=null_resource.validation',
+                '-auto-approve',
+            ]
+            output = execute_shell(
+                    args=command,
+                    environment=os.environ.copy(),
+                    cwd=cwd,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f'Error: ({e.output})')
+            raise e
+
+    @classmethod
+    def get_max_version(cls):
+        return join_version(cls.max_version, '.')
+
+    def install(self):
+        installation_script = textwrap.dedent('''
+            #!/bin/bash
+            set -eu
+
+            rm -rf {path}/terraform/{version}/bin
+            rm -f /tmp/terraform.zip
+            rm -f {path}/bin/terraform
+
+            mkdir -p {path}/bin
+            mkdir -p {path}/terraform/{version}/bin
+            wget -q https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os_flavor}_{arch}.zip -O /tmp/terraform.zip
+            unzip /tmp/terraform.zip -d {path}/terraform/{version}/bin
+            ln -sf {path}/terraform/{version}/bin/terraform {path}/bin/.
+        ''')
+
+        terraform_bin = self.get_terraform_binary()
+        # Skip installation if latest already installed
+        if terraform_bin == self.binary_full_path \
+            and join_version(self.check_version(), '.') == self.get_max_version():
+            return
+
+        script_name = build_temporary_script(
+            installation_script.format(
+                path=self.bin_dir,
+                version=self.get_max_version(),
+                os_flavor=self.operating_system,
+                arch=self.architecture,
+            )
+        )
+
+        execute_temporary_script(script_name)

--- a/edbterraform/Logger.py
+++ b/edbterraform/Logger.py
@@ -1,0 +1,30 @@
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+from edbterraform import __project_name__
+
+DEFAULT_DIR = f'{Path.home()}/.{__project_name__}/logs'
+
+if not os.path.exists(DEFAULT_DIR):
+    os.makedirs(DEFAULT_DIR)
+
+timestamp = datetime.now().strftime('%Y-%m-%d')
+log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+date_format = '%Y-%m-%dT%H:%M:%S%z'
+
+log_file = os.getenv("LOG_FILE", os.path.join(DEFAULT_DIR, f'{timestamp}.log'))
+log_stdout = os.getenv('LOG_STDOUT', None)
+level = os.getenv("LOG_LEVEL",'WARNING').upper()
+log_level = getattr(logging, level, logging.WARNING)
+
+
+if log_stdout:
+    logging.basicConfig(level=log_level, stream=sys.stdout, datefmt=date_format, format=log_format)
+else:
+    log_handler = RotatingFileHandler(log_file, maxBytes=10*1024*1024, backupCount=10, mode='a')
+    logging.basicConfig(level=log_level, datefmt=date_format, format=log_format, handlers=[log_handler])
+
+logger = logging.getLogger(__project_name__)

--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,1 +1,2 @@
 __version__ = "1.3.0"
+__project_name__ = 'edb-terraform'

--- a/edbterraform/__main__.py
+++ b/edbterraform/__main__.py
@@ -1,47 +1,11 @@
 import sys
-import argparse
-from pathlib import Path
-try:
-    from edbterraform.lib import generate_terraform
-except:
-    from lib import generate_terraform
+import os.path
+# When invoked as a script, we need to add the package to the path,
+# this is done to avoid needing to use try/except imports
+if not __package__:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-class Arguments:
-    def __init__(self):
-        self.parser = argparse.ArgumentParser()
-        self.parser.add_argument(
-            'project_path',
-            metavar='PROJECT_PATH',
-            type=Path,
-            help="Project path.",
-        )
-        self.parser.add_argument(
-            'infra_file',
-            metavar='INFRA_FILE_YAML',
-            type=Path,
-            help="CSP infrastructure (YAML format) file path."
-        )
-        self.parser.add_argument(
-            '--cloud-service-provider', '-c',
-            metavar='CLOUD_SERVICE_PROVIDER',
-            dest='csp',
-            choices=['aws', 'gcloud', 'azure'],
-            default='aws',
-            help="Cloud Service Provider. Default: %(default)s"
-        )
-        self.parser.add_argument(
-            '--validate',
-            dest='run_validation',
-            action='store_true',
-            required=False,
-            help='''
-                Requires terraform >= 1.3.6
-                Validates the generated files by running:
-                `terraform apply -target=null_resource.validation`
-                If invalid, error will be displayed and project directory destroyed
-                Default: %(default)s
-                '''
-        )
+from edbterraform.args import Arguments
 
 def main(args=None):
     """ 
@@ -49,19 +13,8 @@ def main(args=None):
 
     Returns the dictionary from generate_terraform()
     """
-    env = Arguments().parser.parse_args(args)
-    outputs = generate_terraform(env.infra_file, env.project_path, env.csp, env.run_validation)
-    sys.stdout.write(f'''
-    Success!
-    You can use now use terraform and see info about your boxes after creation:
-    * cd {env.project_path}
-    * terraform init
-    * terraform apply -auto-approve
-    * terraform output -json {outputs['terraform_output']}
-    * ssh <ssh_user>@<ip-address> -i {outputs['ssh_filename']}
-    \n
-    ''')
-    
+    arg_parser = Arguments()
+    outputs = arg_parser.process_args()
     return outputs
 
 '''

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -29,7 +29,7 @@ class ArgumentConfig:
     metavar: str = None
     dest: str = None
     type: type = None
-    help: str = None
+    help: str = ''
     default: str = None
     choices: list = None
     required: bool = None
@@ -38,9 +38,9 @@ class ArgumentConfig:
     def __post_init__(self) -> None:
         # Allow overriding of variables with environment variables
         self.default = os.getenv(self.default_env_var(), self.default)
-        if self.help:
-            self.help += f'''
-            | Default Environment variable: {self.default_env_var()}'''
+        self.help += f'''
+        | Default Environment variable: {self.default_env_var()}
+        '''
 
         tempdict = self.__dict__.items()
         # dictionary with non-None values

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import textwrap
 from dataclasses import dataclass, field
 from collections import OrderedDict
+from typing import NoReturn
 
 from edbterraform.lib import generate_terraform
 from edbterraform.CLI import TerraformCLI
@@ -124,17 +125,18 @@ Validation = ArgumentConfig(
 
 class Arguments:
 
+    # Command, description, and its options
     COMMANDS = OrderedDict({
-        'generate': [
+        'generate': ['Generate terraform files based on a yaml infrastructure file\n',[
             ProjectPath,
             InfraFile,
             CloudServiceProvider,
             Validation,
             BinPath,
-        ],
-        'setup': [
+        ]],
+        'setup': ['Install needed software such as Terraform inside a bin directory\n',[
             BinPath,
-        ],
+        ]],
     })
     DEFAULT_COMMAND = next(iter(COMMANDS))
 
@@ -147,11 +149,12 @@ class Arguments:
         for name, arg_configs in self.COMMANDS.items():
             self.subparsers.add_parser(name)
             subparser = self.subparsers.choices[name]
-            for config in arg_configs:
+            for config in arg_configs[1]:
                 subparser.add_argument(
                     *(config.get_names()),
                     **(config.get_args())
                 )
+            subparser.usage = arg_configs[0]+subparser.format_usage()
 
         self.env = self.parser.parse_args()
 

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -1,0 +1,145 @@
+import sys
+import argparse
+from pathlib import Path
+import textwrap
+
+from edbterraform.lib import generate_terraform
+from edbterraform.CLI import TerraformCLI
+from edbterraform import __project_name__
+from edbterraform.Logger import logger
+
+class Arguments:
+
+    COMMANDS = ['generate', 'setup']
+    DEFAULT_COMMAND = COMMANDS[0]
+
+    def __init__(self, args:list[str]=sys.argv, parser=argparse.ArgumentParser()):
+        self.parser = parser
+        self.subparsers = self.parser.add_subparsers()
+        self.command = self.override_sys_argv(args)
+
+        for command in Arguments.COMMANDS:
+            self.subparsers.add_parser(command)
+        self.subparsers.default = Arguments.DEFAULT_COMMAND
+
+        generate = self.subparsers.choices['generate']
+        generate.add_argument(
+            'project_path',
+            metavar='PROJECT_PATH',
+            type=Path,
+            help="Project path.",
+        )
+        generate.add_argument(
+            'infra_file',
+            metavar='INFRA_FILE_YAML',
+            type=Path,
+            help="CSP infrastructure (YAML format) file path."
+        )
+        generate.add_argument(
+            '--cloud-service-provider', '-c',
+            metavar='CLOUD_SERVICE_PROVIDER',
+            dest='csp',
+            choices=['aws', 'gcloud', 'azure'],
+            default='aws',
+            help="Cloud Service Provider. Default: %(default)s"
+        )
+        generate.add_argument(
+            '--validate',
+            dest='run_validation',
+            action='store_true',
+            required=False,
+            help='''
+                Requires terraform >= 1.3.6
+                Validates the generated files by running:
+                `terraform apply -target=null_resource.validation`
+                If invalid, error will be displayed and project directory destroyed
+                Default: %(default)s
+                '''
+        )
+        generate.add_argument(
+            '--bin_path',
+            dest='bin_path',
+            default=TerraformCLI.DEFAULT_PATH,
+            required=False,
+            help='''
+                Default location to install binaries.
+                It will default to users home directory.
+                Default: %(default)s
+                '''
+        )
+        setup = self.subparsers.choices['setup']
+        setup.add_argument(
+            '--bin_path',
+            dest='bin_path',
+            default=TerraformCLI.DEFAULT_PATH,
+            required=False,
+            help='''
+                Default location to install binaries.
+                It will default to users home directory.
+                Default: %(default)s
+                '''
+        )
+
+        self.env = self.parser.parse_args()
+
+    def override_sys_argv(self, args: list[str]):
+        '''
+        Override sys.argv and return the default command
+        This is needed for backwards compatability,
+        as we did not have multiple commands previously.
+        '''
+        # Set default subparser if not provided
+        sys.argv = args
+        program_name = self.parser.prog
+        program_index = 0
+        command_index = program_index+1
+
+        for index, argument in enumerate(sys.argv):
+            if argument == program_name:
+                program_index = index
+                command_index = index+1
+                break
+
+        # Set default if not provided
+        if program_index < len(sys.argv)-1 and \
+            sys.argv[command_index] not in Arguments.COMMANDS and \
+            sys.argv[command_index] not in ['-h', '--help']:
+            sys.argv.insert(command_index, Arguments.DEFAULT_COMMAND)
+            return sys.argv[command_index]
+        # Set help if not provided
+        elif program_index == len(sys.argv)-1:
+            sys.argv.insert(command_index, '-h')
+            return sys.argv[command_index]
+        elif program_index < len(sys.argv)-1:
+            return sys.argv[command_index]
+
+        return sys.argv[program_index]
+
+    def process_args(self):
+        if self.command == 'generate':
+            outputs = generate_terraform(
+                self.env.infra_file,
+                self.env.project_path,
+                self.env.csp,
+                self.env.run_validation,
+                self.env.bin_path,
+            )
+            logger.info(textwrap.dedent('''
+            Success!
+            You can use now use terraform and see info about your boxes after creation:
+            * cd {project_path}
+            * terraform init
+            * terraform apply -auto-approve
+            * terraform output -json {output_key}
+            * ssh <ssh_user>@<ip-address> -i {ssh_file}
+            ''').format(
+                project_path = self.env.project_path,
+                output_key = outputs['terraform_output'],
+                ssh_file = outputs['ssh_filename'],
+            ))
+            return outputs
+
+        if self.command == 'setup':
+            terraform = TerraformCLI(self.env.bin_path)
+            terraform.install()
+            return terraform.bin_path

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -220,6 +220,20 @@ def generate_terraform(infra_file: Path, project_path: Path, csp: str, run_valid
 
     run_terraform(project_path, run_validation, bin_path)
 
+    logger.info(textwrap.dedent('''
+    Success!
+    You can use now use terraform and see info about your boxes after creation:
+    * cd {project_path}
+    * terraform init
+    * terraform apply -auto-approve
+    * terraform output -json {output_key}
+    * ssh <ssh_user>@<ip-address> -i {ssh_file}
+    ''').format(
+        project_path = project_path,
+        output_key = OUTPUT['terraform_output'],
+        ssh_file = OUTPUT['ssh_filename'],
+    ))
+
     return OUTPUT
 
 def run_terraform(cwd, validate, bin_path):

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -350,4 +350,4 @@ def spec_compatability(infrastructure_variables, cloud_service_provider):
             if 'zone_name' not in spec_variables['kubernetes'][cluster] and 'zone' in spec_variables['kubernetes'][cluster]:
                 spec_variables['kubernetes'][cluster]['zone_name'] = f'depreciated-{spec_variables["kubernetes"][machine]["zone"]}'
 
-    return spec_variables    
+    return spec_variables


### PR DESCRIPTION
Support for new commands:
* depreciated - generate terraform files with positional arguments (default)
* setup - installs terraform
* generate - generates a terraform files based on an yaml infrastructure file 

---

* Default behavior: In order to avoid breaking old calls, the following syntax is still valid: `edb-terraform PROJECT_PATH INFRA_FILE_YAML`
  * `-h` - help will display the new available commands
  * `edb-terraform depreciated -h` - display help for depreciated call
* `edb-terraform setup`
  * installs a valid terraform binary inside of `~/.edb-terraform/bin` by default
  * short description added
* `edb-terraform generate`
  * generate terraform files based on a yaml infrastructure file
  * short description added
* Any commands with defaults will be exposed as environment variables. User input still takes precedence over environment variables/defaults.
  * Generated environment variables: `ET_<command>`
  * Shown under help command if available
* Logging
  * enviroment variables for overrides
    * LOG_FILE
    * LOG_STDOUT
    * LOG_LEVEL
  * logs default to user `$HOME/.edb-terraform/logs/<timestamp>.log`