### PR TITLE
CLI args updated to use dashes

### DIFF
--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -74,7 +74,7 @@ class ArgumentConfig:
         return self.filtered_dict.get(key, None)
 
 BinPath = ArgumentConfig(
-    names = ['--bin_path'],
+    names = ['--bin-path'],
     dest  = 'bin_path',
     default = TerraformCLI.DEFAULT_PATH,
     required = False,
@@ -86,7 +86,7 @@ BinPath = ArgumentConfig(
 )
 
 ProjectPathDepreciated = ArgumentConfig(
-    names = ['project_path',],
+    names = ['project-path',],
     metavar='PROJECT_PATH',
     type=Path,
     help="Project path. Default: %(default)s",
@@ -100,7 +100,7 @@ InfraFileDepreciated = ArgumentConfig(
 )
 
 WorkPath = ArgumentConfig(
-    names = ['--work_path',],
+    names = ['--work-path',],
     metavar='WORK_PATH',
     dest='work_path',
     type=Path,
@@ -110,7 +110,7 @@ WorkPath = ArgumentConfig(
 )
 
 InfrastructureFilePath = ArgumentConfig(
-    names = ['--infra_file',],
+    names = ['--infra-file',],
     metavar='INFRA_FILE_YAML',
     dest='infra_file',
     type=Path,
@@ -119,7 +119,7 @@ InfrastructureFilePath = ArgumentConfig(
 )
 
 ProjectName = ArgumentConfig(
-    names = ['--project_name',],
+    names = ['--project-name',],
     metavar='PROJECT_NAME',
     dest='project_name',
     required=True,
@@ -154,7 +154,7 @@ Validation = ArgumentConfig(
 )
 
 LogLevel = ArgumentConfig(
-    names = ['--log_level',],
+    names = ['--log-level',],
     dest='log_level',
     required=False,
     default="INFO",
@@ -164,7 +164,7 @@ LogLevel = ArgumentConfig(
 )
 
 LogFile = ArgumentConfig(
-    names = ['--log_file',],
+    names = ['--log-file',],
     dest='log_file',
     required=False,
     default=datetime.now().strftime('%Y-%m-%d'),
@@ -174,7 +174,7 @@ LogFile = ArgumentConfig(
 )
 
 LogDirectory = ArgumentConfig(
-    names = ['--log_directory',],
+    names = ['--log-directory',],
     dest='log_directory',
     required=False,
     default=f'{Path.home()}/.{__project_name__}/logs',
@@ -184,7 +184,7 @@ LogDirectory = ArgumentConfig(
 )
 
 LogStdout = ArgumentConfig(
-    names = ['--log_stdout',],
+    names = ['--log-stdout',],
     dest='log_stdout',
     action='store_true',
     required=False,


### PR DESCRIPTION
```sh
user@su22:~/Projects/edb-terraform
$ python3 -m edbterraform generate -h
usage: Generate terraform files based on a yaml infrastructure file
usage: __main__.py generate [-h] --project-name PROJECT_NAME --infra-file INFRA_FILE_YAML
                            [--work-path WORK_PATH] [--cloud-service-provider CLOUD_SERVICE_PROVIDER]
                            [--validate] [--bin-path BIN_PATH] [--log-level LOG_LEVEL]
                            [--log-file LOG_FILE] [--log-directory LOG_DIRECTORY] [--log-stdout]

options:
  -h, --help            show this help message and exit
  --project-name PROJECT_NAME
                        Creates a directory with PROJECT_NAME for generated files in the WORK_PATH None |
                        Default Environment variable: ET_PROJECT_NAME
  --infra-file INFRA_FILE_YAML
                        cloud service provider infrastructure file path (YAML format). Default: None |
                        Default Environment variable: ET_INFRA_FILE
  --work-path WORK_PATH
                        Project path. Default: /home/user/Projects/edb-terraform | Default Environment
                        variable: ET_WORK_PATH
  --cloud-service-provider CLOUD_SERVICE_PROVIDER, -c CLOUD_SERVICE_PROVIDER
                        Cloud Service Provider. Default: aws | Default Environment variable: ET_CSP
  --validate            Requires terraform >= 1.3.6 Validates the generated files by running: `terraform
                        apply -target=null_resource.validation` If invalid, error will be displayed and
                        project directory destroyed Default: False | Default Environment variable:
                        ET_RUN_VALIDATION
  --bin-path BIN_PATH   Default location to install binaries. It will default to users home directory.
                        Default: /home/user/.edb-terraform | Default Environment variable: ET_BIN_PATH
  --log-level LOG_LEVEL
                        Default: INFO | Default Environment variable: ET_LOG_LEVEL
  --log-file LOG_FILE   Default: 2023-06-10 | Default Environment variable: ET_LOG_FILE
  --log-directory LOG_DIRECTORY
                        Default: /home/user/.edb-terraform/logs | Default Environment variable:
                        ET_LOG_DIRECTORY
  --log-stdout          Default: True | Default Environment variable: ET_LOG_STDOUT
```