### PR TITLE
Fix: type causing error in python3.8 <=

### DIFF
--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -81,7 +81,7 @@ def save_terraform_vars(dir, filename, vars):
         logger.error("ERROR: could not write %s (%s)" % (dest, e))
         sys.exit(1)
 
-def save_user_templates(project_path: Path, template_files: List[str|Path]) -> List[str]:
+def save_user_templates(project_path: Path, template_files: List[str]) -> List[str]:
     '''
     Save any user templates into a template directory
     for reuse during terraform execution and portability of directory


### PR DESCRIPTION
```sh
+++ dirname -- ./run.sh
++ cd -- .
++ pwd
+ SCRIPT_DIR=/var/lib/buildbot-worker/rundir/AWS_HammerDB_TPROC-C_EC2_EPAS_Oracle_Compability/build/14/aws-hammerdb-epas-oracle-compatibility/00_provision
+ edb-terraform /var/lib/buildbot-worker/rundir/AWS_HammerDB_TPROC-C_EC2_EPAS_Oracle_Compability/build/14/terraform /var/lib/buildbot-worker/rundir/AWS_HammerDB_TPROC-C_EC2_EPAS_Oracle_Compability/build/14/aws-hammerdb-epas-oracle-compatibility/00_provision/../infrastructure.yml
Traceback (most recent call last):
  File "/var/lib/buildbot-worker/venv/bin/edb-terraform", line 11, in <module>
    load_entry_point('edb-terraform==1.3.0', 'console_scripts', 'edb-terraform')()
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/edbterraform/__main__.py", line 8, in <module>
    from edbterraform.args import Arguments
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/edbterraform/args.py", line 11, in <module>
    from edbterraform.lib import generate_terraform
  File "/var/lib/buildbot-worker/venv/lib/python3.8/site-packages/edbterraform/lib.py", line 84, in <module>
    def save_user_templates(project_path: Path, template_files: List[str|Path]) -> List[str]:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```