### PR TITLE
aws machine module: just a bunch of volumes disk management

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -106,7 +106,9 @@ resource "aws_ebs_volume" "ebs_volume" {
   availability_zone = var.az
   size              = each.value.size_gb
   type              = each.value.type
-  iops              = each.value.type == "io2" ? each.value.iops : each.value.type == "io1" ? each.value.iops : null
+  # IOPs and throughput limited to certain volume types
+  iops              = contains(["io1","io2","gp3"], each.value.type) ? each.value.iops : null
+  throughput        = contains(["gp3"], each.value.type) ? each.value.throughput : null
   encrypted         = each.value.encrypted
 
   # Implicit dependency to initial devices check

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -34,6 +34,10 @@ output "additional_volumes" {
   value = var.machine.spec.additional_volumes
 }
 
+output "jbod_volumes" {
+  value = aws_ebs_volume.jbod_volumes
+}
+
 output "block_devices" {
   value = {
     initial = local.initial_block_devices

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -86,6 +86,7 @@ variable "spec" {
         mount_point   = string
         size_gb       = number
         iops          = optional(number)
+        throughput    = optional(number)
         type          = string
         encrypted     = optional(bool)
         filesystem    = optional(string)

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -82,6 +82,21 @@ variable "spec" {
         iops      = optional(number)
         encrypted = optional(bool)
       })
+      # Creates a set of volumes around a machine instance to be attached post-terraform
+      jbod_volumes = optional(map(object({
+        type = string
+        size_gb = number
+        iops = optional(number)
+        throughput = optional(number)
+        encrypted = optional(bool)
+      })))
+      # Cloud providers may:
+      #   * change order of volume attachment during reboot/stop
+      #   * mount location can be ignored based on type
+      #   * initial mount location can be set by the instance image
+      # To track volumes, pre-formating is required to create a UUID on the volume.
+      # Use jbod_volumes which are meant to represent "Just a bunch of Disks(Volumes)" as an alternative
+      # to manually manage per machine instance post-terraform
       additional_volumes = optional(list(object({
         mount_point   = string
         size_gb       = number

--- a/infrastructure-examples/aws/machines-v2.yml
+++ b/infrastructure-examples/aws/machines-v2.yml
@@ -62,6 +62,15 @@ aws:
         size_gb: 50
         iops: 5000
         encrypted: false
+      jbod_volumes:
+        0:
+          type: gp2
+          size_gb: 100
+          encrypted: false
+        1:
+          type: gp2
+          size_gb: 100
+          encrypted: false
       additional_volumes:
         - mount_point: /opt/pg_data
           size_gb: 20


### PR DESCRIPTION
`jbod_volumes` option added to allow creation of volumes alongside a machine while skipping the attachment and formatting of the volume.
For management, use the `arn` and `id` set under the `jbod_volumes` for each machine's output.

example usage under a machine configuration:
```yaml
      jbod_volumes:
        0:
          type: gp2
          size_gb: 100
          encrypted: false
        1:
          type: gp3
          size_gb: 100
          encrypted: false
          throughput: 300
          iops: 300
```