### PR TITLE
Get aws, rds, ec2 instance ids, cluster ids from outputs

### DIFF
--- a/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
@@ -41,3 +41,11 @@ output "instance_type" {
 output "tags" {
   value = aws_rds_cluster.aurora_cluster.tags_all
 }
+
+output "cluster_id" {
+  value = aws_rds_cluster.aurora_cluster.id
+}
+
+output "resource_id" {
+  value = aws_rds_cluster_instance.aurora_instance.*.id
+}

--- a/edbterraform/data/terraform/aws/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/database/outputs.tf
@@ -41,3 +41,7 @@ output "dbname" {
 output "tags" {
   value = aws_db_instance.rds_server.tags_all
 }
+
+output "resource_id" {
+  value = aws_db_instance.rds_server.id
+}

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -37,3 +37,7 @@ output "additional_volumes" {
 output "operating_system" {
   value = var.operating_system
 }
+
+output "resource_id" {
+  value = aws_instance.machine.id
+}


### PR DESCRIPTION
Updated `outputs.tf ` to get the instance and/or cluster ids for aurora, rds (database), and ec2 (machines).