### PR TITLE
Terraform CLI - version bump to v1.5.5

### DIFF
--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -129,7 +129,9 @@ def binary_path(name, bin_path=None):
 class TerraformCLI:
     binary_name = 'terraform'
     min_version = Version(1, 3, 6)
-    max_version = Version(1, 4, 6)
+    # Version temporarily locked to 1.5.5
+    # Ref PR: https://github.com/EnterpriseDB/edb-terraform/pull/88
+    max_version = Version(1, 5, 5)
     arch_alias = {
         'x86_64': 'amd64',
     }


### PR DESCRIPTION
Version Bump to v1.5.5:

** *2023 August 10th: HashiCorp changed the Terraform license from MPL to BSL/BUSL-1.1*

- [HashiCorp Licensing](https://www.hashicorp.com/bsl)
- [BSL License Change Commit](https://github.com/hashicorp/terraform/commit/b145fbcaadf0fa7d0e7040eac641d9aef2a26433)
- [Terraform v1.5.5](https://github.com/hashicorp/terraform/releases/tag/v1.5.5)
- [Last MPL Licensed Commit](https://github.com/hashicorp/terraform/tree/8a085b427b74ce3829500a59508b77465f1bbef0)

Full list from the [forum discussion](https://discuss.hashicorp.com/t/hashicorp-projects-changing-license-to-business-source-license-v1-1/57106):
- [Terraform](https://github.com/hashicorp/terraform) - BSL
- [Vagrant](https://github.com/hashicorp/vagrant) - BSL
- [Packer](https://github.com/hashicorp/packer) - BSL
- [Waypoint](https://github.com/hashicorp/waypoint) - BSL
- [Boundary](https://github.com/hashicorp/boundary) - BSL
- [Consul](https://github.com/hashicorp/consul) - BSL
- [Consul API](https://github.com/hashicorp/consul/tree/main/api) - MPL under BSL repo
- [Nomad](https://github.com/hashicorp/nomad) - BSL
- [Nomad API](https://github.com/hashicorp/nomad/tree/main/api) - MPL under BSL repo
- [Vault](https://github.com/hashicorp/vault) - BSL
- [Vault SDK](https://github.com/hashicorp/vault/tree/main/sdk) - MPL under BSL repo
- [Vault API](https://github.com/hashicorp/vault/tree/main/api) - MPL under BSL repo
- [Vault Secrets Operator](https://github.com/hashicorp/vault-secrets-operator) - BSL
- [Vault CSI Provider](https://github.com/hashicorp/vault-csi-provider) - BSL
- [Go KMS Wrapping](https://github.com/hashicorp/go-kms-wrapping) - BSL