### PR TITLE
Surface DB instance id

### DIFF
--- a/edbterraform/data/terraform/aws/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/database/outputs.tf
@@ -45,3 +45,7 @@ output "tags" {
 output "resource_id" {
   value = aws_db_instance.rds_server.identifier
 }
+
+output "instance_id" {
+  value = aws_db_instance.rds_server.identifier
+}


### PR DESCRIPTION
This update is needed to allow the aws-dbt2-rds benchmark to gather Postgres error logs.