### PR TITLE
edb-terraform cli additional saved data

### DIFF
--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -130,6 +130,19 @@ InfrastructureFilePath = ArgumentConfig(
     help="cloud service provider infrastructure file path (YAML format). Default: %(default)s"
 )
 
+TerraformLockHcl = ArgumentConfig(
+    names = ['--lock-hcl-file',],
+    metavar='LOCK_HCL_FILE',
+    dest='lock_hcl_file',
+    type=Path,
+    required=False,
+    help='''
+    Terraform Lock HCL file is used to ensure the same package versions are used across architectures with terraform's cli.
+    If not used, terraform will try to grab the latest versions from each provider.
+    Default: %(default)s
+    '''
+)
+
 ProjectName = ArgumentConfig(
     names = ['--project-name',],
     metavar='PROJECT_NAME',
@@ -233,6 +246,7 @@ class Arguments:
             LogDirectory,
             LogStdout,
             UserTemplatesPath,
+            TerraformLockHcl,
         ]],
         'setup': ['Install needed software such as Terraform inside a bin directory\n',[
             BinPath,
@@ -332,7 +346,8 @@ class Arguments:
                 self.get_env('csp'),
                 self.get_env('run_validation'),
                 self.get_env('bin_path'),
-                self.get_env('user_templates')
+                self.get_env('user_templates'),
+                self.get_env('lock_hcl_file'),
             )
             return outputs
 

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from edbterraform.lib import generate_terraform
 from edbterraform.CLI import TerraformCLI
-from edbterraform import __dot_project__
+from edbterraform import __project_name__, __dot_project__, __version__
 from edbterraform.utils import logs
 
 ENVIRONMENT_PREFIX = 'ET_' # Appended to allow overrides of defaults
@@ -243,6 +243,7 @@ class Arguments:
         ]],
     })
     DEFAULT_COMMAND = next(iter(COMMANDS))
+    VERSION_MESSAGE=f'Version: {__version__}\n'
 
     def __init__(self, args:List[str]=sys.argv, parser=argparse.ArgumentParser()):
         self.parser = parser
@@ -258,7 +259,7 @@ class Arguments:
                     *(config.get_names()),
                     **(config.get_args())
                 )
-            subparser.usage = arg_configs[0]+subparser.format_usage()
+            subparser.usage = arg_configs[0]+self.VERSION_MESSAGE+subparser.format_usage()
 
         self.env = self.parser.parse_args()
 

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -84,6 +84,7 @@ def create_project_dir(project_directory, cloud_service_provider, infrastructure
     - cloud service provider modules
     - infrastructure.yml user file
       - edb-terraform.version key added
+    - hcl lock file
     '''
     if os.path.exists(project_directory):
         sys.exit("ERROR: directory %s already exists" % project_directory)

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -328,7 +328,8 @@ def generate_terraform(infra_file: Path, project_path: Path, csp: str, run_valid
     You can use now use terraform and see info about your boxes after creation:
     * cd {project_path}
     * terraform init
-    * terraform apply -auto-approve
+    * terraform plan -out terraform.plan
+    * terraform apply -auto-approve terraform.plan
     * terraform output -json {output_key}
     * ssh <ssh_user>@<ip-address> -i {ssh_file}
     ''').format(


### PR DESCRIPTION
To help with reproducing and confirming environments, the following changes were made:
* original infrastructure file input will be copied to `<project directory>/infrastructure.yml.bak`
  * `edb-terraform.version` key appended to the end of the yaml file
* terraform hcl lock file can be supplied with `edb-terraform generate`. This is needed to lock provider packages during `terraform init`.
  ```
    --lock-hcl-file LOCK_HCL_FILE
                        Terraform Lock HCL file is used to ensure the same package versions are used across architectures with terraform's cli. If not
                        used, terraform will try to grab the latest versions from each provider. Default: None | Default Environment variable:
                        ET_LOCK_HCL_FILE
   ```

Ref: https://github.com/EnterpriseDB/edb-benchmarks/pull/76