### PR TITLE
Fix: Gcloud machine dependencies

### DIFF
--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -7,9 +7,6 @@ data "google_compute_subnetwork" "selected" {
   name   = var.subnet_name
 }
 
-# TODO: Data source is causes instance to be replaced
-# due to terraform thinking the image has changed
-# Use 'initialize_params.image' in instance and remove/move data source out of module
 data "google_compute_image" "image" {
   name = var.operating_system.name
   family = var.operating_system.family
@@ -46,7 +43,12 @@ resource "google_compute_instance" "machine" {
   }
 
   lifecycle {
-    ignore_changes = [attached_disk, ]
+    ignore_changes = [
+      # VM recreated on re-apply if not ignored
+      boot_disk,
+      # Disks de-tach on re-apply if not ignored
+      attached_disk,
+    ]
   }
 
   metadata = { ssh-keys = "${var.operating_system.ssh_user}:${var.ssh_pub_key}" }


### PR DESCRIPTION
Stop gcloud from re-creating the machines so we can add additional machines as needed. We can still add additional volumes, but we cannot change the image or boot device, which matches AWS. A new resource can be created instead and configured as needed.

Azure is not experiencing the same problem as AWS/Gcloud.