### PR TITLE
GCP machine keyname handling

### DIFF
--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -34,14 +34,13 @@ def execute_shell(args, environment=os.environ, cwd=None):
         return process
     
     except subprocess.CalledProcessError as e:
-        logger.error("Failed to execute the command: %s", e.cmd)
-        logger.error("Return code is: %s", e.returncode)
+        logger.error("Command failed: %s", e.cmd)
+        logger.error("Return code: %s", e.returncode)
         logger.error("Output: %s", e.output)
         raise Exception(
-            "executable seems to be missing. Please install it "
-            "or check your PATH variable"
+            "If executable fails to execute, check the path."
+            "If options --destroy or --apply fail, manual intervention may be required to allow for a recovery."
         )
-
 
 def execute_live_shell(args, environment=os.environ, cwd=None):
     logger.info("Executing command: %s", ' '.join(args))

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -14,15 +14,14 @@ data "google_compute_image" "image" {
 }
 
 resource "google_compute_address" "public_ip" {
-  name         = format("public-ip-%s-%s", var.machine.name, var.name_id)
+  name         = local.public_ip_name
   region       = var.machine.spec.region
   address_type = "EXTERNAL"
   # TODO: Add labels once they are out of beta. 2023-05-05
 }
 
 resource "google_compute_instance" "machine" {
-  # name expects to be lower case
-  name           = lower(format("%s-%s-%s", var.cluster_name, var.machine.name, var.name_id))
+  name           = local.machine_name
   machine_type   = var.machine.spec.instance_type
   zone           = var.zone
   can_ip_forward = try(var.machine.spec.ip_forward, var.ip_forward)

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -44,6 +44,14 @@ locals {
   # we will do any needed handling and continue to treat
   # key-values as tags even though they are labels under gcloud
   labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
+
+  # public ip name and machine name must match regex: "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
+  # Handle underscore in machine name
+  name = lower(replace(var.machine.name, "_", "-"))
+  name_id = lower(replace(var.name_id, "_", "-"))
+  cluster_name = lower(replace(var.cluster_name, "_", "-"))
+  machine_name = format("%s-%s-%s", local.cluster_name, local.name, local.name_id)
+  public_ip_name = format("public-ip-%s-%s", local.machine_name, var.name_id)
 }
 
 locals {

--- a/infrastructure-examples/aws/all.yml
+++ b/infrastructure-examples/aws/all.yml
@@ -29,8 +29,7 @@ aws:
           protocol: tcp
           description: "PostgreSQL"
   machines:
-    dbt2-client:
-      type: dbt2-client
+    dbt2_client:
       region: us-east-1
       zone: us-east-1b
       instance_type: c5.4xlarge
@@ -40,9 +39,8 @@ aws:
         iops: 5000
         encrypted: false
       tags:
-        foo: bar
-    dbt2-driver:
-      type: dbt2-driver
+        type: dbt2-client
+    dbt2_driver:
       region: us-east-1
       zone: us-east-1c
       instance_type: c5.4xlarge
@@ -51,8 +49,8 @@ aws:
         size_gb: 50
         iops: 5000
         encrypted: false
+      tags: dbt2-driver
     pg1:
-      type: postgres
       region: us-east-1
       zone: us-east-1c
       instance_type: c5.4xlarge
@@ -76,6 +74,8 @@ aws:
           mount_options:
             - noatime
             - nodiratime
+      tags:
+        type: postgres
   databases:
     mydb1:
       region: us-east-1

--- a/infrastructure-examples/aws/edb-ra-3.yml
+++ b/infrastructure-examples/aws/edb-ra-3.yml
@@ -73,7 +73,7 @@ aws:
           protocol: tcp
           description: dbt2 client
   machines:
-    pem-server-0:
+    pem_server_0:
       instance_type: c5.xlarge
       volume:
         type: gp2
@@ -118,7 +118,7 @@ aws:
         postgres_group: postgres_server
         pooler_type: pgpool2
         pooler_local: false
-    postgres-server-1:
+    postgres_server_1:
       volume:
         type: gp2
         size: 50
@@ -149,7 +149,7 @@ aws:
         replication_type: synchronous
         pooler_type: pgpool2
         pooler_local: false
-    postgres-server-2:
+    postgres_server_2:
       volume:
         type: gp2
         size: 50
@@ -180,7 +180,7 @@ aws:
         replication_type: asynchronous
         pooler_type: pgpool2
         pooler_local: false
-    barman-server-0:
+    barman_server_0:
       instance_type: c5.2xlarge
       volume:
         type: gp2
@@ -202,7 +202,7 @@ aws:
         type: barman_server
         pg_type: epas
         index: 0
-    pooler-server-0:
+    pooler_server_0:
       instance_type: c5.xlarge
       volume:
         type: gp2
@@ -219,7 +219,7 @@ aws:
         index: 0
         pooler_type: pgpool2
         pooler_local: false
-    pooler-server-1:
+    pooler_server_1:
       instance_type: c5.xlarge
       volume:
         type: gp2
@@ -235,7 +235,7 @@ aws:
         index: 1
         pooler_type: pgpool2
         pooler_local: false
-    pooler-server-2:
+    pooler_server_2:
       instance_type: c5.xlarge
       volume:
         type: gp2

--- a/infrastructure-examples/aws/machines-v2.yml
+++ b/infrastructure-examples/aws/machines-v2.yml
@@ -34,7 +34,7 @@ aws:
           protocol: tcp
           description: "ranges"
   machines:
-    dbt2-driver:
+    dbt2_driver:
       image_name: debian
       region: us-east-1
       zone_name: proxy

--- a/infrastructure-examples/aws/machines.yml
+++ b/infrastructure-examples/aws/machines.yml
@@ -16,8 +16,7 @@ aws:
           protocol: tcp
           description: "SSH"
   machines:
-    dbt2-client:
-      type: dbt2-client
+    dbt2_client:
       region: us-east-1
       zone: us-east-1b
       instance_type: c5.4xlarge
@@ -28,8 +27,8 @@ aws:
         encrypted: false
       tags:
         foo: bar
-    dbt2-driver:
-      type: dbt2-driver
+        type: dbt2-client
+    dbt2_driver:
       region: us-east-1
       zone: us-east-1b
       instance_type: c5.4xlarge
@@ -38,6 +37,7 @@ aws:
         size_gb: 50
         iops: 5000
         encrypted: false
+      type: dbt2-driver
     pg1:
       type: postgres
       region: us-east-1

--- a/infrastructure-examples/azure/machines.yml
+++ b/infrastructure-examples/azure/machines.yml
@@ -34,16 +34,16 @@ azure:
           protocol: icmp
           description: "ping"
   machines:
-    dbt2-driver:
-      type: dbt2-driver
+    dbt2_driver:
       region: westus
       zone: 0
       instance_type: Standard_D2as_v4
       volume:
         type: StandardSSD_LRS
         size_gb: 50
+      tags:
+        type: dbt2-driver
     pg1:
-      type: postgres
       region: westus3
       zone: 2
       instance_type: Standard_D2as_v4
@@ -59,4 +59,5 @@ azure:
           type: UltraSSD_LRS
           size_gb: 50
           iops: 1000
-          
+      tags:
+        type: postgres

--- a/infrastructure-examples/gcloud/all.yml
+++ b/infrastructure-examples/gcloud/all.yml
@@ -29,8 +29,7 @@ gcloud:
     us-west4:
       cidr_block: 10.4.0.0/16
   machines:
-    dbt2-driver2:
-      type: dbt2-driver
+    dbt2_driver2:
       region: us-west1
       zone: us-west1-b
       instance_type: c2-standard-4
@@ -39,8 +38,8 @@ gcloud:
         size_gb: 50
       tags:
         foo: bar
-    dbt2-proxy:
-      type: proxy
+        type: dbt2-driver
+    dbt2_proxy:
       region: us-west2
       zone: us-west2-b
       ip_forward: true
@@ -48,6 +47,8 @@ gcloud:
       volume:
         type: pd-standard
         size_gb: 50
+      tags:
+        type: proxy
   databases:
     mydb1:
       region: us-west2
@@ -103,6 +104,8 @@ gcloud:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar
   alloy:
     mydb2:
       region: us-west4

--- a/infrastructure-examples/gcloud/alloy.yml
+++ b/infrastructure-examples/gcloud/alloy.yml
@@ -15,14 +15,15 @@ gcloud:
           protocol: tcp
           description: "SSH"
   machines:
-    dbt2-driver2:
-      type: dbt2-driver
+    dbt2_driver2:
       region: us-west4
       zone: us-west4-a
       instance_type: c2-standard-4
       volume:
         type: pd-standard
         size_gb: 50
+      tags:
+        type: dbt2-driver
   alloy:
     mydb2:
       region: us-west4
@@ -35,3 +36,5 @@ gcloud:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar

--- a/infrastructure-examples/gcloud/biganimal.yml
+++ b/infrastructure-examples/gcloud/biganimal.yml
@@ -32,3 +32,5 @@ gcloud:
         - cidr_block: 10.0.0.0/24
         - cidr_block: 127.0.0.1/32
           description: localhost
+      tags:
+        foo: bar

--- a/infrastructure-examples/gcloud/cloudsql.yml
+++ b/infrastructure-examples/gcloud/cloudsql.yml
@@ -27,16 +27,16 @@ gcloud:
           protocol: tcp
           description: "SSH"
   machines:
-    dbt2-driver2:
-      type: dbt2-driver
+    dbt2_driver2:
       region: us-west1
       zone: us-west1-b
       instance_type: c2-standard-4
       volume:
         type: pd-standard
         size_gb: 50
-    dbt2-proxy:
-      type: proxy
+      tags:
+        type: dbt2-driver
+    dbt2_proxy:
       region: us-west2
       zone: us-west2-b
       ip_forward: true
@@ -44,6 +44,8 @@ gcloud:
       volume:
         type: pd-standard
         size_gb: 50
+      tags:
+        type: proxy
   databases:
     mydb1:
       region: us-west2
@@ -71,3 +73,5 @@ gcloud:
           value: 1.25
         - name: work_mem
           value: 16000
+      tags:
+        foo: bar

--- a/infrastructure-examples/gcloud/machines-v2.yml
+++ b/infrastructure-examples/gcloud/machines-v2.yml
@@ -33,7 +33,7 @@ gcloud:
           protocol: tcp
           description: "ranges"
   machines:
-    dbt2-driver:
+    dbt2_driver:
       image_name: debian
       region: us-west4
       zone_name: proxy

--- a/infrastructure-examples/gcloud/machines.yml
+++ b/infrastructure-examples/gcloud/machines.yml
@@ -26,16 +26,16 @@ gcloud:
         - protocol: icmp
           description: "ping"
   machines:
-    dbt2-driver:
-      type: dbt2-driver
+    dbt2_driver:
       region: us-west2
       zone: us-west2-b
       instance_type: c2-standard-4
       volume:
         type: pd-standard
         size_gb: 50
+      tags:
+        type: dbt2-driver
     pg1:
-      type: postgres
       region: us-west1
       zone: us-west1-c
       instance_type: e2-standard-4
@@ -51,4 +51,6 @@ gcloud:
         - mount_point: /opt/pg_wal
           type: pd-ssd
           size_gb: 50
-          iops: null      
+          iops: null
+      tags:
+        type: postgres


### PR DESCRIPTION
Handle GCP regex restriction when using a machine key that contains an underscore:
* Regex restriction:
  * `^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$` 
* Resources:
  * `google_compute_address`
  * `google_compute_instance`

This is needed to allow referencing of variables with dot notation instead of brackets or escaped strings when using `terraform`, `ansible` and `jq`.