### PR TITLE
Allow for biganimal hosted resources

### DIFF
--- a/edbterraform/data/templates/aws/biganimal.tf.j2
+++ b/edbterraform/data/templates/aws/biganimal.tf.j2
@@ -10,6 +10,7 @@ module "biganimal_{{ region_ }}" {
   name                      = each.value.name
   name_id                   = module.spec.hex_id
 
+  cloud_account             = each.value.spec.cloud_account
   cluster_name              = module.spec.base.tags.cluster_name
   cluster_type              = each.value.spec.type
   node_count                = each.value.spec.node_count

--- a/edbterraform/data/templates/azure/biganimal.tf.j2
+++ b/edbterraform/data/templates/azure/biganimal.tf.j2
@@ -10,6 +10,7 @@ module "biganimal_{{ region_ }}" {
   name                      = each.value.name
   name_id                   = module.spec.hex_id
 
+  cloud_account             = each.value.spec.cloud_account
   cluster_name              = module.spec.base.tags.cluster_name
   cluster_type              = each.value.spec.type
   node_count                = each.value.spec.node_count

--- a/edbterraform/data/templates/gcloud/biganimal.tf.j2
+++ b/edbterraform/data/templates/gcloud/biganimal.tf.j2
@@ -10,6 +10,7 @@ module "biganimal_{{ region_ }}" {
   name                      = each.value.name
   name_id                   = module.spec.hex_id
 
+  cloud_account             = each.value.spec.cloud_account
   cluster_name              = module.spec.base.tags.cluster_name
   cluster_type              = each.value.spec.type
   node_count                = each.value.spec.node_count

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -6,6 +6,10 @@ variable "project" {
 
 variable "name" {}
 variable "name_id" {}
+variable "cloud_account" {
+  type = bool
+  description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
+}
 variable "cluster_name" {}
 variable "cluster_type" {
   type = string
@@ -72,6 +76,6 @@ locals {
 
   volume_size = "${var.volume.size_gb} Gi"
 
-  cloud_provider = "aws"
+  cloud_provider = var.cloud_account ? "aws" : "bah:aws"
   cluster_name = format("%s-%s", var.name, var.name_id)
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -136,6 +136,7 @@ variable "spec" {
       project        = object({
         id = optional(string)
       })
+      cloud_account = optional(bool, false)
       region         = string
       node_count     = number
       engine         = string

--- a/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
@@ -6,6 +6,10 @@ variable "project" {
 
 variable "name" {}
 variable "name_id" {}
+variable "cloud_account" {
+  type = bool
+  description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
+}
 variable "cluster_name" {}
 variable "cluster_type" {
   type = string
@@ -74,6 +78,6 @@ locals {
   volume_type = !startswith("azure", var.volume.type) && endswith("premiumstorage", var.volume.type) ? format("azure%s", var.volume.type) : var.volume.type
   volume_size = "${var.volume.size_gb} Gi"
 
-  cloud_provider = "azure"
+  cloud_provider = var.cloud_account ? "azure" : "bah:azure"
   cluster_name = format("%s-%s", var.name, var.name_id)
 }

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -117,6 +117,7 @@ variable "spec" {
       project        = object({
         id = optional(string)
       })
+      cloud_account = optional(bool, false)
       region         = string
       node_count     = number
       engine         = string

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
@@ -6,6 +6,10 @@ variable "project" {
 
 variable "name" {}
 variable "name_id" {}
+variable "cloud_account" {
+  type = bool
+  description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
+}
 variable "cluster_name" {}
 variable "cluster_type" {
   type = string
@@ -72,6 +76,6 @@ locals {
 
   volume_size = "${var.volume.size_gb} Gi"
 
-  cloud_provider = "gcp"
+  cloud_provider = var.cloud_account ? "gcp" : "bah:gcp"
   cluster_name = format("%s-%s", var.name, var.name_id)
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -132,6 +132,7 @@ variable "spec" {
       project        = object({
         id = optional(string)
       })
+      cloud_account = optional(bool, false)
       region         = string
       node_count     = number
       engine         = string

--- a/infrastructure-examples/aws/biganimal.yml
+++ b/infrastructure-examples/aws/biganimal.yml
@@ -9,6 +9,7 @@ aws:
     mydb2:
       project:
         id: prj_ziJPLQw3XxpR7nxV
+      cloud_account: true
       region: us-east-1
       type: ha
       node_count: 3

--- a/infrastructure-examples/azure/biganimal.yml
+++ b/infrastructure-examples/azure/biganimal.yml
@@ -9,6 +9,7 @@ azure:
     mydb2:
       project:
         id: prj_ziJPLQw3XxpR7nxV
+      cloud_account: true
       region: eastus
       type: ha
       node_count: 3

--- a/infrastructure-examples/gcloud/biganimal.yml
+++ b/infrastructure-examples/gcloud/biganimal.yml
@@ -9,6 +9,7 @@ gcloud:
     mydb2:
       project:
         id: prj_ziJPLQw3XxpR7nxV
+      cloud_account: true
       region: us-east4
       type: ha # Options: single | ha
       node_count: 3 # must be 1 when using type: single


### PR DESCRIPTION
We can allow the use of biganimal hosted resources instead of using your own cloud account.
`bah` must be appended to the `cloud_provider` name:
Ref: https://github.com/EnterpriseDB/terraform-provider-biganimal/discussions/309

`cloud_account` (`true` by default) can be set under biganimal configurations. To use biganimal hosted resources, `cloud_account` should be set to `false`.