### PR TITLE
Volume refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ describing the target cloud infrastructure.
 ## Prerequisites and installation
 
 The following components must be installed on the system:
-- Python3 >= 3.6
+- Terraform >= 1.3.6
+- Python >= 3.6
+- Bash
+- JQ
 - AWS CLI
 - GCloud CLI
 - Azure CLI
 - BigAnimal token (CLI currently optional)
-- Terraform >= 1.3.6
 
 ## Infrastructure file examples
 

--- a/edbterraform/data/terraform/aws/modules/machine/lsblk_devices.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/lsblk_devices.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SSH_CONNECTION="$1"
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+CMD="sudo lsblk -o NAME,KNAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,SERIAL,MODEL,VENDOR,REV,LABEL,UUID,PARTTYPE,PARTLABEL,PARTUUID,SCHED --json 2>&1"
+
+RESULT=$(ssh $SSH_OPTIONS $SSH_CONNECTION $CMD)
+RC=$?
+if [[ $RC -ne 0 ]];
+then
+  printf "%s\n" "$RESULT" 1>&2
+  exit $RC
+fi
+
+jq -n --arg base64json "$(printf %s $RESULT | base64 | tr -d \\n)" '{"base64json": $base64json}'

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -65,12 +65,13 @@ resource "aws_instance" "machine" {
 resource "null_resource" "ensure_ssh_open" {
   count = local.additional_volumes_count
   triggers = {
-    "depends_on" = can(module.machine_ports) ? local.additional_volumes_length : local.additional_volumes_length
+    "depends0" = local.additional_volumes_length
+    "depends1" = can(module.machine_ports)
   }
 
   provisioner "remote-exec" {
     inline = [
-      "echo connected",
+      "printf 'connected\n'",
     ]
     connection {
       type        = "ssh"
@@ -83,6 +84,23 @@ resource "null_resource" "ensure_ssh_open" {
   }
 }
 
+resource "toolbox_external" "initial_block_devices" {
+  count = local.additional_volumes_count
+  query = {
+    depend0 = can(null_resource.ensure_ssh_open)
+    depends1 = local.additional_volumes_length
+  }
+  program = [
+    "bash",
+    "-c",
+    "${abspath(path.module)}/lsblk_devices.sh '${var.operating_system.ssh_user}@${aws_instance.machine.public_ip} -p ${var.machine.spec.ssh_port} -i ${var.machine.spec.operating_system.ssh_private_key_file}'",
+  ]
+}
+
+locals {
+  initial_block_devices = can(toolbox_external.initial_block_devices.0.result) ? jsondecode(base64decode(toolbox_external.initial_block_devices.0.result.base64json)) : {}
+}
+
 resource "aws_ebs_volume" "ebs_volume" {
   for_each = local.additional_volumes_map 
 
@@ -92,8 +110,8 @@ resource "aws_ebs_volume" "ebs_volume" {
   iops              = each.value.type == "io2" ? each.value.iops : each.value.type == "io1" ? each.value.iops : null
   encrypted         = each.value.encrypted
 
-  # Implicit dependency to aws_ebs_volume.ebs_volume
-  tags = can(null_resource.ensure_ssh_open) ? var.tags : var.tags
+  # Implicit dependency to initial devices check
+  tags = can(toolbox_external.initial_block_devices) ? var.tags : var.tags
 }
 
 resource "aws_volume_attachment" "attached_volume" {
@@ -109,43 +127,100 @@ resource "aws_volume_attachment" "attached_volume" {
   }
 }
 
-resource "null_resource" "copy_setup_volume_script" {
+resource "toolbox_external" "all_block_devices" {
   count = local.additional_volumes_count
-  triggers = {
-    "depends_on" = local.additional_volumes_length
+  query = {
+    depend0 = can(aws_volume_attachment.attached_volume)
+    depends1 = local.additional_volumes_length
   }
-
-  provisioner "file" {
-    content     = file("${abspath(path.module)}/setup_volume.sh")
-    destination = "/tmp/setup_volume.sh"
-
-    connection {
-      # Implicit dependency to null_resource.attached_volume
-      type        = can(aws_volume_attachment.attached_volume) ? "ssh" : "ssh"
-      user        = var.operating_system.ssh_user
-      host        = aws_instance.machine.public_ip
-      port        = var.machine.spec.ssh_port
-      agent       = var.use_agent # agent and private_key conflict
-      private_key = var.use_agent ? null : var.ssh_priv_key
-    }
-  }
+  program = [
+    "bash",
+    "-c",
+    "${abspath(path.module)}/lsblk_devices.sh '${var.operating_system.ssh_user}@${aws_instance.machine.public_ip} -p ${var.machine.spec.ssh_port} -i ${var.machine.spec.operating_system.ssh_private_key_file}'",
+  ]
 }
 
-resource "null_resource" "setup_volume" {
-  for_each = local.additional_volumes_map
-  provisioner "remote-exec" {
-    inline = [
-      "chmod a+x /tmp/setup_volume.sh",
-      "/tmp/setup_volume.sh ${element(local.string_device_names, tonumber(each.key))} ${each.value.mount_point} ${length(lookup(var.machine.spec, "additional_volumes", [])) + 1} ${coalesce(each.value.filesystem, local.filesystem)} ${coalesce(try(join(",", each.value.mount_options), null), try(join(",", local.mount_options), null))} >> /tmp/mount.log 2>&1" ]
+locals {
+  all_block_devices = can(toolbox_external.all_block_devices.0.result) ? jsondecode(base64decode(toolbox_external.all_block_devices.0.result.base64json)) : {}
+}
 
-    connection {
-      # Implicit dependency to null_resource.copy_setup_volume_script
-      type        = can(null_resource.copy_setup_volume_script) ? "ssh" : "ssh"
-      user        = var.operating_system.ssh_user
-      host        = aws_instance.machine.public_ip
-      port        = var.machine.spec.ssh_port
-      agent       = var.use_agent # agent and private_key conflict
-      private_key = var.use_agent ? null : var.ssh_priv_key
+locals {
+  script_variables = [
+    for key, values in local.additional_volumes_map: {
+        "device_names": element(local.linux_device_names, tonumber(key))
+        "number_of_volumes": length(lookup(var.machine.spec, "additional_volumes", [])) + 1
+        "mount_point": values.mount_point
+        "mount_options": coalesce(try(join(",", values.mount_options), null), try(join(",", local.mount_options), null))
+        "filesystem": coalesce(values.filesystem, local.filesystem)
     }
+  ]
+}
+
+resource "toolbox_external" "setup_volumes" {
+  count = local.additional_volumes_count
+  query = {
+    depend0 = can(toolbox_external.all_block_devices)
+    depends1 = local.additional_volumes_length
   }
+  program = [
+    "bash",
+    "-c",
+    <<-EOT
+    CONNECTION="${var.operating_system.ssh_user}@${aws_instance.machine.public_ip}"
+    SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    SFTP_OPTIONS="-P ${var.machine.spec.ssh_port} -i ${var.machine.spec.operating_system.ssh_private_key_file} $SSH_OPTIONS"
+
+    # Copy script to /tmp directory
+    CMD="sftp -b <(printf '%s\n' 'put ${abspath(path.module)}/setup_volume.sh') $SFTP_OPTIONS $CONNECTION:/tmp/"
+    RESULT=$(eval $CMD)
+    RC=$?
+    if [[ $RC -ne 0 ]];
+    then
+      printf "%s\n" "$RESULT" 1>&2
+      exit $RC
+    fi
+
+    ADDITIONAL_SSH_OPTIONS="-p ${var.machine.spec.ssh_port} -i ${var.machine.spec.operating_system.ssh_private_key_file}"
+    SSH_CMD="ssh $CONNECTION $ADDITIONAL_SSH_OPTIONS $SSH_OPTIONS"
+
+    # Set script as executable
+    CMD="$SSH_CMD chmod a+x /tmp/setup_volume.sh 2>&1"
+    RESULT=$($CMD)
+    RC=$?
+    if [[ $RC -ne 0 ]];
+    then
+      printf "%s\n" "$RESULT" 1>&2
+      exit $RC
+    fi
+
+    # Execute Script
+    CMD="$SSH_CMD /tmp/setup_volume.sh ${base64encode(jsonencode(local.script_variables))} >> /tmp/mount.log 2>&1"
+    RESULT=$($CMD)
+    RC=$?
+    if [[ $RC -ne 0 ]];
+    then
+      printf "%s\n" "$RESULT" 1>&2
+      exit $RC
+    fi
+
+    jq -n --arg base64json "$(printf %s $result | base64 | tr -d \\n)" '{"base64json": $base64json}'
+    EOT
+  ]
+}
+
+resource "toolbox_external" "final_block_devices" {
+  count = local.additional_volumes_count
+  query = {
+    depend0 = can(toolbox_external.setup_volumes)
+    depends1 = local.additional_volumes_length
+  }
+  program = [
+    "bash",
+    "-c",
+    "${abspath(path.module)}/lsblk_devices.sh '${var.operating_system.ssh_user}@${aws_instance.machine.public_ip} -p ${var.machine.spec.ssh_port} -i ${var.machine.spec.operating_system.ssh_private_key_file}'",
+  ]
+}
+
+locals {
+  final_block_devices = can(toolbox_external.final_block_devices.0.result) ? jsondecode(base64decode(toolbox_external.final_block_devices.0.result.base64json)) : {}
 }

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -34,6 +34,14 @@ output "additional_volumes" {
   value = var.machine.spec.additional_volumes
 }
 
+output "block_devices" {
+  value = {
+    initial = local.initial_block_devices
+    all = local.all_block_devices
+    final = local.final_block_devices
+  }
+}
+
 output "operating_system" {
   value = var.operating_system
 }

--- a/edbterraform/data/terraform/aws/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/providers.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.7.0"
     }
+    toolbox = {
+      source = "bryan-bar/toolbox"
+      version = "~> 0.1.4"
+    }
   }
 }

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -1,75 +1,88 @@
 #!/bin/bash
+set -euo pipefail
 
-# Expected EBS device paths: "/dev/sdX,/dev/sdY"
-IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
-
-# Mount point
-MOUNT_POINT=$2
-# Total number of nvme devices that should be present on the system
-N_NVME_DEVICE=$3
-FSTYPE=$4
-FSMOUNTOPT=$5
-
-TARGET_NVME_DEVICE=""
-FSMOUNTOPT_ARG=""
-
-if [ ! "${FSMOUNTOPT}" = "" ]; then
-	FSMOUNTOPT_ARG="-o ${FSMOUNTOPT}"
-fi
-
-# Install nvme-cli
+# Install nvme-cli and jq
 if [ -f /etc/redhat-release ]; then
-	sudo yum install nvme-cli -y
+	sudo yum clean all
+	sudo yum install nvme-cli jq -y
 fi
 if [ -f /etc/debian_version ]; then
 	sudo apt update -y
-	sudo apt install nvme-cli -y
+	sudo apt install nvme-cli jq -y
 fi
 
-# Wait for the availability of all the NVME devices that should be
-# present on the system.
-while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
-	sleep 2
-	COUNTER=$((COUNTER + 1))
-	if [ $COUNTER -ge 10 ]; then
-		echo "ERROR: unable to get the full list of NVME devices after 20s"
-		break
+# Expects a base64encoded json object
+SCRIPT_INPUTS=$(printf %s "$1" | base64 -d | jq -rc '.[]')
+
+for item in ${SCRIPT_INPUTS}
+do
+	_jq_key() {
+		printf %s "$1" | jq -rc "$2"
+	}
+	# Expected device paths: ["/dev/sdX","/dev/sdY"]
+	TARGET_DEVICES=$(_jq_key "$item" '.device_names[]')
+
+	# Mount point
+	MOUNT_POINT=$(_jq_key "$item" '.mount_point')
+	# Total number of nvme devices that should be present on the system
+	N_NVME_DEVICE=$(_jq_key "$item" '.number_of_volumes')
+	FSTYPE=$(_jq_key "$item" '.filesystem')
+	FSMOUNTOPT=$(_jq_key "$item" '.mount_options')
+
+	TARGET_NVME_DEVICE=""
+	FSMOUNTOPT_ARG=""
+
+	if [ ! "${FSMOUNTOPT}" = "" ]; then
+		FSMOUNTOPT_ARG="-o ${FSMOUNTOPT}"
 	fi
+
+	# Wait for the availability of all the NVME devices that should be
+	# present on the system.
+	COUNTER=0
+	while [ "$(sudo nvme list | tail -n +3 | wc -l)" -ne "${N_NVME_DEVICE}" ]; do
+		sleep 2
+		COUNTER=$((COUNTER + 1))
+		if [ $COUNTER -ge 10 ]; then
+			printf "%s\n" "ERROR: unable to get the full list of NVME devices after 20s"
+			break
+		fi
+	done
+
+	# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+	# NVME device.
+	for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+		FOUND_DEVICE=$(sudo nvme id-ctrl -v "${NVME_DEVICE}" | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+
+		# /dev/ might be dropped at times so we need to check both cases
+	    if [[ "${TARGET_DEVICES[*]}" =~ "$FOUND_DEVICE" ]] || [[ "${TARGET_DEVICES[*]}" =~ "/dev/$FOUND_DEVICE" ]]; then
+			TARGET_NVME_DEVICE=${NVME_DEVICE}
+			break
+		fi
+	done;
+
+	# Fallback to device names
+	for DEVICE_NAME in "${TARGET_DEVICES[@]}"; do
+		if [[ -e ${DEVICE_NAME} ]]; then
+			TARGET_NVME_DEVICE=${DEVICE_NAME}
+			printf "%s\n" "Warning: Falling back to device name"
+			printf "%s\n" "Warning: Device names might change if instance is stopped or volumes are detached/added"
+			break
+		fi
+	done;
+
+	if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+		printf "%s\n" "ERROR: unable to find the NVME device for ${TARGET_DEVICES}" 1>&2
+		exit 2
+	fi
+
+	# Mount point and volume creation
+	sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
+	sudo mkdir -p "${MOUNT_POINT}"
+	# Get device UUID with blkid as exported format:
+	# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	printf "%s\n" "Warning: Will be mounted by UUID in /etc/fstab"
+	UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+	printf "%s\n" "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
+	eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"
+
 done
-
-# Based on the target EBS device (/dev/sdX) we have to find the corresponding
-# NVME device.
-for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
-	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
-
-	# /dev/ might be dropped at times so we need to check both cases
-    if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ] || [ "/dev/$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
-		TARGET_NVME_DEVICE=${NVME_DEVICE}
-		break
-	fi
-done;
-
-# Fallback to device names
-for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
-	if [[ -e ${DEVICE_NAME} ]]; then
-		TARGET_NVME_DEVICE=${DEVICE_NAME}
-		echo "Warning: Falling back to device name"
-		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
-		break
-	fi
-done;
-
-if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
-	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
-	exit 2
-fi
-
-# Mount point and volume creation
-sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
-sudo mkdir -p "${MOUNT_POINT}"
-# Get device UUID with blkid as exported format:
-# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-echo "Warning: Will be mounted by UUID in /etc/fstab"
-UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
-eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -42,12 +42,6 @@ locals {
     for letter in local.letters:
       formatlist("${local.prefix}%s${letter}", local.base)
   ]
-  # List(String) with comma delimiter
-  # [ "/dev/sdf,/dev/xvdf,/dev/hdf" , ]
-  string_device_names = [
-    for names in local.linux_device_names:
-      format("%s,%s,%s", names...)
-  ]
   # Default filesystem related variables
   filesystem = "xfs"
   mount_options = ["noatime", "nodiratime", "logbsize=256k", "allocsize=1m"]

--- a/edbterraform/data/terraform/azure/modules/machine/lsblk_devices.sh
+++ b/edbterraform/data/terraform/azure/modules/machine/lsblk_devices.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SSH_CONNECTION="$1"
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+CMD="sudo lsblk -o NAME,KNAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,SERIAL,MODEL,VENDOR,REV,LABEL,UUID,PARTTYPE,PARTLABEL,PARTUUID,SCHED --json 2>&1"
+
+RESULT=$(ssh $SSH_OPTIONS $SSH_CONNECTION $CMD)
+RC=$?
+if [[ $RC -ne 0 ]];
+then
+  printf "%s\n" "$RESULT" 1>&2
+  exit $RC
+fi
+
+jq -n --arg base64json "$(printf %s $RESULT | base64 | tr -d \\n)" '{"base64json": $base64json}'

--- a/edbterraform/data/terraform/azure/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/outputs.tf
@@ -24,6 +24,14 @@ output "additional_volumes" {
   value = var.additional_volumes
 }
 
+output "block_devices" {
+  value = {
+    initial = local.initial_block_devices
+    all = local.all_block_devices
+    final = local.final_block_devices
+  }
+}
+
 output "operating_system" {
   value = var.operating_system
 }

--- a/edbterraform/data/terraform/azure/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.37.0"
     }
+    toolbox = {
+      source = "bryan-bar/toolbox"
+      version = "~> 0.1.4"
+    }
   }
   required_version = ">= 1.3.6"
 }

--- a/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/azure/modules/machine/setup_volume.sh
@@ -1,68 +1,88 @@
 #!/bin/bash
+set -euo pipefail
 
-# Expected EBS device paths: "/dev/sdX,/dev/sdY"
-IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
-
-# Mount point
-MOUNT_POINT=$2
-# Total number of nvme devices that should be present on the system
-N_NVME_DEVICE=$3
-
-TARGET_NVME_DEVICE=""
-
-# Install nvme-cli
+# Install nvme-cli and jq
 if [ -f /etc/redhat-release ]; then
-	sudo yum install nvme-cli -y
+	sudo yum clean all
+	sudo yum install nvme-cli jq -y
 fi
 if [ -f /etc/debian_version ]; then
 	sudo apt update -y
-	sudo apt install nvme-cli -y
+	sudo apt install nvme-cli jq -y
 fi
 
-# Wait for the availability of all the NVME devices that should be
-# present on the system.
-while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
-	sleep 2
-	COUNTER=$((COUNTER + 1))
-	if [ $COUNTER -ge 10 ]; then
-		echo "ERROR: unable to get the full list of NVME devices after 20s"
-		break
+# Expects a base64encoded json object
+SCRIPT_INPUTS=$(printf %s "$1" | base64 -d | jq -rc '.[]')
+
+for item in ${SCRIPT_INPUTS}
+do
+	_jq_key() {
+		printf %s "$1" | jq -rc "$2"
+	}
+	# Expected device paths: ["/dev/sdX","/dev/sdY"]
+	TARGET_DEVICES=$(_jq_key "$item" '.device_names[]')
+
+	# Mount point
+	MOUNT_POINT=$(_jq_key "$item" '.mount_point')
+	# Total number of nvme devices that should be present on the system
+	N_NVME_DEVICE=$(_jq_key "$item" '.number_of_volumes')
+	FSTYPE=$(_jq_key "$item" '.filesystem')
+	FSMOUNTOPT=$(_jq_key "$item" '.mount_options')
+
+	TARGET_NVME_DEVICE=""
+	FSMOUNTOPT_ARG=""
+
+	if [ ! "${FSMOUNTOPT}" = "" ]; then
+		FSMOUNTOPT_ARG="-o ${FSMOUNTOPT}"
 	fi
+
+	# Wait for the availability of all the NVME devices that should be
+	# present on the system.
+	COUNTER=0
+	while [ "$(sudo nvme list | tail -n +3 | wc -l)" -ne "${N_NVME_DEVICE}" ]; do
+		sleep 2
+		COUNTER=$((COUNTER + 1))
+		if [ $COUNTER -ge 10 ]; then
+			printf "%s\n" "ERROR: unable to get the full list of NVME devices after 20s"
+			break
+		fi
+	done
+
+	# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+	# NVME device.
+	for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+		FOUND_DEVICE=$(sudo nvme id-ctrl -v "${NVME_DEVICE}" | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+
+		# /dev/ might be dropped at times so we need to check both cases
+	    if [[ "${TARGET_DEVICES[*]}" =~ "$FOUND_DEVICE" ]] || [[ "${TARGET_DEVICES[*]}" =~ "/dev/$FOUND_DEVICE" ]]; then
+			TARGET_NVME_DEVICE=${NVME_DEVICE}
+			break
+		fi
+	done;
+
+	# Fallback to device names
+	for DEVICE_NAME in "${TARGET_DEVICES[@]}"; do
+		if [[ -e ${DEVICE_NAME} ]]; then
+			TARGET_NVME_DEVICE=${DEVICE_NAME}
+			printf "%s\n" "Warning: Falling back to device name"
+			printf "%s\n" "Warning: Device names might change if instance is stopped or volumes are detached/added"
+			break
+		fi
+	done;
+
+	if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+		printf "%s\n" "ERROR: unable to find the NVME device for ${TARGET_DEVICES}" 1>&2
+		exit 2
+	fi
+
+	# Mount point and volume creation
+	sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
+	sudo mkdir -p "${MOUNT_POINT}"
+	# Get device UUID with blkid as exported format:
+	# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	printf "%s\n" "Warning: Will be mounted by UUID in /etc/fstab"
+	UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+	printf "%s\n" "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
+	eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"
+
 done
-
-# Based on the target EBS device (/dev/sdX) we have to find the corresponding
-# NVME device.
-for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
-	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
-
-	# /dev/ might be dropped at times so we need to check both cases
-    if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ] || [ "/dev/$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
-		TARGET_NVME_DEVICE=${NVME_DEVICE}
-		break
-	fi
-done;
-
-# Fallback to device names
-for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
-	if [[ -e ${DEVICE_NAME} ]]; then
-		TARGET_NVME_DEVICE=${DEVICE_NAME}
-		echo "Warning: Falling back to device name"
-		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
-		break
-	fi
-done;
-
-if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
-	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
-	exit 2
-fi
-
-# Mount point and volume creation
-sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
-sudo mkdir -p "${MOUNT_POINT}"
-# Get device UUID with blkid as exported format:
-# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-echo "Warning: Will be mounted by UUID in /etc/fstab"
-UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -64,6 +64,8 @@ variable "additional_volumes" {
     type        = string
     caching     = optional(string, "None")
     iops        = optional(number)
+    filesystem    = optional(string)
+    mount_options = optional(string)
   }))
 
   validation {
@@ -125,10 +127,7 @@ locals {
     for letter in local.letters:
       formatlist("${local.prefix}%s${letter}", local.base)
   ]
-  # List(String) with comma delimiter
-  # [ "/dev/sdc" , ]
-  string_device_names = [
-    for names in local.linux_device_names:
-      format("%s", names...)
-  ]
+  # Default filesystem related variables
+  filesystem = "xfs"
+  mount_options = ["noatime", "nodiratime", "logbsize=256k", "allocsize=1m"]
 }

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -90,6 +90,8 @@ variable "spec" {
         size_gb     = number
         iops        = optional(number)
         type        = string
+        filesystem    = optional(string)
+        mount_options = optional(string)
       })), [])
       tags = optional(map(string), {})
     })), {})

--- a/edbterraform/data/terraform/gcloud/modules/machine/lsblk_devices.sh
+++ b/edbterraform/data/terraform/gcloud/modules/machine/lsblk_devices.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SSH_CONNECTION="$1"
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+CMD="sudo lsblk -o NAME,KNAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,SERIAL,MODEL,VENDOR,REV,LABEL,UUID,PARTTYPE,PARTLABEL,PARTUUID,SCHED --json 2>&1"
+
+RESULT=$(ssh $SSH_OPTIONS $SSH_CONNECTION $CMD)
+RC=$?
+if [[ $RC -ne 0 ]];
+then
+  printf "%s\n" "$RESULT" 1>&2
+  exit $RC
+fi
+
+jq -n --arg base64json "$(printf %s $RESULT | base64 | tr -d \\n)" '{"base64json": $base64json}'

--- a/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/outputs.tf
@@ -25,6 +25,15 @@ output "labels" {
 output "additional_volumes" {
   value = var.machine.spec.additional_volumes
 }
+
+output "block_devices" {
+  value = {
+    initial = local.initial_block_devices
+    all = local.all_block_devices
+    final = local.final_block_devices
+  }
+}
+
 output "operating_system" {
   value = var.operating_system
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/providers.tf
@@ -3,6 +3,10 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
+    toolbox = {
+      source = "bryan-bar/toolbox"
+      version = "~> 0.1.4"
+    }
   }
   required_version = ">= 1.3.6"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/gcloud/modules/machine/setup_volume.sh
@@ -1,68 +1,88 @@
 #!/bin/bash
+set -euo pipefail
 
-# Expected EBS device paths: "/dev/sdX,/dev/sdY"
-IFS=',' read -r -a TARGET_EBS_DEVICES <<< $1
-
-# Mount point
-MOUNT_POINT=$2
-# Total number of nvme devices that should be present on the system
-N_NVME_DEVICE=$3
-
-TARGET_NVME_DEVICE=""
-
-# Install nvme-cli
+# Install nvme-cli and jq
 if [ -f /etc/redhat-release ]; then
-	sudo yum install nvme-cli -y
+	sudo yum clean all
+	sudo yum install nvme-cli jq -y
 fi
 if [ -f /etc/debian_version ]; then
 	sudo apt update -y
-	sudo apt install nvme-cli -y
+	sudo apt install nvme-cli jq -y
 fi
 
-# Wait for the availability of all the NVME devices that should be
-# present on the system.
-while [ $(sudo nvme list | tail -n +3 | wc -l) -ne ${N_NVME_DEVICE} ]; do
-	sleep 2
-	COUNTER=$((COUNTER + 1))
-	if [ $COUNTER -ge 10 ]; then
-		echo "ERROR: unable to get the full list of NVME devices after 20s"
-		break
+# Expects a base64encoded json object
+SCRIPT_INPUTS=$(printf %s "$1" | base64 -d | jq -rc '.[]')
+
+for item in ${SCRIPT_INPUTS}
+do
+	_jq_key() {
+		printf %s "$1" | jq -rc "$2"
+	}
+	# Expected device paths: ["/dev/sdX","/dev/sdY"]
+	TARGET_DEVICES=$(_jq_key "$item" '.device_names[]')
+
+	# Mount point
+	MOUNT_POINT=$(_jq_key "$item" '.mount_point')
+	# Total number of nvme devices that should be present on the system
+	N_NVME_DEVICE=$(_jq_key "$item" '.number_of_volumes')
+	FSTYPE=$(_jq_key "$item" '.filesystem')
+	FSMOUNTOPT=$(_jq_key "$item" '.mount_options')
+
+	TARGET_NVME_DEVICE=""
+	FSMOUNTOPT_ARG=""
+
+	if [ ! "${FSMOUNTOPT}" = "" ]; then
+		FSMOUNTOPT_ARG="-o ${FSMOUNTOPT}"
 	fi
+
+	# Wait for the availability of all the NVME devices that should be
+	# present on the system.
+	COUNTER=0
+	while [ "$(sudo nvme list | tail -n +3 | wc -l)" -ne "${N_NVME_DEVICE}" ]; do
+		sleep 2
+		COUNTER=$((COUNTER + 1))
+		if [ $COUNTER -ge 10 ]; then
+			printf "%s\n" "ERROR: unable to get the full list of NVME devices after 20s"
+			break
+		fi
+	done
+
+	# Based on the target EBS device (/dev/sdX) we have to find the corresponding
+	# NVME device.
+	for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
+		FOUND_DEVICE=$(sudo nvme id-ctrl -v "${NVME_DEVICE}" | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
+
+		# /dev/ might be dropped at times so we need to check both cases
+	    if [[ "${TARGET_DEVICES[*]}" =~ "$FOUND_DEVICE" ]] || [[ "${TARGET_DEVICES[*]}" =~ "/dev/$FOUND_DEVICE" ]]; then
+			TARGET_NVME_DEVICE=${NVME_DEVICE}
+			break
+		fi
+	done;
+
+	# Fallback to device names
+	for DEVICE_NAME in "${TARGET_DEVICES[@]}"; do
+		if [[ -e ${DEVICE_NAME} ]]; then
+			TARGET_NVME_DEVICE=${DEVICE_NAME}
+			printf "%s\n" "Warning: Falling back to device name"
+			printf "%s\n" "Warning: Device names might change if instance is stopped or volumes are detached/added"
+			break
+		fi
+	done;
+
+	if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
+		printf "%s\n" "ERROR: unable to find the NVME device for ${TARGET_DEVICES}" 1>&2
+		exit 2
+	fi
+
+	# Mount point and volume creation
+	sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
+	sudo mkdir -p "${MOUNT_POINT}"
+	# Get device UUID with blkid as exported format:
+	# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	printf "%s\n" "Warning: Will be mounted by UUID in /etc/fstab"
+	UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
+	printf "%s\n" "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
+	eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"
+
 done
-
-# Based on the target EBS device (/dev/sdX) we have to find the corresponding
-# NVME device.
-for NVME_DEVICE in $(sudo ls /dev/nvme*n*); do
-	EBS_DEVICE=$(sudo nvme id-ctrl -v ${NVME_DEVICE} | grep "0000:" | awk '{ print $18 }' | sed 's/["\.]//g')
-
-	# /dev/ might be dropped at times so we need to check both cases
-    if [ "$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ] || [ "/dev/$EBS_DEVICE" = "${TARGET_EBS_DEVICES[0]}" ]; then
-		TARGET_NVME_DEVICE=${NVME_DEVICE}
-		break
-	fi
-done;
-
-# Fallback to device names
-for DEVICE_NAME in "${TARGET_EBS_DEVICES[@]}"; do
-	if [[ -e ${DEVICE_NAME} ]]; then
-		TARGET_NVME_DEVICE=${DEVICE_NAME}
-		echo "Warning: Falling back to device name"
-		echo "Warning: Device names might change if instance is stopped or volumes are detached/added"
-		break
-	fi
-done;
-
-if [ "${#TARGET_NVME_DEVICE}" -eq 0 ]; then
-	echo "ERROR: unable to find the NVME device for ${TARGET_EBS_DEVICES}"
-	exit 2
-fi
-
-# Mount point and volume creation
-sudo mkfs.xfs "${TARGET_NVME_DEVICE}"
-sudo mkdir -p "${MOUNT_POINT}"
-# Get device UUID with blkid as exported format:
-# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-echo "Warning: Will be mounted by UUID in /etc/fstab"
-UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
-echo "${UUID} ${MOUNT_POINT} xfs noatime 0 0" | sudo tee -a /etc/fstab
-sudo mount -t xfs -o noatime ${TARGET_NVME_DEVICE} ${MOUNT_POINT}

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -72,10 +72,7 @@ locals {
     for letter in local.letters:
       formatlist("${local.prefix}%s${letter}", local.base)
   ]
-  # List(String) with comma delimiter
-  # [ "/dev/disk/by-id/google-sdf" , ]
-  string_device_names = [
-    for names in local.linux_device_names:
-      format("%s", names...)
-  ]
+  # Default filesystem related variables
+  filesystem = "xfs"
+  mount_options = ["noatime", "nodiratime", "logbsize=256k", "allocsize=1m"]
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -91,6 +91,8 @@ variable "spec" {
         iops        = optional(number)
         type        = string
         encrypted   = optional(bool)
+        filesystem    = optional(string)
+        mount_options = optional(string)
       })), [])
       tags = optional(map(string), {})
     })), {})

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,8 @@ setup(
     data_files=[],
     package_data={
         'edbterraform': [
-            'data/terraform/*/variables.tf',
-            'data/terraform/*/modules/*/*.tf',
-            'data/terraform/*/modules/*/*.sh',
+            'data/terraform/*/*',
+            'data/terraform/*/modules/*/*',
             'data/templates/*/*',
             'utils/*'
         ]


### PR DESCRIPTION
Refactor how volumes are setup so that we can later handle filesystems such as LVM:
* Use of `toolbox_external` instead of provisioners:
  * Return values back into terraform state
    1. after machine creation
    2. after addtional volumes are attached
    3. after volumes are formatted.
  * Setup volume script copied once and run once after it has a view of all available resources
  * Implicit dependencies set in query parameter but unused
* `block_devices` output available for AWS, Azure, and GCP virtual machines.
  * 3 map values
    * `initial` - block devices after creation/first start.
    * `all` - block devices after attaching all volumes
    * `final` - block devices after formatting

resolves https://github.com/EnterpriseDB/edb-terraform/issues/30
closes https://github.com/EnterpriseDB/edb-terraform/pull/40
Ref PR: https://github.com/EnterpriseDB/edb-terraform/pull/83

---

Ansible's Terraform Provider `v1.1.0` was not used due to the following reasons:
1. Requires ansible plugin installation: cloud.terraform and it needs to be defined in an inventory file and passed to the playbook as a variable.
2. Does not pass around set variables from ansible_host resource and leaves tmp files behind
    - [ansible_playbook not using ansible_user and ansible_host variables from ansible_host resource ? · Issue #37 · ansible/terraform-provider-ansible (github.com)](https://github.com/ansible/terraform-provider-ansible/issues/37)
3. Provider masks errors instead of surfacing them.
    - [Provide Ansible tool errors up to the provider · Issue #39 · ansible/terraform-provider-ansible (github.com)](https://github.com/ansible/terraform-provider-ansible/issues/39)
    - Workaround: ignore playbook errors so terraform does not fail and using a postcondition to check the stderr output.
4. Provider populates stdout past the allowed default limit of 4MB.
    - [[ERROR] gRPC "message larger than max" error · Issue #54 · ansible/terraform-provider-ansible (github.com)](https://github.com/ansible/terraform-provider-ansible/issues/54)
```
Error:

╷
│ Error: Plugin error
│ 
│   with module.machine_us_west_2["pg1"].ansible_playbook.setup_volume[0],
│   on modules/machine/main.tf line 209, in resource "ansible_playbook" "setup_volume":
│  209: resource "ansible_playbook" "setup_volume" {
│ 
│ The plugin returned an unexpected error from plugin.(*GRPCProvider).UpgradeResourceState: rpc error: code = ResourceExhausted desc = grpc: received message larger than max
│ (4299187 vs. 4194304)
```