### PR TITLE
Biganimal cloud_account `nullable` fix

### DIFF
--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -9,7 +9,7 @@ variable "name_id" {}
 variable "cloud_account" {
   type = bool
   default = true
-  nullable = true
+  nullable = false
   description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
 }
 variable "cluster_name" {}

--- a/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
@@ -9,7 +9,7 @@ variable "name_id" {}
 variable "cloud_account" {
   type = bool
   default = true
-  nullable = true
+  nullable = false
   description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
 }
 variable "cluster_name" {}

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
@@ -9,7 +9,7 @@ variable "name_id" {}
 variable "cloud_account" {
   type = bool
   default = true
-  nullable = true
+  nullable = false
   description = "Option for selecting if biganimal should host the resources with your own cloud account instead of biganimal hosted resources"
 }
 variable "cluster_name" {}


### PR DESCRIPTION
`nullable` should be set to `false` so that the default is used when `null` is passed in.
Original PR: https://github.com/EnterpriseDB/edb-terraform/pull/97