### PR TITLE
Fix root module outputs

### DIFF
--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -66,16 +66,34 @@
   }  
 } %}
 locals {
-  # outputs set with the help of jinja2 in edb-terraform
-  outputs = {
+  # Module names set with jinja2 in edb-terraform
+  # Modules cannot be referenced dynamically.
+  modules = {
 {% for type, attributes in boxes.items() if attributes["active"] %}
-    "{{type}}" = merge(
+    {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-    tomap([for key, values in {{module}}[*]: values]...),
+      {{ module }},
 {%   endfor %}
-    )
+    ])
 {% endfor %}
+  }
+}
+
+output "modules" {
+  description = "Variable which holds all final modules."
+  value = local.modules
+  sensitive = true
+}
+
+locals {
+  # Set final output
+  outputs = {
+    for type, modules in local.modules: type => merge(jsondecode(
+    <<-EOT
+    [ %{ for num, module in modules ~}${ jsonencode(module) }%{ if tonumber(num) < length(modules)-1 ~},%{ endif ~}%{ endfor ~} ]
+    EOT
+    )...)
   }
   servers = { "servers" = local.outputs }
 }

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -60,16 +60,34 @@
   }
 } %}
 locals {
-  # outputs set with the help of jinja2 in edb-terraform
-  outputs = {
+  # Module names set with jinja2 in edb-terraform
+  # Modules cannot be referenced dynamically.
+  modules = {
 {% for type, attributes in boxes.items() if attributes["active"] %}
-    "{{type}}" = merge(
+    {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-    tomap([for key, values in {{module}}[*]: values]...),
+      {{ module }},
 {%   endfor %}
-    )
+    ])
 {% endfor %}
+  }
+}
+
+output "modules" {
+  description = "Variable which holds all final modules."
+  value = local.modules
+  sensitive = true
+}
+
+locals {
+  # Set final output
+  outputs = {
+    for type, modules in local.modules: type => merge(jsondecode(
+    <<-EOT
+    [ %{ for num, module in modules ~}${ jsonencode(module) }%{ if tonumber(num) < length(modules)-1 ~},%{ endif ~}%{ endfor ~} ]
+    EOT
+    )...)
   }
   servers = { "servers" = local.outputs }
 }

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -60,16 +60,34 @@
   }  
 } %}
 locals {
-  # outputs set with the help of jinja2 in edb-terraform
-  outputs = {
+  # Module names set with jinja2 in edb-terraform
+  # Modules cannot be referenced dynamically.
+  modules = {
 {% for type, attributes in boxes.items() if attributes["active"] %}
-    "{{type}}" = merge(
+    {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-    tomap([for key, values in {{module}}[*]: values]...),
+      {{ module }},
 {%   endfor %}
-    )
+    ])
 {% endfor %}
+  }
+}
+
+output "modules" {
+  description = "Variable which holds all final modules."
+  value = local.modules
+  sensitive = true
+}
+
+locals {
+  # Set final output
+  outputs = {
+    for type, modules in local.modules: type => merge(jsondecode(
+    <<-EOT
+    [ %{ for num, module in modules ~}${ jsonencode(module) }%{ if tonumber(num) < length(modules)-1 ~},%{ endif ~}%{ endfor ~} ]
+    EOT
+    )...)
   }
   servers = { "servers" = local.outputs }
 }


### PR DESCRIPTION
Root module should be able to surface any variable set by any module:
* Update jinja to create a map of module name => list of modules
* set modules as a root output
* set final output with jsonencoding/decoding and templating to create terraform objects instead of terraform maps

Ref PR: https://github.com/EnterpriseDB/edb-terraform/pull/26