### PR TITLE
AWS/Azure/GCloud: Allow port ranges and per machine rules

### DIFF
--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -8,10 +8,12 @@ module "machine_{{ region_ }}" {
 
   resource_name                   = module.vpc_{{ region_ }}.resource_name
   subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone_name].subnet_id
+  security_group_name             = module.network_{{ region_ }}[each.value.spec.zone_name].security_group_name
   operating_system                = each.value.spec.operating_system
   cluster_name                    = module.spec.base.tags.cluster_name
   name                            = each.value.name
   machine                         = each.value.spec
+  ports                           = each.value.spec.ports
   additional_volumes              = each.value.spec.additional_volumes
   private_key                     = module.spec.private_key
   public_key                      = module.spec.public_key

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -9,6 +9,7 @@ module "machine_{{ region_ }}" {
   resource_name                   = module.vpc_{{ region_ }}.resource_name
   subnet_id                       = module.network_{{ region_ }}[each.value.spec.zone_name].subnet_id
   security_group_name             = module.network_{{ region_ }}[each.value.spec.zone_name].security_group_name
+  security_group_id               = module.network_{{ region_ }}[each.value.spec.zone_name].security_group_id
   operating_system                = each.value.spec.operating_system
   cluster_name                    = module.spec.base.tags.cluster_name
   name                            = each.value.name

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -23,7 +23,8 @@ module "network_{{ region_ }}" {
   region          = module.vpc_{{ region_ }}.region
   zone            = each.value.zone
   ip_cidr_range   = [ each.value.cidr ]
-  name            = "{{region}}-${each.key}-${module.spec.hex_id}"
+  name            = "{{region}}-${each.key}"
+  name_id         = module.spec.hex_id
 
   depends_on = [module.vpc_{{ region_ }}]
 
@@ -37,9 +38,8 @@ module "security_{{ region_ }}" {
 
   for_each = lookup(module.spec.region_zone_networks, "{{ region }}", null)
 
-  subnet_id         = module.network_{{ region_ }}[each.key].subnet_id
-  zone              = each.key
-  name_id           = module.spec.hex_id
+  security_group_name = module.network_{{ region_ }}[each.key].security_group_name
+  name_id           = "${each.key}-${module.spec.hex_id}"
   region            = module.vpc_{{ region_ }}.region
   resource_name     = module.vpc_{{ region_ }}.resource_name
   ports             = try(module.spec.region_ports["{{ region }}"], [])

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -13,6 +13,7 @@ module "machine_{{ region_ }}" {
   ssh_priv_key                    = module.spec.private_key
   ssh_pub_key                     = module.spec.public_key
   use_agent                       = module.spec.base.ssh_key.use_agent
+  network_name                    = module.vpc_{{ region_ }}.vpc_id
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone_name].name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -50,7 +50,7 @@ resource "aws_instance" "machine" {
 resource "null_resource" "ensure_ssh_open" {
   count = local.additional_volumes_count
   triggers = {
-    "depends_on" = local.additional_volumes_length
+    "depends_on" = can(module.machine_ports) ? local.additional_volumes_length : local.additional_volumes_length
   }
 
   provisioner "remote-exec" {

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -3,7 +3,7 @@ locals {
   # Allow machine default outbound access if no egress is defined
   egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])
   machine_ports = concat(var.machine.spec.ports, 
-      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "description": "Default Egress if not defined"}])
+      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "to_port": null, "description": "Default Egress if not defined"}])
     )
 }
 

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -14,7 +14,10 @@ resource "aws_security_group_rule" "rule" {
   type = each.value.type
 
   from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
-  to_port     = each.value.port != null && each.value.protocol != "icmp"  ? each.value.port : -1
+  to_port     = (
+      each.value.to_port != null && each.value.protocol != "icmp"  ? each.value.to_port : 
+      each.value.port != null && each.value.protocol != "icmp" ? each.value.port : -1
+    )
   protocol    = each.value.protocol
   cidr_blocks = each.value.cidrs
 

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -20,18 +20,18 @@ locals {
   # Create mapping with new key and collapse protocol, port, description and ingress_cidrs
   port_rules_cidr_blocks = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
+      join("_", formatlist("%#v", [port.protocol, port.port, port.to_port, port.type])) 
       => coalesce(port.cidrs, var.ingress_cidrs)...
     }
 
   port_rules_descriptions = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
+      join("_", formatlist("%#v", [port.protocol, port.port, port.to_port, port.type])) 
       => coalesce(port.description, "default")...
     }
   port_rules_mapping = {
     for port in var.ports:
-      join("_", formatlist("%#v", [port.protocol, port.port, port.type])) 
+      join("_", formatlist("%#v", [port.protocol, port.port, port.to_port, port.type])) 
        => port...
   }
   merged_rules = {

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -37,8 +37,13 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
+      # TODO: Collapse service and regions ports into one
+      # 0.0.0.0/0 defaults can be blocked by IT.
+      # Instead, use region_ports as the default and if user wants access,
+      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       service_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
@@ -46,6 +51,7 @@ variable "spec" {
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
@@ -60,6 +66,7 @@ variable "spec" {
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -90,7 +90,7 @@ module "machine_ports" {
 resource "null_resource" "ensure_ssh_open" {
   count = local.additional_volumes_count
   triggers = {
-    "depends_on" = local.additional_volumes_length
+    "depends_on" = can(module.machine_ports) ? local.additional_volumes_length : local.additional_volumes_length
   }
 
   provisioner "remote-exec" {

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -74,8 +74,42 @@ resource "azurerm_linux_virtual_machine" "main" {
   depends_on = [azurerm_network_interface.internal, ]
 }
 
+module "machine_ports" {
+  source = "../security"
+
+  security_group_name = var.security_group_name
+  name_id          = "${var.name}-${var.name_id}"
+  region           = var.machine.region
+  resource_name    = var.resource_name
+  ports            = var.ports
+  ingress_cidrs    = flatten([azurerm_linux_virtual_machine.main.public_ip_address, azurerm_linux_virtual_machine.main.private_ip_addresses])  
+  egress_cidrs     = flatten([azurerm_linux_virtual_machine.main.public_ip_address, azurerm_linux_virtual_machine.main.private_ip_addresses])
+  tags             = var.tags
+}
+
+resource "null_resource" "ensure_ssh_open" {
+  count = local.additional_volumes_count
+  triggers = {
+    "depends_on" = local.additional_volumes_length
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo connected",
+    ]
+    connection {
+      type        = "ssh"
+      user        = var.operating_system.ssh_user
+      host        = azurerm_linux_virtual_machine.main.public_ip_address
+      port        = var.machine.ssh_port
+      agent       = var.use_agent # agent and private_key conflict
+      private_key = var.use_agent ? null : var.private_key
+    }
+  }
+}
+
 resource "azurerm_managed_disk" "volume" {
-  for_each = local.additional_volumes
+  for_each = local.additional_volumes_map
 
   name                 = format("%s-%s-%s-%s", var.name, var.cluster_name, var.name_id, each.key)
   resource_group_name  = var.resource_name
@@ -85,7 +119,8 @@ resource "azurerm_managed_disk" "volume" {
   create_option        = "Empty"
   disk_size_gb         = each.value.size_gb
   disk_iops_read_write = each.value.iops
-  tags                 = var.tags
+  # Implicit dependency to aws_ebs_volume.ebs_volume
+  tags = can(null_resource.ensure_ssh_open) ? var.tags : var.tags
   lifecycle {
     precondition {
       condition = (
@@ -100,68 +135,56 @@ resource "azurerm_managed_disk" "volume" {
       EOT
     }
   }
-
-  depends_on = [
-    azurerm_linux_virtual_machine.main,
-  ]
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "attached_volumes" {
-  for_each = local.additional_volumes
+  for_each = local.additional_volumes_map
 
   virtual_machine_id = azurerm_linux_virtual_machine.main.id
   managed_disk_id    = azurerm_managed_disk.volume[each.key].id
   lun                = 10 + tonumber(each.key)
-  caching            = each.value.caching
-
-  depends_on = [
-    azurerm_managed_disk.volume,
-  ]
+  caching            = can(azurerm_managed_disk.volume) ? each.value.caching : each.value.caching
 }
 
 resource "null_resource" "copy_setup_volume_script" {
-  count = local.volume_script_count
+  count = local.additional_volumes_count
+  triggers = {
+    "depends_on" = local.additional_volumes_length
+  }
 
   provisioner "file" {
     content     = file("${abspath(path.module)}/setup_volume.sh")
     destination = "/tmp/setup_volume.sh"
 
-    # Requires firewall access to ssh port
     connection {
-      type        = "ssh"
+      # Implicit dependency to null_resource.attached_volume
+      type        = can(azurerm_virtual_machine_data_disk_attachment.attached_volumes) ? "ssh" : "ssh"
       user        = var.operating_system.ssh_user
       host        = azurerm_linux_virtual_machine.main.public_ip_address
+      port        = var.machine.ssh_port
       agent       = var.use_agent # agent and private_key conflict
       private_key = var.use_agent ? null : var.private_key
     }
   }
-
-  depends_on = [
-    azurerm_virtual_machine_data_disk_attachment.attached_volumes,
-  ]
-
 }
 
 resource "null_resource" "setup_volume" {
-  for_each = local.additional_volumes
-
+  for_each = local.additional_volumes_map
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(var.additional_volumes) + 1}  >> /tmp/mount.log 2>&1"
     ]
 
-    # Requires firewall access to ssh port
     connection {
-      type        = "ssh"
+      # Implicit dependency to null_resource.copy_setup_volume_script
+      type        = can(null_resource.copy_setup_volume_script) ? "ssh" : "ssh"
       user        = var.operating_system.ssh_user
       host        = azurerm_linux_virtual_machine.main.public_ip_address
+      port        = var.machine.ssh_port
       agent       = var.use_agent # agent and private_key conflict
       private_key = var.use_agent ? null : var.private_key
     }
   }
-
-  depends_on = [
-    null_resource.copy_setup_volume_script
-  ]
 }
+

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -27,7 +27,11 @@ variable "machine" {
     })
   })
 }
-variable "ports" {}
+variable "ports" {
+  type = list
+  default = []
+  nullable = false
+}
 variable "tags" {
   type    = map(string)
   default = {}
@@ -45,6 +49,7 @@ variable "name_id" {
 }
 variable "subnet_id" {}
 variable "security_group_name" {}
+variable "security_group_id" {}
 variable "private_key" {}
 variable "public_key" {}
 variable "use_agent" {

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -19,6 +19,7 @@ variable "machine" {
     region        = string
     zone          = optional(string)
     instance_type = string
+    ssh_port      = optional(number, 22)
     volume = object({
       caching = optional(string, "None")
       size_gb = number
@@ -26,6 +27,7 @@ variable "machine" {
     })
   })
 }
+variable "ports" {}
 variable "tags" {
   type    = map(string)
   default = {}
@@ -42,6 +44,7 @@ variable "name_id" {
   type = string
 }
 variable "subnet_id" {}
+variable "security_group_name" {}
 variable "private_key" {}
 variable "public_key" {}
 variable "use_agent" {
@@ -84,12 +87,9 @@ variable "additional_volumes" {
 }
 
 locals {
-  additional_volumes = {
-    for key, value in var.additional_volumes :
-    key => value
-  }
-
-  volume_script_count = length(var.additional_volumes) > 0 ? 1 : 0
+  additional_volumes_length = length(var.additional_volumes)
+  additional_volumes_count = local.additional_volumes_length > 0 ? 1 : 0
+  additional_volumes_map = { for i, v in var.additional_volumes : i => v }
 
   premium_ssd = {
     regions = ["eastus", "westeurope", ]

--- a/edbterraform/data/terraform/azure/modules/network/main.tf
+++ b/edbterraform/data/terraform/azure/modules/network/main.tf
@@ -19,3 +19,15 @@ resource "azurerm_subnet" "internal" {
     }
   }
 }
+
+resource "azurerm_network_security_group" "firewall" {
+  name                = replace(join("-", formatlist("%#v", [var.name, var.region, var.zone, var.name_id])), "\"", "")
+  resource_group_name = var.resource_name
+  location            = var.region
+  tags                = var.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "firewall" {
+  subnet_id                 = azurerm_subnet.internal.id
+  network_security_group_id = azurerm_network_security_group.firewall.id
+}

--- a/edbterraform/data/terraform/azure/modules/network/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/network/outputs.tf
@@ -1,3 +1,11 @@
 output "subnet_id" {
   value = azurerm_subnet.internal.id
 }
+
+output "security_group_id" {
+  value = azurerm_network_security_group.firewall.id
+}
+
+output "security_group_name" {
+  value = azurerm_network_security_group.firewall.name
+}

--- a/edbterraform/data/terraform/azure/modules/network/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/network/variables.tf
@@ -44,7 +44,14 @@ variable "zone" {
     EOT
   }
 }
-
+variable "tags" {
+  type = map(string)
+  default = {}
+  nullable = false
+}
+variable "name_id" {
+  default = 0
+}
 locals {
   regions_with_zones = [
     # Americas

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -1,8 +1,9 @@
 resource "azurerm_network_security_rule" "rules" {
   for_each = {
     # preserve ordering
-    for values in var.ports:
-      format("0%.5d",values.priority) => values
+    # 100-4096 priorities allowed by Azure
+    for idx, values in var.ports:
+      format("0%.4d",idx+100) => values
   }
 
   resource_group_name         = var.resource_name

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_network_security_rule" "rules" {
   destination_address_prefixes = lower(each.value.type) == "egress" && each.value.cidrs != null ? each.value.cidrs : var.egress_cidrs
   source_port_range          = "*"
   source_address_prefixes    = lower(each.value.type) == "ingress" && each.value.cidrs != null ? each.value.cidrs : var.ingress_cidrs
-  access                     = "Allow"
+  access                     = lower(each.value.access) == "deny" ? "Deny" : "Allow"
   priority                   = tonumber(each.key)
 
   lifecycle {

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -28,7 +28,10 @@ resource "azurerm_network_security_rule" "rules" {
   description                = each.value.description
   # First letter must be uppercase
   protocol                   = title(each.value.protocol)
-  destination_port_range     = each.value.port != null ? each.value.port : "*"
+  destination_port_range     = (
+    each.value.port != null && each.value.to_port != null ? "${each.value.port}-${each.value.to_port}" : 
+    each.value.port != null ? each.value.port : "*"
+    )
   destination_address_prefixes = each.value.egress_cidrs != null ? each.value.egress_cidrs : var.egress_cidrs
   source_port_range          = "*"
   source_address_prefixes    = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs

--- a/edbterraform/data/terraform/azure/modules/security/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/security/variables.tf
@@ -1,5 +1,4 @@
-variable "subnet_id" {}
-variable "zone" {}
+variable "security_group_name" {}
 variable "resource_name" {}
 variable "region" {}
 variable "ports" {

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -50,6 +50,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
@@ -58,6 +59,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs = optional(list(string))
       })), [])
     }))
@@ -75,6 +77,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type        = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs       = optional(list(string))
         })), []
       )

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -60,7 +60,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs = optional(list(string))
+        cidrs = optional(list(string), [])
       })), [])
     }))
     machines = optional(map(object({
@@ -78,7 +78,7 @@ variable "spec" {
         description = optional(string, "default")
         type        = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs       = optional(list(string))
+        cidrs       = optional(list(string), [])
         })), []
       )
       volume = object({

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -40,8 +40,13 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
+      # TODO: Collapse service and regions ports into one
+      # 0.0.0.0/0 defaults can be blocked by IT.
+      # Instead, use region_ports as the default and if user wants access,
+      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       service_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
@@ -49,6 +54,7 @@ variable "spec" {
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         ingress_cidrs = optional(list(string))

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -49,16 +49,16 @@ variable "spec" {
         to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
-        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
-        ingress_cidrs = optional(list(string))
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -70,7 +70,7 @@ module "machine_ports" {
 resource "null_resource" "ensure_ssh_open" {
   count = local.additional_volumes_count
   triggers = {
-    "depends_on" = local.additional_volumes_length
+    "depends_on" = can(module.machine_ports) ? local.additional_volumes_length : local.additional_volumes_length
   }
 
   provisioner "remote-exec" {

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -19,6 +19,7 @@ variable "operating_system" {
     error_message = "only one, name or family must be defined"
   }
 }
+variable "network_name" {}
 variable "subnet_name" {}
 variable "name_id" { default = "0" }
 variable "use_agent" {
@@ -44,6 +45,10 @@ locals {
 }
 
 locals {
+  additional_volumes_length = length(lookup(var.machine.spec, "additional_volumes", []))
+  additional_volumes_count = local.additional_volumes_length > 0 ? 1 : 0
+  additional_volumes_map = { for i, v in lookup(var.machine.spec, "additional_volumes", []) : i => v }
+
   prefix = "/dev/disk/by-id/google-"
   base = ["sd"]
   letters = [

--- a/edbterraform/data/terraform/gcloud/modules/security/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/main.tf
@@ -8,7 +8,10 @@ resource "google_compute_firewall" "rules" {
   network = var.network_name
   allow {
     protocol = each.value.protocol
-    ports    = each.value.port != null ? [each.value.port] : []
+    ports    = (
+      each.value.port != null && each.value.to_port != null ? ["${each.value.port}-${each.value.to_port}"] :
+      each.value.port != null ? [each.value.port] : []
+    )
   }
   source_ranges = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
   destination_ranges = each.value.egress_cidrs != null ? each.value.egress_cidrs : var.egress_cidrs

--- a/edbterraform/data/terraform/gcloud/modules/security/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/main.tf
@@ -2,16 +2,30 @@ resource "google_compute_firewall" "rules" {
   for_each = {
     # preserve ordering
     for index, values in var.ports:
-      format("0%.3d",index) => values
+      format("0%.4d",index) => values
   }
   name    = "${each.value.protocol}-${var.region}-${var.name_id}-${each.key}"
   network = var.network_name
-  allow {
-    protocol = each.value.protocol
-    ports    = (
-      each.value.port != null && each.value.to_port != null ? ["${each.value.port}-${each.value.to_port}"] :
-      each.value.port != null ? [each.value.port] : []
-    )
+  priority = each.key
+  dynamic "allow" {
+    for_each = each.value.access != "deny" ? { "0" : each.value } : {}
+    content {
+      protocol = allow.value.protocol
+      ports    = (
+        allow.value.port != null && allow.value.to_port != null ? ["${allow.value.port}-${allow.value.to_port}"] :
+        allow.value.port != null ? [allow.value.port] : []
+      )
+    }
+  }
+  dynamic "deny" {
+    for_each = each.value.access == "deny" ? { "0" : each.value } : {}
+    content {
+      protocol = deny.value.protocol
+      ports    = (
+        deny.value.port != null && deny.value.to_port != null ? ["${deny.value.port}-${deny.value.to_port}"] :
+        deny.value.port != null ? [deny.value.port] : []
+      )
+    }
   }
   direction = lower(each.value.type) == "ingress" ? "INGRESS" : "EGRESS"
   source_ranges = lower(each.value.type) == "ingress" && each.value.cidrs != null ? each.value.cidrs : var.ingress_cidrs

--- a/edbterraform/data/terraform/gcloud/modules/security/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/main.tf
@@ -13,6 +13,14 @@ resource "google_compute_firewall" "rules" {
       each.value.port != null ? [each.value.port] : []
     )
   }
-  source_ranges = each.value.ingress_cidrs != null ? each.value.ingress_cidrs : var.ingress_cidrs
-  destination_ranges = each.value.egress_cidrs != null ? each.value.egress_cidrs : var.egress_cidrs
+  direction = lower(each.value.type) == "ingress" ? "INGRESS" : "EGRESS"
+  source_ranges = lower(each.value.type) == "ingress" && each.value.cidrs != null ? each.value.cidrs : var.ingress_cidrs
+  destination_ranges = lower(each.value.type) == "egress" && each.value.cidrs != null ? each.value.cidrs : var.egress_cidrs
+
+  lifecycle {
+    precondition {
+      condition     = each.value.type == "ingress" || each.value.type == "egress"
+      error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
+    }
+  }
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -38,8 +38,13 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
+      # TODO: Collapse service and regions ports into one
+      # 0.0.0.0/0 defaults can be blocked by IT.
+      # Instead, use region_ports as the default and if user wants access,
+      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       service_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
@@ -47,6 +52,7 @@ variable "spec" {
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
+        to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
         ingress_cidrs = optional(list(string))

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -47,16 +47,16 @@ variable "spec" {
         to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
-        ingress_cidrs = optional(list(string), ["0.0.0.0/0"])
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
         description = optional(string, "default")
-        ingress_cidrs = optional(list(string))
-        egress_cidrs = optional(list(string))
+        type = optional(string, "ingress")
+        cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -48,6 +48,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs = optional(list(string), ["0.0.0.0/0"])
       })), [])
       region_ports = optional(list(object({
@@ -56,6 +57,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs = optional(list(string))
       })), [])
     }))
@@ -74,9 +76,9 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type        = optional(string, "ingress")
+        access      = optional(string, "allow")
         cidrs       = optional(list(string))
-        })), []
-      )
+      })), [])
       volume = object({
         type      = string
         size_gb   = number

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -67,6 +67,16 @@ variable "spec" {
       zone_name     = string
       instance_type = string
       ip_forward    = optional(bool)
+      ssh_port      = optional(number, 22)
+      ports         = optional(list(object({
+        port        = optional(number)
+        to_port     = optional(number)
+        protocol    = string
+        description = optional(string, "default")
+        type        = optional(string, "ingress")
+        cidrs       = optional(list(string))
+        })), []
+      )
       volume = object({
         type      = string
         size_gb   = number
@@ -125,29 +135,6 @@ variable "spec" {
     templates = optional(list(string), [])
   })
 
-  validation {
-    condition = (
-      alltrue([
-        for machine in var.spec.machines :
-        length(machine.additional_volumes) == 0 ||
-        anytrue([for service_port in var.spec.regions[machine.region].service_ports :
-          service_port.port == 22
-        ])
-      ])
-    )
-    error_message = (
-      <<-EOT
-When using machines with additional volumes, SSH must be open.
-Ensure each region listed below has port 22 open under service_ports.
-Region - Machine:
-%{for name, spec in var.spec.machines~}
-%{if length(spec.additional_volumes) != 0~}
-  ${spec.region} - ${name}
-%{endif~}
-%{endfor~}
-EOT
-    )
-  }
 }
 
 locals {

--- a/infrastructure-examples/aws-ec2-v2.yml
+++ b/infrastructure-examples/aws-ec2-v2.yml
@@ -21,10 +21,18 @@ aws:
         main:
           zone: us-east-1b
           cidr: 10.2.30.0/24
-      service_ports: []
+      service_ports:
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
       region_ports:
-        - protocol: icmp
-          description: "ping"
+        - port: 22
+          to_port: 65
+          protocol: tcp
+          description: "ranges"
   machines:
     dbt2-driver:
       image_name: debian
@@ -43,9 +51,10 @@ aws:
       region: us-east-1
       zone_name: main
       ports:
-        - port: 22
-          protocol: tcp
-          description: "SSH"
+        - protocol: icmp
+          description: "ping"
+          cidrs:
+            - 10.2.20.0/24
       instance_type: c5.4xlarge
       volume:
         type: gp2

--- a/infrastructure-examples/azure-vms-v2.yml
+++ b/infrastructure-examples/azure-vms-v2.yml
@@ -30,9 +30,16 @@ azure:
         - port: 22
           protocol: tcp
           description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
       region_ports:
         - protocol: icmp
           description: "ping"
+        - port: 22
+          to_port: 65
+          protocol: tcp
+          description: "ranges"
   machines:
     dbt2-driver:
       image_name: rocky_8_7_0

--- a/infrastructure-examples/azure-vms-v2.yml
+++ b/infrastructure-examples/azure-vms-v2.yml
@@ -34,8 +34,6 @@ azure:
           cidrs:
             - 0.0.0.0/0
       region_ports:
-        - protocol: icmp
-          description: "ping"
         - port: 22
           to_port: 65
           protocol: tcp
@@ -55,6 +53,16 @@ azure:
       image_name: rocky
       region: westus
       zone_name: main
+      ports:
+        - protocol: icmp
+          description: "ping"
+          cidrs:
+            - 10.2.20.0/24
+        - protocol: icmp
+          description: "ping"
+          type: egress
+          cidrs:
+            - 10.2.20.0/24
       instance_type: Standard_D2s_v3
       volume:
         type: StandardSSD_LRS

--- a/infrastructure-examples/azure-vms-v2.yml
+++ b/infrastructure-examples/azure-vms-v2.yml
@@ -31,6 +31,7 @@ azure:
           protocol: tcp
           description: "SSH"
           type: ingress
+          access: allow
           cidrs:
             - 0.0.0.0/0
       region_ports:

--- a/infrastructure-examples/compute-engine-v2.yml
+++ b/infrastructure-examples/compute-engine-v2.yml
@@ -27,8 +27,6 @@ gcloud:
           cidrs:
             - 0.0.0.0/0
       region_ports:
-        - protocol: icmp
-          description: "ping"
         - port: 22
           to_port: 65
           protocol: tcp
@@ -48,6 +46,11 @@ gcloud:
       image_name: rocky
       region: us-west4
       zone_name: main
+      ports:
+        - protocol: icmp
+          description: "ping"
+          cidrs:
+            - 10.2.20.0/24
       instance_type: e2-standard-4
       volume:
         type: pd-standard

--- a/infrastructure-examples/compute-engine-v2.yml
+++ b/infrastructure-examples/compute-engine-v2.yml
@@ -24,6 +24,7 @@ gcloud:
           protocol: tcp
           description: "SSH"
           type: ingress
+          access: allow
           cidrs:
             - 0.0.0.0/0
       region_ports:

--- a/infrastructure-examples/compute-engine-v2.yml
+++ b/infrastructure-examples/compute-engine-v2.yml
@@ -23,9 +23,16 @@ gcloud:
         - port: 22
           protocol: tcp
           description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
       region_ports:
         - protocol: icmp
           description: "ping"
+        - port: 22
+          to_port: 65
+          protocol: tcp
+          description: "ranges"
   machines:
     dbt2-driver:
       image_name: debian


### PR DESCRIPTION
Allow for port ranges to be defined with an optional `to_port` key, under any port rule.
* Azure/Gcloud can define an optional `access` key and set it to `allow` (default) or `deny`.
  * This is not set for AWS as its security groups grant access but cannot deny access.

Fixes:
* GCloud spec updated to allow machine specific port rules, mimicking AWS security groups 
  * Requires unique naming within security module
* GCloud implicit dependencies updated for volume scripts
* Azure spec updated to allow machine specific port rules, mimicking AWS security groups
  * Each service/region port rule added to a machine if it has additional port rules so that a network interface security group can be used instead of the default security group
    * avoids conflicting priorities as each interface will have its own set of rules
    * if a machine has no port rules, it will skip creating the network interface security group and instead default to the subnets security group
* Azure implicit dependencies updated for volume scripts

Ref: https://github.com/EnterpriseDB/edb-terraform/pull/47
Commit Hash: 517bfcc