### PR TITLE
Fix: tags regression from PR-56

### DIFF
--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -4,7 +4,7 @@ module "vpc_{{ region_ }}" {
   vpc_cidr_block = try(module.spec.base.regions["{{ region }}"].cidr_block, null)
   vpc_tag        = var.vpc_tag
   name_id        = module.spec.hex_id
-  tags           = module.spec.tags
+  tags           = module.spec.base.tags
 
   providers = {
     aws = aws.{{ region_ }}
@@ -22,7 +22,7 @@ module "network_{{ region_ }}" {
   public_subnet_tag  = var.public_subnet_tag
   cidr_block         = each.value.cidr
   availability_zone  = each.value.zone
-  tags               = module.spec.tags
+  tags               = module.spec.base.tags
 
   depends_on = [module.vpc_{{ region_ }}]
 
@@ -39,7 +39,7 @@ module "routes_{{ region_ }}" {
   project_tag        = var.project_tag
   public_cidrblock   = var.public_cidrblock
   cluster_name       = module.spec.base.tags.cluster_name
-  tags               = module.spec.tags
+  tags               = module.spec.base.tags
 
   depends_on = [module.network_{{ region_ }}]
 
@@ -57,7 +57,7 @@ module "security_{{ region_ }}" {
   ports            = try(module.spec.region_ports["{{ region }}"], [])
   ingress_cidrs    = module.spec.region_cidrblocks
   egress_cidrs     = module.spec.region_cidrblocks
-  tags             = module.spec.tags
+  tags             = module.spec.base.tags
 
   depends_on = [module.routes_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/region_peering.tf.j2
+++ b/edbterraform/data/templates/aws/region_peering.tf.j2
@@ -7,7 +7,7 @@ module "vpc_peering_{{ requester_ }}_{{ accepter_ }}" {
   vpc_id      = module.vpc_{{ requester_ }}.vpc_id
   peer_vpc_id = module.vpc_{{ accepter_ }}.vpc_id
   peer_region = "{{ accepter }}"
-  tags        = module.spec.tags
+  tags        = module.spec.base.tags
 
   depends_on = [module.vpc_{{ requester_ }}, module.vpc_{{ accepter_ }}]
 
@@ -20,7 +20,7 @@ module "vpc_peering_accepter_{{ requester_}}_{{ accepter_ }}" {
   source = "./modules/vpc_peering_accepter"
 
   connection_id = module.vpc_peering_{{ requester_ }}_{{ accepter_ }}.id
-  tags          = module.spec.tags
+  tags          = module.spec.base.tags
 
   depends_on = [module.vpc_peering_{{ requester_ }}_{{ accepter_ }}]
 

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -4,7 +4,7 @@ module "vpc_{{ region_ }}"{
   name          = "${var.vpc_tag}-{{ region }}-${module.spec.hex_id}"
   cidr_blocks = [ lookup(lookup(module.spec.base.regions, "{{ region }}"), "cidr_block") ]
   region = "{{ region }}"
-  tags          = module.spec.tags
+  tags          = module.spec.base.tags
 
   providers = {
     azurerm = azurerm.{{ region_ }}
@@ -45,7 +45,7 @@ module "security_{{ region_ }}" {
   ports             = try(module.spec.region_ports["{{ region }}"], [])
   ingress_cidrs     = module.spec.region_cidrblocks
   egress_cidrs      = module.spec.region_cidrblocks
-  tags              = module.spec.tags
+  tags              = module.spec.base.tags
 
   depends_on = [module.network_{{ region_ }}]
 

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -1,13 +1,17 @@
-output "base" {
-  value = var.spec
-}
-
 locals {
   tags = merge(var.spec.tags, {
     # add ids for tracking
     terraform_hex   = random_id.apply.hex
     terraform_id    = random_id.apply.id
     terraform_time  = time_static.first_created.id
+    created_by      = local.created_by
+    cluster_name    = local.cluster_name
+  })
+}
+
+output "base" {
+  value = merge(var.spec, {
+    "tags" = local.tags
   })
 }
 

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -129,13 +129,6 @@ variable "spec" {
     })), {})
   })
 
-  validation {
-    condition = can(var.spec.tags.cluster_name) && can(var.spec.tags.created_by)
-    error_message = <<-EOT
-    cluster_name and created_by need to be defined under tags
-    Tags: ${jsonencode(var.spec.tags)}
-    EOT
-  }
 }
 
 locals {

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -139,6 +139,6 @@ variable "spec" {
 }
 
 locals {
-  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "AWS-Cluster-default"
-  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-AWS"
+  cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "AWS-Cluster-default"
+  created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-AWS"
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -137,3 +137,8 @@ variable "spec" {
     EOT
   }
 }
+
+locals {
+  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "AWS-Cluster-default"
+  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-AWS"
+}

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -1,13 +1,17 @@
-output "base" {
-  value = var.spec
-}
-
 locals {
   tags = merge(var.spec.tags, {
     # add ids for tracking
     terraform_hex   = random_id.apply.hex
     terraform_id    = random_id.apply.id
     terraform_time  = time_static.first_created.id
+    created_by      = local.created_by
+    cluster_name    = local.cluster_name
+  })
+}
+
+output "base" {
+  value = merge(var.spec, {
+    "tags" = local.tags
   })
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -134,6 +134,6 @@ EOT
 }
 
 locals {
-  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "Azure-Cluster-default"
-  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-Azure"
+  cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "Azure-Cluster-default"
+  created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-Azure"
 }

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -131,12 +131,9 @@ EOT
     )
   }
 
-  validation {
-    condition = can(var.spec.tags.cluster_name) && can(var.spec.tags.created_by)
-    error_message = <<-EOT
-    cluster_name and created_by need to be defined under tags
-    Tags: ${jsonencode(var.spec.tags)}
-    EOT
-  }
+}
 
+locals {
+  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "Azure-Cluster-default"
+  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-Azure"
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -1,19 +1,23 @@
-output "base" {
-  value = var.spec
-}
-
 locals {
-  # add ids for tracking
-  # gcloud label restrictions:
-  # - lowercase letters, numeric characters, underscores and dashes
-  # - 63 characters max
-  # to match other providers as close as possible,
-  # we will do any needed handling and continue to treat
-  # key-values as tags even though they are labels under gcloud
   tags = merge(var.spec.tags, {
+    # add ids for tracking
+    # gcloud label restrictions:
+    # - lowercase letters, numeric characters, underscores and dashes
+    # - 63 characters max
+    # to match other providers as close as possible,
+    # we will do any needed handling and continue to treat
+    # key-values as tags even though they are labels under gcloud
     terraform_hex   = lower(random_id.apply.hex)
     terraform_id    = lower(random_id.apply.id)
     terraform_time  = lower(replace(time_static.first_created.id,":","_"))
+    created_by      = lower(local.created_by)
+    cluster_name    = lower(local.cluster_name)
+  })
+}
+
+output "base" {
+  value = merge(var.spec, {
+    "tags" = local.tags
   })
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -142,3 +142,8 @@ EOT
     )
   }
 }
+
+locals {
+  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "GCloud-Cluster-default"
+  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-GCloud"
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -144,6 +144,6 @@ EOT
 }
 
 locals {
-  cluster_name = can(var.spec.tags.cluster_name) && length(var.spec.tags.cluster_name) > 0 ? var.spec.tags.cluster_name : "GCloud-Cluster-default"
-  created_by = can(var.spec.tags.created_by) && length(var.spec.tags.created_by) > 0 ? var.spec.tags.created_by : "EDB-Terraform-GCloud"
+  cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "GCloud-Cluster-default"
+  created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-GCloud"
 }


### PR DESCRIPTION
PR-https://github.com/EnterpriseDB/edb-terraform/pull/56 broke old workflows as it enforced `cluster_name` and `created_by` tags. Validation check was removed and updated templates to use outputs and not the specification variable directly.

Related error:
```
+ terraform apply -auto-approve
╷
│ Error: Invalid value for variable
│
│   on main.tf line 10, in module "spec":
│   10:   spec = var.spec
│     ├────────────────
│     │ var.spec.tags is map of string with 1 element
│     │ var.spec.tags.cluster_name is "TPCC-refdata"
│
│ cluster_name and created_by need to be defined under tags
│ Tags: {"cluster_name":"TPCC-refdata"}
│
│ This was checked by the validation rule at
│ modules/specification/variables.tf:132,3-13.
```
