### PR TITLE
Fix: Update Gcloud to match Azure/AWS tags output

### DIFF
--- a/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/main.tf
@@ -25,7 +25,7 @@ resource "google_alloydb_cluster" "main" {
     }
   }
 
-  labels = var.tags
+  labels = local.labels
 
 }
 
@@ -47,5 +47,5 @@ resource "google_alloydb_instance" "main" {
 
   depends_on = [google_alloydb_cluster.main]
 
-  labels = var.tags
+  labels = local.labels
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/outputs.tf
@@ -25,5 +25,9 @@ output "version" {
   value = google_alloydb_cluster.main.database_version
 }
 output "tags" {
+  value = var.tags
+}
+
+output "labels" {
   value = google_alloydb_cluster.main.labels
 }

--- a/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/alloy/variables.tf
@@ -68,20 +68,13 @@ variable "backup_days" {
 variable "tags" {
   type    = map(string)
   default = {}
-
-  validation {
-    condition = alltrue([
-      for key, value in var.tags :
-      lower(key) == key && lower(value) == value
-    ])
-    error_message = <<-EOT
-GCloud expects all tags(labels) to be lowercase
-Fix the following tags:
-%{for key, value in var.tags}
-%{if !(lower(key) == key && lower(value) == value)}
-  ${key}: ${value}
-%{endif}
-%{endfor}
-    EOT
-  }
+}
+locals {
+  # gcloud label restrictions:
+  # - lowercase letters, numeric characters, underscores and dashes
+  # - 63 characters max
+  # to match other providers as close as possible,
+  # we will do any needed handling and continue to treat
+  # key-values as tags even though they are labels under gcloud
+  labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
 }

--- a/edbterraform/data/terraform/gcloud/modules/database/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/main.tf
@@ -18,7 +18,7 @@ resource "google_sql_database_instance" "instance" {
     disk_type             = upper(replace(var.disk_type, ".", "_"))
     disk_autoresize       = var.autoresize
     disk_autoresize_limit = (var.autoresize ? var.autoresize_limit : null)
-    user_labels           = var.tags
+    user_labels           = local.labels
 
     location_preference {
       zone = var.zone

--- a/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/outputs.tf
@@ -26,5 +26,8 @@ output "dbname" {
   value = google_sql_database.db.name
 }
 output "tags" {
+  value = var.tags
+}
+output "labels" {
   value = google_sql_database_instance.instance.settings[0].user_labels
 }

--- a/edbterraform/data/terraform/gcloud/modules/database/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/database/variables.tf
@@ -89,20 +89,13 @@ variable "deletion_protection" {
 variable "tags" {
   type    = map(string)
   default = {}
-
-  validation {
-    condition = alltrue([
-      for key, value in var.tags :
-      lower(key) == key && lower(value) == value
-    ])
-    error_message = <<-EOT
-GCloud expects all tags(labels) to be lowercase
-Fix the following tags:
-%{for key, value in var.tags}
-%{if !(lower(key) == key && lower(value) == value)}
-  ${key}: ${value}
-%{endif}
-%{endfor}
-    EOT
-  }
+}
+locals {
+  # gcloud label restrictions:
+  # - lowercase letters, numeric characters, underscores and dashes
+  # - 63 characters max
+  # to match other providers as close as possible,
+  # we will do any needed handling and continue to treat
+  # key-values as tags even though they are labels under gcloud
+  labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
 }

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
@@ -7,7 +7,7 @@ resource "google_container_cluster" "primary" {
   network    = var.network
   subnetwork = var.subnetwork
 
-  resource_labels = var.tags
+  resource_labels = local.labels
 }
 
 resource "google_container_node_pool" "primary_nodes" {
@@ -23,7 +23,7 @@ resource "google_container_node_pool" "primary_nodes" {
     ]
 
     machine_type = var.machine.spec.instance_type
-    labels       = var.tags
+    labels       = local.labels
     tags         = [format("%s-%s", var.cluster_name, "gke-node"), format("%s-%s", var.cluster_name, "gke")]
     metadata = {
       disable-legacy-endpoints = "true"

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/outputs.tf
@@ -10,5 +10,8 @@ output "host" {
   description = "GKE Cluster Host"
 }
 output "tags" {
+  value = var.tags
+}
+output "labels" {
   value = google_container_cluster.primary.resource_labels
 }

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
@@ -10,21 +10,13 @@ variable "name_id" { default = "0" }
 variable "tags" {
   type    = map(string)
   default = {}
-
-  validation {
-    condition = alltrue([
-      for key, value in var.tags :
-      lower(key) == key && lower(value) == value
-    ])
-    error_message = <<-EOT
-GCloud expects all tags(labels) to be lowercase
-Fix the following tags:
-%{for key, value in var.tags}
-%{if !(lower(key) == key && lower(value) == value)}
-  ${key}: ${value}
-%{endif}
-%{endfor}
-    EOT
-  }
-
+}
+locals {
+  # gcloud label restrictions:
+  # - lowercase letters, numeric characters, underscores and dashes
+  # - 63 characters max
+  # to match other providers as close as possible,
+  # we will do any needed handling and continue to treat
+  # key-values as tags even though they are labels under gcloud
+  labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance" "machine" {
   }
 
   metadata = { ssh-keys = "${var.operating_system.ssh_user}:${var.ssh_pub_key}" }
-  labels   = var.tags
+  labels   = local.labels
 }
 
 resource "google_compute_disk" "volumes" {
@@ -64,7 +64,7 @@ resource "google_compute_disk" "volumes" {
   size             = each.value.size_gb
   zone             = var.machine.spec.zone
   provisioned_iops = try(each.value.iops, null)
-  labels           = var.tags
+  labels           = local.labels
 
   depends_on = [google_compute_instance.machine]
 

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -17,6 +17,9 @@ output "private_ip" {
   value = google_compute_instance.machine.network_interface.0.network_ip
 }
 output "tags" {
+  value = var.tags
+}
+output "labels" {
   value = google_compute_instance.machine.labels
 }
 output "additional_volumes" {

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -32,22 +32,15 @@ variable "ip_forward" {
 variable "tags" {
   type    = map(string)
   default = {}
-
-  validation {
-    condition = alltrue([
-      for key, value in var.tags :
-      lower(key) == key && lower(value) == value
-    ])
-    error_message = <<-EOT
-GCloud expects all tags(labels) to be lowercase
-Fix the following tags:
-%{for key, value in var.tags}
-%{if !(lower(key) == key && lower(value) == value)}
-  ${key}: ${value}
-%{endif}
-%{endfor}
-    EOT
-  }
+}
+locals {
+  # gcloud label restrictions:
+  # - lowercase letters, numeric characters, underscores and dashes
+  # - 63 characters max
+  # to match other providers as close as possible,
+  # we will do any needed handling and continue to treat
+  # key-values as tags even though they are labels under gcloud
+  labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
 }
 
 locals {

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -1,17 +1,11 @@
 locals {
   tags = merge(var.spec.tags, {
     # add ids for tracking
-    # gcloud label restrictions:
-    # - lowercase letters, numeric characters, underscores and dashes
-    # - 63 characters max
-    # to match other providers as close as possible,
-    # we will do any needed handling and continue to treat
-    # key-values as tags even though they are labels under gcloud
-    terraform_hex   = lower(random_id.apply.hex)
-    terraform_id    = lower(random_id.apply.id)
-    terraform_time  = lower(replace(time_static.first_created.id,":","_"))
-    created_by      = lower(local.created_by)
-    cluster_name    = lower(local.cluster_name)
+    terraform_hex   = random_id.apply.hex
+    terraform_id    = random_id.apply.id
+    terraform_time  = time_static.first_created.id
+    created_by      = local.created_by
+    cluster_name    = local.cluster_name
   })
 }
 


### PR DESCRIPTION
Issue: 
PR https://github.com/EnterpriseDB/edb-terraform/pull/56 , modified the tags with lower and replace before passing them through to the outputs for gcloud but this was not needed for azure and aws. This now means the tags might vary between outputs and users might face issues when creating templates based on expected tags or need additional error handling within their templates, PR: https://github.com/EnterpriseDB/edb-terraform/pull/64 .

Fix: 
Gcloud tags passed through in the tags outputs to match the rest of the providers. Since gcloud requires specific structure and uses the term `labels` instead of `tags`, so it will have an output for labels instead.

Terraform servers.yml file output:
```terraform
        labels: {"cluster_name":"gcloud-infra","created_by":"edb-terraform-gcloud","name":"pg1","terraform_hex":"fcecf78e","terraform_id":"_oz3jg","terraform_time":"2023-06-10t17_07_43z","type":"postgres"}
        tags: {"cluster_name":"gcloud-infra","created_by":"EDB-Terraform-GCloud","name":"pg1","terraform_hex":"fcecf78e","terraform_id":"_Oz3jg","terraform_time":"2023-06-10T17:07:43Z","type":"postgres"}
```