### PR TITLE
fix: python compatibility for `types` and `dataclasses`

### DIFF
--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import textwrap
 from dataclasses import dataclass, field
 from collections import OrderedDict
-from typing import NoReturn
+from typing import List
 
 from edbterraform.lib import generate_terraform
 from edbterraform.CLI import TerraformCLI
@@ -177,7 +177,7 @@ class Arguments:
     })
     DEFAULT_COMMAND = next(iter(COMMANDS))
 
-    def __init__(self, args:list[str]=sys.argv, parser=argparse.ArgumentParser()):
+    def __init__(self, args:List[str]=sys.argv, parser=argparse.ArgumentParser()):
         self.parser = parser
         self.subparsers = self.parser.add_subparsers()
         self.command = self.override_sys_argv(args)
@@ -195,7 +195,7 @@ class Arguments:
 
         self.env = self.parser.parse_args()
 
-    def override_sys_argv(self, args: list[str]):
+    def override_sys_argv(self, args: List[str]):
         '''
         Override sys.argv and return the default command
         This is needed for backwards compatability,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+cryptography
+dataclasses==0.8;python_version~="3.6.0"
+PyYaml>=5.1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,13 @@ def get_long_description():
     with open(os.path.join(cur_dir, "README.md")) as f:
         return f.read()
 
+def get_requirements():
+    cur_dir = os.path.dirname(__file__)
+    requirements_path = os.path.join(cur_dir, "requirements.txt")
+
+    with open(requirements_path) as f:
+        return f.read().splitlines()
+
 setup(
     name="edb-terraform",
     version=get_version(),
@@ -49,7 +56,7 @@ setup(
     ],
     keywords="terraform cloud yaml edb cli aws rds aurora azure aks gcloud gke kubernetes k8s",
     python_requires=">=3.6",
-    install_requires=["PyYAML>=5.1", "cryptography", "jinja2"],
+    install_requires=get_requirements(),
     extras_require={},
     data_files=[],
     package_data={


### PR DESCRIPTION
* built-in types are not supported until `python3.9`
* built-in dataclasses are not supported until `python3.7`
* added `requirements.txt` and used in `setup.py`

Ref: https://github.com/EnterpriseDB/edb-terraform/pull/55