### PR TITLE
support requesting persistent spot instances

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -31,6 +31,21 @@ resource "aws_instance" "machine" {
   subnet_id              = var.subnet_id
   vpc_security_group_ids = flatten([var.custom_security_group_ids, module.machine_ports.security_group_ids])
 
+  dynamic "instance_market_options" {
+    for_each = var.machine.spec.spot_max_price[*]
+    content {
+      market_type = "spot"
+      dynamic "spot_options" {
+        for_each = var.machine.spec.spot_max_price[*]
+        content {
+          instance_interruption_behavior = "hibernate"
+          max_price = var.machine.spec.spot_max_price
+          spot_instance_type = "persistent"
+        }
+      }
+    }
+  }
+
   root_block_device {
     delete_on_termination = "true"
     volume_size           = var.machine.spec.volume.size_gb

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -62,6 +62,7 @@ variable "spec" {
       type          = optional(string)
       image_name    = string
       count         = optional(number, 1)
+      spot_max_price = optional(number)
       region        = string
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({

--- a/infrastructure-examples/aws/machines-v2.yml
+++ b/infrastructure-examples/aws/machines-v2.yml
@@ -47,6 +47,7 @@ aws:
       tags:
         type: dbt2-driver
     pg1:
+      spot_max_price: .50
       image_name: rocky
       region: us-east-1
       zone_name: main


### PR DESCRIPTION
The infrastructure template now allows spot_max_price to be defined per AWS machine for the maximum hourly price.  Omitting this value continue previous behavior where an on-demand price will be used for an on-demand instance.