### PR TITLE
aws: refactor file system handling

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -121,7 +121,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1}  >> /tmp/mount.log 2>&1"
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1} ${coalesce(each.value.filesystem, local.filesystem)} >> /tmp/mount.log 2>&1"
     ]
 
     connection {

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -7,6 +7,7 @@ IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
 MOUNT_POINT=$2
 # Total number of nvme devices that should be present on the system
 N_NVME_DEVICE=$3
+FSTYPE=$4
 
 TARGET_NVME_DEVICE=""
 
@@ -58,11 +59,11 @@ if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
 fi
 
 # Mount point and volume creation
-sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
+sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
 sudo mkdir -p "${MOUNT_POINT}"
 # Get device UUID with blkid as exported format:
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}
+echo "${UUID} ${MOUNT_POINT} ${FSTYPE} noatime 0 0" | sudo tee -a /etc/fstab
+sudo mount -t "${FSTYPE}" -o noatime "${TARGET_NVME_DEVICE}" "${MOUNT_POINT}"

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -48,4 +48,6 @@ locals {
     for names in local.linux_device_names:
       format("%s,%s,%s", names...)
   ]
+  # Default filesystem related variables
+  filesystem = "xfs"
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -87,6 +87,7 @@ variable "spec" {
         iops        = optional(number)
         type        = string
         encrypted   = optional(bool)
+        filesystem  = optional(string)
       })), [])
       tags = optional(map(string), {})
     })), {})


### PR DESCRIPTION
Make xfs the default filesystem but make it a variable instead of hard coding it.  This is in preparation of being able to handle raw volumes for software volume management.

As a side effect we could also set different file system other than xfs.