### PR TITLE
allow creation or destroying of resources while generating a project

### DIFF
--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -218,16 +218,12 @@ class TerraformCLI:
             logger.error(f'Error: ({e.output})')
             raise e
 
-    def apply_target_command(self, cwd):
+    def apply_command(self, cwd, validate_only=False):
         try:
             terraform_path = self.get_compatible_terraform()
-            command = [
-                terraform_path,
-                'apply',
-                '-input=false',
-                '-target=null_resource.validation',
-                '-auto-approve',
-            ]
+            command = [terraform_path, 'apply', '-input=false', '-auto-approve',]
+            if validate_only:
+                command.append('-target=null_resource.validation')
             output = execute_shell(
                     args=command,
                     environment=os.environ.copy(),

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -190,6 +190,34 @@ Validation = ArgumentConfig(
         '''
 )
 
+Apply = ArgumentConfig(
+    names = ['--apply',],
+    dest='apply',
+    action='store_true',
+    required=False,
+    default=False,
+    help='''
+        Requires terraform >= 1.3.6
+        `terraform apply`
+        If invalid, error will be displayed and project directory destroyed
+        Default: %(default)s
+        '''
+)
+
+Destroy = ArgumentConfig(
+    names = ['--destroy',],
+    dest='destroy',
+    action='store_true',
+    required=False,
+    default=False,
+    help='''
+        Requires terraform >= 1.3.6
+        Attempt to remove an existing project before creating a new one.
+        If invalid, error will be displayed and project directory destroyed
+        Default: %(default)s
+        '''
+)
+
 LogLevel = ArgumentConfig(
     names = ['--log-level',],
     dest='log_level',
@@ -252,6 +280,8 @@ class Arguments:
             WorkPath,
             CloudServiceProvider,
             Validation,
+            Apply,
+            Destroy,
             BinPath,
             LogLevel,
             LogFile,
@@ -347,8 +377,8 @@ class Arguments:
                 self.get_env('infra_file'),
                 self.get_env('project_path'),
                 self.get_env('csp'),
-                self.get_env('run_validation'),
                 self.get_env('bin_path'),
+                self.get_env('run_validation'),
             )
 
         if self.command == 'generate':
@@ -356,10 +386,12 @@ class Arguments:
                 self.get_env('infra_file'),
                 self.get_env('work_path') / self.get_env('project_name'),
                 self.get_env('csp'),
-                self.get_env('run_validation'),
                 self.get_env('bin_path'),
                 self.get_env('user_templates'),
                 self.get_env('lock_hcl_file'),
+                self.get_env('run_validation'),
+                self.get_env('apply'),
+                self.get_env('destroy'),
             )
             return outputs
 


### PR DESCRIPTION
New options added to `edb-terraform generate` allow a user to destroy a project as well as being able to apply after generating the terraform project:
* `--destroy` - attempt to destroy resources before creating a new project
* `--apply` - attempt to create resources with `terraform apply`

Terraform plan created with the filename `terraform.plan` under the project when using `--apply` or `--run-validation`.