### PR TITLE
Use filesystemmountopt for custom mount options

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -136,8 +136,7 @@ resource "null_resource" "setup_volume" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1} ${coalesce(each.value.filesystem, local.filesystem)} >> /tmp/mount.log 2>&1"
-    ]
+      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1} ${coalesce(each.value.filesystem, local.filesystem)} ${coalesce(try(join(",", each.value.mount_options), null), try(join(",", local.mount_options), null))} >> /tmp/mount.log 2>&1" ]
 
     connection {
       # Implicit dependency to null_resource.copy_setup_volume_script

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -8,8 +8,14 @@ MOUNT_POINT=$2
 # Total number of nvme devices that should be present on the system
 N_NVME_DEVICE=$3
 FSTYPE=$4
+FSMOUNTOPT=$5
 
 TARGET_NVME_DEVICE=""
+FSMOUNTOPT_ARG=""
+
+if [ ! "${FSMOUNTOPT}" = "" ]; then
+	FSMOUNTOPT_ARG="-o ${FSMOUNTOPT}"
+fi
 
 # Install nvme-cli
 if [ -f /etc/redhat-release ]; then
@@ -65,5 +71,5 @@ sudo mkdir -p "${MOUNT_POINT}"
 # UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 echo "Warning: Will be mounted by UUID in /etc/fstab"
 UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} ${FSTYPE} noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t "${FSTYPE}" -o noatime "${TARGET_NVME_DEVICE}" "${MOUNT_POINT}"
+echo "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
+eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -50,4 +50,5 @@ locals {
   ]
   # Default filesystem related variables
   filesystem = "xfs"
+  mount_options = ["noatime", "nodiratime", "logbsize=256k", "allocsize=1m"]
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -83,12 +83,13 @@ variable "spec" {
         encrypted = optional(bool)
       })
       additional_volumes = optional(list(object({
-        mount_point = string
-        size_gb     = number
-        iops        = optional(number)
-        type        = string
-        encrypted   = optional(bool)
-        filesystem  = optional(string)
+        mount_point   = string
+        size_gb       = number
+        iops          = optional(number)
+        type          = string
+        encrypted     = optional(bool)
+        filesystem    = optional(string)
+        mount_options = optional(string)
       })), [])
       tags = optional(map(string), {})
     })), {})

--- a/infrastructure-examples/aws/all.yml
+++ b/infrastructure-examples/aws/all.yml
@@ -72,6 +72,10 @@ aws:
           type: io2
           iops: 50000
           encrypted: false
+          filesystem: xfs
+          mount_options:
+            - noatime
+            - nodiratime
   databases:
     mydb1:
       region: us-east-1


### PR DESCRIPTION
Example:

      additional_volumes:
        - mount_point: /opt/pg_data size_gb: 20 type: io2 iops: 5000 encrypted: false filesystem: "xfs" filesystemmountopt: "noatime,nodiratime"