### PR TITLE
resource tags updated across all providers

### DIFF
--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -4,7 +4,7 @@ module "vpc_{{ region_ }}" {
   vpc_cidr_block = try(module.spec.base.regions["{{ region }}"].cidr_block, null)
   vpc_tag        = var.vpc_tag
   name_id        = module.spec.hex_id
-  tags             = module.spec.base.tags
+  tags           = module.spec.tags
 
   providers = {
     aws = aws.{{ region_ }}
@@ -22,7 +22,7 @@ module "network_{{ region_ }}" {
   public_subnet_tag  = var.public_subnet_tag
   cidr_block         = each.value.cidr
   availability_zone  = each.value.zone
-  tags               = module.spec.base.tags
+  tags               = module.spec.tags
 
   depends_on = [module.vpc_{{ region_ }}]
 
@@ -39,7 +39,7 @@ module "routes_{{ region_ }}" {
   project_tag        = var.project_tag
   public_cidrblock   = var.public_cidrblock
   cluster_name       = module.spec.base.tags.cluster_name
-  tags               = module.spec.base.tags
+  tags               = module.spec.tags
 
   depends_on = [module.network_{{ region_ }}]
 
@@ -57,7 +57,7 @@ module "security_{{ region_ }}" {
   ports            = try(module.spec.region_ports["{{ region }}"], [])
   ingress_cidrs    = module.spec.region_cidrblocks
   egress_cidrs     = module.spec.region_cidrblocks
-  tags             = module.spec.base.tags
+  tags             = module.spec.tags
 
   depends_on = [module.routes_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -4,6 +4,7 @@ module "vpc_{{ region_ }}" {
   vpc_cidr_block = try(module.spec.base.regions["{{ region }}"].cidr_block, null)
   vpc_tag        = var.vpc_tag
   name_id        = module.spec.hex_id
+  tags             = module.spec.base.tags
 
   providers = {
     aws = aws.{{ region_ }}
@@ -21,6 +22,7 @@ module "network_{{ region_ }}" {
   public_subnet_tag  = var.public_subnet_tag
   cidr_block         = each.value.cidr
   availability_zone  = each.value.zone
+  tags               = module.spec.base.tags
 
   depends_on = [module.vpc_{{ region_ }}]
 
@@ -37,6 +39,7 @@ module "routes_{{ region_ }}" {
   project_tag        = var.project_tag
   public_cidrblock   = var.public_cidrblock
   cluster_name       = module.spec.base.tags.cluster_name
+  tags               = module.spec.base.tags
 
   depends_on = [module.network_{{ region_ }}]
 
@@ -54,6 +57,7 @@ module "security_{{ region_ }}" {
   ports            = try(module.spec.region_ports["{{ region }}"], [])
   ingress_cidrs    = module.spec.region_cidrblocks
   egress_cidrs     = module.spec.region_cidrblocks
+  tags             = module.spec.base.tags
 
   depends_on = [module.routes_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/region_peering.tf.j2
+++ b/edbterraform/data/templates/aws/region_peering.tf.j2
@@ -7,6 +7,7 @@ module "vpc_peering_{{ requester_ }}_{{ accepter_ }}" {
   vpc_id      = module.vpc_{{ requester_ }}.vpc_id
   peer_vpc_id = module.vpc_{{ accepter_ }}.vpc_id
   peer_region = "{{ accepter }}"
+  tags        = module.spec.base.tags
 
   depends_on = [module.vpc_{{ requester_ }}, module.vpc_{{ accepter_ }}]
 
@@ -19,6 +20,7 @@ module "vpc_peering_accepter_{{ requester_}}_{{ accepter_ }}" {
   source = "./modules/vpc_peering_accepter"
 
   connection_id = module.vpc_peering_{{ requester_ }}_{{ accepter_ }}.id
+  tags          = module.spec.base.tags
 
   depends_on = [module.vpc_peering_{{ requester_ }}_{{ accepter_ }}]
 

--- a/edbterraform/data/templates/aws/region_peering.tf.j2
+++ b/edbterraform/data/templates/aws/region_peering.tf.j2
@@ -7,7 +7,7 @@ module "vpc_peering_{{ requester_ }}_{{ accepter_ }}" {
   vpc_id      = module.vpc_{{ requester_ }}.vpc_id
   peer_vpc_id = module.vpc_{{ accepter_ }}.vpc_id
   peer_region = "{{ accepter }}"
-  tags        = module.spec.base.tags
+  tags        = module.spec.tags
 
   depends_on = [module.vpc_{{ requester_ }}, module.vpc_{{ accepter_ }}]
 
@@ -20,7 +20,7 @@ module "vpc_peering_accepter_{{ requester_}}_{{ accepter_ }}" {
   source = "./modules/vpc_peering_accepter"
 
   connection_id = module.vpc_peering_{{ requester_ }}_{{ accepter_ }}.id
-  tags          = module.spec.base.tags
+  tags          = module.spec.tags
 
   depends_on = [module.vpc_peering_{{ requester_ }}_{{ accepter_ }}]
 

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -4,6 +4,7 @@ module "vpc_{{ region_ }}"{
   name          = "${var.vpc_tag}-{{ region }}-${module.spec.hex_id}"
   cidr_blocks = [ lookup(lookup(module.spec.base.regions, "{{ region }}"), "cidr_block") ]
   region = "{{ region }}"
+  tags          = module.spec.tags
 
   providers = {
     azurerm = azurerm.{{ region_ }}
@@ -44,6 +45,7 @@ module "security_{{ region_ }}" {
   ports             = try(module.spec.region_ports["{{ region }}"], [])
   ingress_cidrs     = module.spec.region_cidrblocks
   egress_cidrs      = module.spec.region_cidrblocks
+  tags              = module.spec.tags
 
   depends_on = [module.network_{{ region_ }}]
 

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -21,6 +21,7 @@ module "machine_ports" {
   project_tag      = "machine_rules"
   cluster_name     = var.machine.name
   ports            = local.machine_ports
+  tags             = var.tags
 }
 
 resource "aws_instance" "machine" {

--- a/edbterraform/data/terraform/aws/modules/network/main.tf
+++ b/edbterraform/data/terraform/aws/modules/network/main.tf
@@ -2,6 +2,7 @@ variable "public_subnet_tag" {}
 variable "vpc_id" {}
 variable "cidr_block" {}
 variable "availability_zone" {}
+variable "tags" {}
 
 terraform {
   required_providers {
@@ -18,9 +19,9 @@ resource "aws_subnet" "public_subnets" {
   map_public_ip_on_launch = "true" // Makes the subnet public
   availability_zone       = var.availability_zone
 
-  tags = {
+  tags = merge({
     Name = format("%s_%s_%s", var.public_subnet_tag, var.availability_zone, var.cidr_block)
-  }
+  }, var.tags)
 }
 
 output "subnet_id" {

--- a/edbterraform/data/terraform/aws/modules/routes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/routes/main.tf
@@ -3,6 +3,7 @@ variable "subnet_count" {}
 variable "vpc_id" {}
 variable "project_tag" {}
 variable "public_cidrblock" {}
+variable "tags" {}
 
 terraform {
   required_providers {
@@ -23,9 +24,9 @@ data "aws_subnets" "ids" {
 resource "aws_internet_gateway" "igw" {
   vpc_id = var.vpc_id
 
-  tags = {
+  tags = merge({
     Name = format("%s_%s_%s", var.project_tag, var.cluster_name, "igw")
-  }
+  }, var.tags)
 }
 
 resource "aws_route_table" "custom_route_table" {
@@ -38,9 +39,9 @@ resource "aws_route_table" "custom_route_table" {
     gateway_id = aws_internet_gateway.igw.id
   }
 
-  tags = {
+  tags = merge({
     Name = format("%s_%s_%s", var.project_tag, var.cluster_name, "route_table")
-  }
+  }, var.tags)
 }
 
 resource "aws_route_table_association" "rt_associations" {

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -2,9 +2,9 @@ resource "aws_security_group" "rules" {
   name = format("%s_%s", var.project_tag, var.cluster_name)
   vpc_id = var.vpc_id
 
-  tags = {
+  tags = merge({
     Name = format("%s_%s", var.project_tag, var.cluster_name)
-  }
+  }, var.tags)
 }
 
 resource "aws_security_group_rule" "rule" {

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -1,5 +1,6 @@
 variable "vpc_id" {}
 variable "project_tag" {}
+variable "tags" {}
 variable "ports" {}
 variable "cluster_name" {}
 variable "ingress_cidrs" {

--- a/edbterraform/data/terraform/aws/modules/specification/main.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/main.tf
@@ -2,5 +2,8 @@ resource "random_id" "apply" {
   byte_length = 4
 }
 
+resource "time_static" "first_created" {
+}
+
 resource "random_pet" "name" {
 }

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -2,6 +2,19 @@ output "base" {
   value = var.spec
 }
 
+locals {
+  tags = merge(var.spec.tags, {
+    # add ids for tracking
+    terraform_hex   = random_id.apply.hex
+    terraform_id    = random_id.apply.id
+    terraform_time  = time_static.first_created.id
+  })
+}
+
+output "tags" {
+  value = local.tags
+}
+
 output "private_key" {
   value = var.spec.ssh_key.private_path != null ? file(var.spec.ssh_key.private_path) : tls_private_key.default[0].private_key_openssh
 }
@@ -18,11 +31,10 @@ locals {
         name = machine_spec.count > 1 ? "${name}-${index}" : name
         spec = merge(machine_spec, {
           # spec project tags
-          tags = merge(var.spec.tags, machine_spec.tags, {
+          tags = merge(local.tags, machine_spec.tags, {
           # machine module specific tags
           # Use 'Name' tag to have instance name set for AWS UI
           Name = format("%s-%s-%s", (machine_spec.count > 1 ? "${name}-${index}" : name), var.spec.tags.cluster_name, random_id.apply.hex)
-          id   = random_id.apply.hex
           })
           # assign operating system from mapped names
           operating_system = var.spec.images[machine_spec.image_name]
@@ -48,10 +60,9 @@ output "region_databases" {
       name = name
       spec = merge(database_spec, {
         # spec project tags
-        tags = merge(var.spec.tags, database_spec.tags, {
+        tags = merge(local.tags, database_spec.tags, {
           # database module specific tags
           Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.hex)
-          id   = random_id.apply.hex
         })
       })
     }...
@@ -64,10 +75,9 @@ output "region_auroras" {
       name = name
       spec = merge(aurora_spec, {
         # spec project tags
-        tags = merge(var.spec.tags, aurora_spec.tags, {
+        tags = merge(local.tags, aurora_spec.tags, {
           # aurora module specific tags
-          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.hex)
-          id   = random_id.apply.hex
+          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.id)
         })
       })
     }...
@@ -88,10 +98,9 @@ output "region_kubernetes" {
       name = name
       spec = merge(spec, {
         # spec project tags
-        tags = merge(var.spec.tags, spec.tags, {
+        tags = merge(local.tags, spec.tags, {
           # kubernetes module specific tags
-          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.hex)
-          id   = random_id.apply.hex
+          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.id)
         })
       })
     }...

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -17,8 +17,8 @@ variable "spec" {
   type = object({
     # Project Level Tags to be merged with other tags
     tags = optional(map(string), {
-      cluster_name = optional(string, "AWS-Cluster")
-      created_by   = optional(string, "EDB-Terraform-AWS")
+      cluster_name = "AWS-Cluster-default"
+      created_by   = "EDB-Terraform-AWS"
     })
     ssh_key = optional(object({
       public_path  = optional(string)
@@ -128,4 +128,12 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
+
+  validation {
+    condition = can(var.spec.tags.cluster_name) && can(var.spec.tags.created_by)
+    error_message = <<-EOT
+    cluster_name and created_by need to be defined under tags
+    Tags: ${jsonencode(var.spec.tags)}
+    EOT
+  }
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -16,10 +16,10 @@ variable "spec" {
   EOT
   type = object({
     # Project Level Tags to be merged with other tags
-    tags = optional(object({
+    tags = optional(map(string), {
       cluster_name = optional(string, "AWS-Cluster")
       created_by   = optional(string, "EDB-Terraform-AWS")
-    }), {})
+    })
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)

--- a/edbterraform/data/terraform/aws/modules/vpc/main.tf
+++ b/edbterraform/data/terraform/aws/modules/vpc/main.tf
@@ -1,6 +1,7 @@
 variable "vpc_cidr_block" {}
 variable "vpc_tag" {}
 variable "name_id" { default = "0" }
+variable "tags" {}
 
 terraform {
   required_providers {
@@ -17,8 +18,8 @@ resource "aws_vpc" "main" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = {
+  tags = merge({
     Name = "${var.vpc_tag}-${var.name_id}"
-  }
+  }, var.tags)
 }
 

--- a/edbterraform/data/terraform/aws/modules/vpc_peering/main.tf
+++ b/edbterraform/data/terraform/aws/modules/vpc_peering/main.tf
@@ -1,6 +1,7 @@
 variable "vpc_id" {}
 variable "peer_vpc_id" {}
 variable "peer_region" {}
+variable "tags" {}
 
 terraform {
   required_providers {
@@ -16,4 +17,5 @@ resource "aws_vpc_peering_connection" "main" {
   peer_vpc_id = var.peer_vpc_id
   peer_region = var.peer_region
   auto_accept = false
+  tags        = var.tags
 }

--- a/edbterraform/data/terraform/aws/modules/vpc_peering_accepter/main.tf
+++ b/edbterraform/data/terraform/aws/modules/vpc_peering_accepter/main.tf
@@ -12,4 +12,5 @@ terraform {
 resource "aws_vpc_peering_connection_accepter" "main" {
   vpc_peering_connection_id = var.connection_id
   auto_accept               = true
+  tags                      = var.tags
 }

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -12,13 +12,14 @@ resource "azurerm_public_ip" "main" {
   allocation_method   = "Static"
   zones               = local.zones
   sku                 = local.public_ip_sku
+  tags                = var.tags
 }
 
 resource "azurerm_network_interface" "internal" {
   name                = "internal-${var.name}-${var.name_id}"
   resource_group_name = var.resource_name
   location            = var.machine.region
-
+  tags                = var.tags
   ip_configuration {
     name                          = "internal"
     private_ip_address_version    = "IPv4"
@@ -84,7 +85,7 @@ resource "azurerm_managed_disk" "volume" {
   create_option        = "Empty"
   disk_size_gb         = each.value.size_gb
   disk_iops_read_write = each.value.iops
-
+  tags                 = var.tags
   lifecycle {
     precondition {
       condition = (

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -2,6 +2,7 @@ resource "azurerm_network_security_group" "firewall" {
   name                = "${var.region}-${var.zone}-${var.name_id}"
   resource_group_name = var.resource_name
   location            = var.region
+  tags                = var.tags
 }
 
 resource "azurerm_subnet_network_security_group_association" "firewall" {

--- a/edbterraform/data/terraform/azure/modules/security/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/security/variables.tf
@@ -14,3 +14,4 @@ variable "egress_cidrs" {
 variable "name_id" {
     type = string
 }
+variable "tags" {}

--- a/edbterraform/data/terraform/azure/modules/specification/main.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/main.tf
@@ -2,5 +2,8 @@ resource "random_id" "apply" {
   byte_length = 4
 }
 
+resource "time_static" "first_created" {
+}
+
 resource "random_pet" "name" {
 }

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -16,10 +16,10 @@ variable "spec" {
   EOT
   type = object({
     # Project Level Tags to be merged with other tags
-    tags = optional(object({
-      cluster_name = optional(string, "Azure-Cluster")
-      created_by   = optional(string, "EDB-Terraform-Azure")
-    }), {})
+    tags = optional(map(string), {
+      cluster_name = "Azure-Cluster-default"
+      created_by   = "EDB-Terraform-Azure"
+    })
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)
@@ -129,6 +129,14 @@ Region - Machine:
 %{endfor~}
 EOT
     )
+  }
+
+  validation {
+    condition = can(var.spec.tags.cluster_name) && can(var.spec.tags.created_by)
+    error_message = <<-EOT
+    cluster_name and created_by need to be defined under tags
+    Tags: ${jsonencode(var.spec.tags)}
+    EOT
   }
 
 }

--- a/edbterraform/data/terraform/azure/modules/vpc/main.tf
+++ b/edbterraform/data/terraform/azure/modules/vpc/main.tf
@@ -1,6 +1,7 @@
 resource "azurerm_resource_group" "main" {
   name     = var.name
   location = var.region
+  tags     = var.tags
 }
 
 resource "azurerm_virtual_network" "main" {
@@ -8,6 +9,7 @@ resource "azurerm_virtual_network" "main" {
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   address_space       = var.cidr_blocks
+  tags                = var.tags
 
   depends_on = [azurerm_resource_group.main]
 }

--- a/edbterraform/data/terraform/azure/modules/vpc/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/vpc/variables.tf
@@ -5,3 +5,4 @@ variable "cidr_blocks" {
   nullable = true
 }
 variable "name" {}
+variable "tags" {}

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -20,6 +20,7 @@ resource "google_compute_address" "public_ip" {
   name         = format("public-ip-%s-%s", var.machine.name, var.name_id)
   region       = var.machine.spec.region
   address_type = "EXTERNAL"
+  # TODO: Add labels once they are out of beta. 2023-05-05
 }
 
 resource "google_compute_instance" "machine" {
@@ -61,6 +62,7 @@ resource "google_compute_disk" "volumes" {
   size             = each.value.size_gb
   zone             = var.machine.spec.zone
   provisioned_iops = try(each.value.iops, null)
+  labels           = var.tags
 
   depends_on = [google_compute_instance.machine]
 

--- a/edbterraform/data/terraform/gcloud/modules/service_connection/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/service_connection/main.tf
@@ -5,6 +5,7 @@ resource "google_compute_global_address" "sql_private_ip" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = var.network
+  # TODO: Add labels once they are out of beta. 2023-05-05
 }
 
 resource "google_service_networking_connection" "vpc_connection" {

--- a/edbterraform/data/terraform/gcloud/modules/specification/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/main.tf
@@ -107,5 +107,8 @@ resource "random_id" "apply" {
   byte_length = 4
 }
 
+resource "time_static" "first_created" {
+}
+
 resource "random_pet" "name" {
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -16,10 +16,10 @@ variable "spec" {
   EOT
   type = object({
     # Project Level Tags to be merged with other tags
-    tags = optional(object({
-      cluster_name = optional(string, "gcp-cluster")
-      created_by   = optional(string, "edb-terraform")
-    }), {})
+    tags = optional(map(string), {
+      cluster_name = "GCloud-Cluster-default"
+      created_by   = "EDB-Terraform-GCloud"
+    })
     ssh_key = optional(object({
       public_path  = optional(string)
       private_path = optional(string)


### PR DESCRIPTION
Tags updated for all providers.

Top-level tag changed to `map(str)` to allow for additional top level tags instead of filtering them out. Since they are used across all resources, there could be issues due to account restrictions or quotas.
* `cluster_name` - required top level tag
* `created_by` - required top level tag
* `terraform_id` - generated from random during initial terraform run
* `terraform_hex` - generated from random during initial terraform run
* `terraform_time` - timestamp generated during initial terraform run

** to avoid errors, gcloud generated outputs are modified to match label restrictions