### PR TITLE
Biganimal fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ sudo pip3 install pip --upgrade
   - changes after every refresh with a new access_token
 ```console
 wget https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/api/get-token.sh
-sh get-token.sh
+bash get-token.sh
 # Visit the biganimal link to activate the device
 # ex. Please login to https://auth.biganimal.com/activate?user_code=JWPL-RCXL with your BigAnimal account
 #     Have you finished the login successfully. (y/n)
@@ -72,7 +72,7 @@ export BA_BEARER_TOKEN=<access_token>
 
 Refresh the token
 ```console
-sh get-token.sh --refresh <refresh_token>
+bash get-token.sh --refresh <refresh_token>
 # Save the new refresh token, if needed again
 export BA_BEARER_TOKEN=<access_token>
 ```

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -68,7 +68,7 @@ variable "tags" {
 
 locals {
   # resource expects a cloud provider prefix infront of its instance type
-  instance_type = !startswith("azure:", var.instance_type) ? format("azure:%s",var.instance_type) : var.instance_type
+  instance_type = !startswith("aws:", var.instance_type) ? format("aws:%s",var.instance_type) : var.instance_type
 
   volume_size = "${var.volume.size_gb} Gi"
 

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -96,7 +96,7 @@ output "region_biganimals" {
       spec = merge(biganimal_spec, {
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
-          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.id)
+          Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
         })
       })
     }...

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -100,7 +100,7 @@ output "region_biganimals" {
       spec = merge(biganimal_spec, {
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
-          Name = format("%s-%s-%s", name, var.spec.tags.cluster_name, random_id.apply.id)
+          Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
         })
       })
     }...


### PR DESCRIPTION
Fixes:
* BigAnimal: aws - modules referenced wrong provider, `azure`, instead of `aws`
* BigAnimal: aws/azure - `cluster_name` references local, instead of variable, since it may be omitted in configuration files.