### PR TITLE
Fix: AWS security module fails due to empty string

### DIFF
--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -27,7 +27,7 @@ locals {
   port_rules_descriptions = {
     for port in var.ports:
       join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
-      => coalesce(port.description, "")...
+      => coalesce(port.description, "default")...
     }
   port_rules_mapping = {
     for port in var.ports:

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -40,14 +40,14 @@ variable "spec" {
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = optional(string)
+        description = optional(string, "default")
         type = optional(string, "ingress")
         cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = optional(string)
+        description = optional(string, "default")
         type = optional(string, "ingress")
         cidrs = optional(list(string))
       })), [])
@@ -61,7 +61,7 @@ variable "spec" {
       ports         = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = optional(string)
+        description = optional(string, "default")
         type = optional(string, "ingress")
         cidrs = optional(list(string))
         })), []

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -43,14 +43,14 @@ variable "spec" {
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string, "default")
         ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
         egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string, "default")
         ingress_cidrs = optional(list(string))
         egress_cidrs = optional(list(string))
       })), [])

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -41,14 +41,14 @@ variable "spec" {
       service_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string, "default")
         ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
         egress_cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         protocol    = string
-        description = string
+        description = optional(string, "default")
         ingress_cidrs = optional(list(string))
         egress_cidrs = optional(list(string))
       })), [])


### PR DESCRIPTION
Issue:
Security module for `AWS` is failing when port description is omitted by the user.

Error message:
```terraform
╷
│ Error: Error in function call
│ 
│   on modules/security/variables.tf line 30, in locals:
│   30:       => coalesce(port.description, "")...
│     ├────────────────
│     │ port.description is null
│ 
│ Call to function "coalesce" failed: no non-null, non-empty-string arguments.
╵
```

Fix:
Default, non-empty string provided in `coalesce` function to handle case where module is given a port with no description. 
AWS/Azure/Gcloud specification module's port descriptions updated with a default to match.