### PR TITLE
Biganimal retention updated to `1d`

### DIFF
--- a/edbterraform/data/terraform/aws/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/main.tf
@@ -30,7 +30,7 @@ resource "biganimal_cluster" "instance" {
             description = allowed_ip_ranges.value.description
         }
     }
-    # backup_retention_period = "30d"
+    backup_retention_period = "1d"
     csp_auth = false
     dynamic "pg_config" {
         for_each = { for key,values in var.settings: key=>values } 

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -16,7 +16,7 @@ variable "cluster_type" {
   default = "single"
 
   validation {
-    condition = contains(["single", "ha", "eha"], var.cluster_type)
+    condition = contains(["single", "ha"], var.cluster_type)
     error_message = (
       <<-EOT
       ${var.cluster_type} not a valid option.

--- a/edbterraform/data/terraform/azure/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/main.tf
@@ -30,7 +30,7 @@ resource "biganimal_cluster" "instance" {
             description = allowed_ip_ranges.value.description
         }
     }
-    # backup_retention_period = "30d"
+    backup_retention_period = "1d"
     csp_auth = false
     dynamic "pg_config" {
         for_each = { for key,values in var.settings: key=>values } 

--- a/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
@@ -16,7 +16,7 @@ variable "cluster_type" {
   default = "single"
 
   validation {
-    condition = contains(["single", "ha", "eha"], var.cluster_type)
+    condition = contains(["single", "ha"], var.cluster_type)
     error_message = (
       <<-EOT
       ${var.cluster_type} not a valid option.

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
@@ -28,7 +28,7 @@ resource "biganimal_cluster" "instance" {
             description = allowed_ip_ranges.value.description
         }
     }
-    # backup_retention_period = "30d"
+    backup_retention_period = "1d"
     csp_auth = false
     dynamic "pg_config" {
         for_each = { for key,values in var.settings: key=>values }


### PR DESCRIPTION
Omitted backup retention period causes provisioning to fail with biganimal provider `v0.6.0`.
Issue: https://github.com/EnterpriseDB/terraform-provider-biganimal/issues/322
Fix be apart of `v0.6.1` release next week.

We need the minimum retention period so we will set it to `1d`.
PR: https://github.com/EnterpriseDB/edb-terraform/pull/84
Commit: 2f6660901230e73e0617f2c28d6a9316d8e5a7fc

```
# module.biganimal_us_east4["mydb2"].biganimal_cluster.instance will be created
  + resource "biganimal_cluster" "instance" {
      + backup_retention_period       = "1d"
      + cloud_provider                = "bah:gcp"
      + cluster_id                    = (known after apply)
      + cluster_name                  = (known after apply)
      + cluster_type                  = (known after apply)
      + connection_uri                = (known after apply)
      + created_at                    = (known after apply)
      + csp_auth                      = false
      + faraway_replica_ids           = (known after apply)
      + first_recoverability_point_at = (known after apply)
      + id                            = (known after apply)
      + instance_type                 = "gcp:e2-highcpu-4"
      + logs_url                      = (known after apply)
      + metrics_url                   = (known after apply)
      + pg_type                       = "epas"
      + pg_version                    = "14"
      + phase                         = (known after apply)
      + private_networking            = false
      + read_only_connections         = false
      + region                        = "us-east4"
      + resizing_pvc                  = (known after apply)
      + ro_connection_uri             = (known after apply)

      + allowed_ip_ranges {
          + cidr_block  = "10.0.0.0/24"
          + description = "default description"
        }
      + allowed_ip_ranges {
          + cidr_block  = "127.0.0.1/32"
          + description = "localhost"
        }

      + cluster_architecture {
          + id    = "single"
          + name  = (known after apply)
          + nodes = 1
        }

      + pg_config {
          + name  = "autovacuum_max_workers"
          + value = "5"
        }
      + pg_config {
          + name  = "autovacuum_vacuum_cost_limit"
          + value = "3000"
        }
      + pg_config {
          + name  = "checkpoint_completion_target"
          + value = "0.9"
        }
      + pg_config {
          + name  = "checkpoint_timeout"
          + value = "15min"
        }
      + pg_config {
          + name  = "cpu_tuple_cost"
          + value = "0.03"
        }
      + pg_config {
          + name  = "effective_cache_size"
          + value = "0.75 * ram"
        }
      + pg_config {
          + name  = "maintenance_work_mem"
          + value = "(0.15 * (ram - shared_buffers) / autovacuum_max_workers) > 1GB ? 1GB : (0.15 * (ram - shared_buffers) / autovacuum_max_workers)"
        }
      + pg_config {
          + name  = "max_connections"
          + value = "300"
        }
      + pg_config {
          + name  = "random_page_cost"
          + value = "1.25"
        }
      + pg_config {
          + name  = "shared_buffers"
          + value = "((0.25 * ram) > 80GB) ? 80GB : (0.25 * ram)"
        }
      + pg_config {
          + name  = "tcp_keepalives_idle"
          + value = "120"
        }
      + pg_config {
          + name  = "tcp_keepalives_interval"
          + value = "30"
        }
      + pg_config {
          + name  = "wal_buffers"
          + value = "64MB"
        }
      + pg_config {
          + name  = "wal_compression"
          + value = "on"
        }
      + pg_config {
          + name  = "work_mem"
          + value = "16000"
        }

      + storage {
          + iops              = (known after apply)
          + size              = "10 Gi"
          + throughput        = (known after apply)
          + volume_properties = "pd-ssd"
          + volume_type       = "pd-ssd"
        }
    }
```
