### PR TITLE
Add instance id for aws-dbt2-rds

### DIFF
--- a/edbterraform/data/terraform/aws/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/database/outputs.tf
@@ -43,5 +43,5 @@ output "tags" {
 }
 
 output "resource_id" {
-  value = aws_db_instance.rds_server.id
+  value = aws_db_instance.rds_server.identifier
 }


### PR DESCRIPTION
Changed one variable in outputs.tf to make this functional with aws-dbt2-rds metric-stats updates.