### PR TITLE
AWS Module updates

### DIFF
--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -96,8 +96,9 @@ locals {
 
 resource "local_file" "servers_yml" {
   /*
-  Manually create the yaml
-  TODO: Update to yamlencode function once stable
+  Manually create the yaml file
+  - ignore attributes named 'resources' for now to avoid cluttering the yaml file
+  - For a view of 'resources', reference the outputs through 'terraform output -json modules or servers'
   */
   filename        = "${abspath(path.root)}/servers.yml"
   file_permission = "0600"
@@ -109,7 +110,9 @@ servers:
 %{   for name, attributes in instances ~}
       ${name}:
 %{     for key, values in attributes ~}
+%{       if key != "resources" ~}
         ${key}: ${jsonencode(values)}
+%{       endif ~}
 %{     endfor ~}
 %{   endfor ~}
 %{ endfor ~}

--- a/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/outputs.tf
@@ -49,3 +49,12 @@ output "cluster_id" {
 output "resource_id" {
   value = aws_rds_cluster_instance.aurora_instance.*.id
 }
+
+output "resources" {
+  value = {
+    aws_db_subnet_group = { aurora = aws_db_subnet_group.aurora }
+    aws_rds_cluster = { aurora_cluster = aws_rds_cluster.aurora_cluster }
+    aws_rds_cluster_instance = { aurora_instance = aws_rds_cluster_instance.aurora_instance }
+    aws_db_parameter_group = { aurora_db_params = aws_db_parameter_group.aurora_db_params }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/main.tf
@@ -42,3 +42,33 @@ resource "biganimal_cluster" "instance" {
     private_networking = !var.publicly_accessible
     read_only_connections = false
 }
+
+locals {
+  /*
+  BigAnimal does not output the VPC id as it shares a VPC for all clusters within a project
+  - Currently it has the following VPC name format: vpc-<project_id>-<region>
+  - the resource will contain the project id: prj_<project_id>
+  */
+  vpc_name = format("vpc-%s-%s",trimprefix(biganimal_cluster.instance.project_id, "prj_"), biganimal_cluster.instance.region)
+  vpc_cmd = "aws ec2 describe-vpcs --filter Name=tag:Name,Values=${local.vpc_name} --query Vpcs[].VpcId --output text --region ${biganimal_cluster.instance.region}"
+}
+
+resource "toolbox_external" "vpc_id" {
+  program = [
+    "bash",
+    "-c",
+    <<-EOT
+    # Execute Script
+    CMD="${local.vpc_cmd}"
+    RESULT=$($CMD)
+    RC=$?
+    if [[ $RC -ne 0 ]];
+    then
+      printf "%s\n" "$RESULT" 1>&2
+      exit $RC
+    fi
+
+    jq -n --arg result "$RESULT" '{"id": $result}'
+    EOT
+  ]
+}

--- a/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
@@ -114,6 +114,13 @@ output "buckets" {
   } : {}
 }
 
+output "loadbalancer" {
+  value = var.cloud_account ? {
+    name = toolbox_external.vpc.0.result.loadbalancer_name
+    dns = toolbox_external.vpc.0.result.loadbalancer_dns
+  } : {}
+}
+
 output "all" {
     value = biganimal_cluster.instance
 }

--- a/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
@@ -86,6 +86,14 @@ output "tags" {
   value = var.tags
 }
 
+output "vpc_name" {
+  value = local.vpc_name
+}
+
+output "vpc_id" {
+  value = toolbox_external.vpc_id.result.id
+}
+
 output "all" {
     value = biganimal_cluster.instance
 }

--- a/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
@@ -124,3 +124,14 @@ output "loadbalancer" {
 output "all" {
     value = biganimal_cluster.instance
 }
+
+output "resources" {
+  value = {
+    biganimal_cluster = {
+      instance = biganimal_cluster.instance
+    }
+    toolbox_external = {
+      vpc = toolbox_external.vpc
+    }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/outputs.tf
@@ -87,11 +87,31 @@ output "tags" {
 }
 
 output "vpc_name" {
-  value = local.vpc_name
+  value = can(toolbox_external.vpc.0) ? local.vpc_name : ""
 }
 
 output "vpc_id" {
-  value = toolbox_external.vpc_id.result.id
+  value = can(toolbox_external.vpc.0) ? toolbox_external.vpc.0.result.vpc_id : ""
+}
+
+output "biganimal_id" {
+  value = can(toolbox_external.vpc.0) ? toolbox_external.vpc.0.result.biganimal_id : ""
+}
+
+output "buckets" {
+  value = var.cloud_account ? {
+    postgres = {
+      bucket = local.postgres_bucket
+      prefix = local.postgres_bucket_prefix
+    }
+    container = {
+      bucket = local.container_bucket
+      prefix = local.partial_container_prefix
+    }
+    metrics = {
+      bucket = local.metrics_bucket
+    }
+  } : {}
 }
 
 output "all" {

--- a/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
@@ -2,7 +2,11 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = ">= 0.5.1"
+      version = "~> 0.6.0"
+    }
+    toolbox = {
+      source = "bryan-bar/toolbox"
+      version = "~> 0.1.4"
     }
   }
 }

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -57,6 +57,16 @@ variable "publicly_accessible" {
   nullable = false
 }
 
+variable "cidr_range" {
+  description = "BigAnimal ip range is pre-set and cannot be updated"
+  type = string
+  default = "10.0.0.0/16"
+  validation {
+    condition = var.cidr_range == "10.0.0.0/16"
+    error_message = "BigAnimal ip range is pre-set and cannot be updated"
+  }
+}
+
 variable "allowed_ip_ranges" {
   type = list(object({
     cidr_block = string

--- a/edbterraform/data/terraform/aws/modules/database/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/database/outputs.tf
@@ -45,3 +45,11 @@ output "tags" {
 output "resource_id" {
   value = aws_db_instance.rds_server.identifier
 }
+
+output "resources" {
+  value = {
+    aws_db_subnet_group = { rds = aws_db_subnet_group.rds }
+    aws_db_instance = {rds_server = aws_db_instance.rds_server }
+    aws_db_parameter_group = { edb_rds_db_params = aws_db_parameter_group.edb_rds_db_params }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/machine/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/outputs.tf
@@ -53,3 +53,17 @@ output "operating_system" {
 output "resource_id" {
   value = aws_instance.machine.id
 }
+
+output "resources" {
+  value = {
+    aws_instance = { machine = aws_instance.machine }
+    aws_ebs_volume = { 
+      jbod_volumes = aws_ebs_volume.jbod_volumes
+      ebs_volume = aws_ebs_volume.ebs_volume
+    }
+    aws_volume_attachment = { attached_volume = aws_volume_attachment.attached_volume }
+    module = {
+      machine_ports = module.machine_ports
+    }
+  }
+}

--- a/edbterraform/data/terraform/aws/modules/vpc_peering_accepter/main.tf
+++ b/edbterraform/data/terraform/aws/modules/vpc_peering_accepter/main.tf
@@ -1,4 +1,5 @@
 variable "connection_id" {}
+variable "tags" {}
 
 terraform {
   required_providers {


### PR DESCRIPTION
## Changes:
* VPC Peering tags fix
* Additional BigAnimal outputs added which are needed for vpc peering or vpc endpoints
  * `vpc_id`
  * `vpc_name`
  * `biganimal_id`
  * `loadbalancer.name`
  * `loadbalancer.dns`
* `resources` output added to modules to easily reference any child resource name and all available attributes. While we could use `terraform.tfstate` to find some of this information, local access will be lost with a remote state and it is grouped as a list of resources and not by the parent module:
  * For example:
`terraform.tfstate`
```json
{
  "resources" : [
   {
      "module": "module.biganimal_us_east_2[\"mydb2\"]",
      "mode": "managed",
      "type": "biganimal_cluster",
      "name": "instance",
      "instances": [ ... ],
      ...
    }
  ]
}
```
`terraform output -json servers | jq .`
```json
{
  "biganimal": {
    "mydb2": {
        "resources": {
            "biganimal_cluster": {
                "instance": {
                ...
                }
            }
        }
    }
  }
}
```


#### BigAnimal example output:
`$ terraform output -json servers | jq .`
```json
{
  "aurora": {},
  "biganimal": {
    "mydb2": {
      "all": {
        "allowed_ip_ranges": [
          {
            "cidr_block": "127.0.0.1/32",
            "description": "localhost"
          }
        ],
        "backup_retention_period": "1d",
        "cloud_provider": "aws",
        "cluster_architecture": {
          "id": "single",
          "name": "Single Node",
          "nodes": 1
        },
        "cluster_id": "p-vlv6ma7yjj",
        "cluster_name": "mydb2-f5d62b74",
        "cluster_type": "cluster",
        "connection_uri": "postgresql://edb_admin@p-vlv6ma7yjj.zijplqw3xxpr7nxv.biganimal.io:5432/edb_admin",
        "created_at": "2023-11-04 16:23:43.309066 +0000 UTC",
        "csp_auth": false,
        "faraway_replica_ids": [],
        "first_recoverability_point_at": null,
        "id": "prj_ziJPLQw3XxpR7nxV/p-vlv6ma7yjj",
        "instance_type": "aws:c5.large",
        "logs_url": "https://logs-bucket-zijplqw3xxpr7nxv-us-east-2.s3.us-east-2.amazonaws.com",
        "maintenance_window": {
          "is_enabled": false,
          "start_day": 0,
          "start_time": "00:00"
        },
        "metrics_url": "https://m-awsuseast2-0.zijplqw3xxpr7nxv.biganimal.io:10902",
        "password": "ndslniv&03ind**vDdjfnjv",
        "pe_allowed_principal_ids": [],
        "pg_config": [
          {
            "name": "autovacuum_max_workers",
            "value": "5"
          },
          {
            "name": "autovacuum_vacuum_cost_limit",
            "value": "3000"
          },
          {
            "name": "checkpoint_completion_target",
            "value": "0.9"
          },
          {
            "name": "checkpoint_timeout",
            "value": "15min"
          },
          {
            "name": "cpu_tuple_cost",
            "value": "0.03"
          },
          {
            "name": "effective_cache_size",
            "value": "0.75 * ram"
          },
          {
            "name": "maintenance_work_mem",
            "value": "(0.15 * (ram - shared_buffers) / autovacuum_max_workers) > 1GB ? 1GB : (0.15 * (ram - shared_buffers) / autovacuum_max_workers)"
          },
          {
            "name": "random_page_cost",
            "value": "1.1"
          },
          {
            "name": "shared_buffers",
            "value": "((0.25 * ram) > 80GB) ? 80GB : (0.25 * ram)"
          },
          {
            "name": "tcp_keepalives_idle",
            "value": "120"
          },
          {
            "name": "tcp_keepalives_interval",
            "value": "30"
          },
          {
            "name": "wal_buffers",
            "value": "64MB"
          },
          {
            "name": "wal_compression",
            "value": "on"
          }
        ],
        "pg_type": "postgres",
        "pg_version": "15",
        "phase": "Cluster in healthy state",
        "private_networking": false,
        "project_id": "prj_ziJPLQw3XxpR7nxV",
        "read_only_connections": false,
        "region": "us-east-2",
        "resizing_pvc": [],
        "ro_connection_uri": "",
        "service_account_ids": [],
        "storage": {
          "iops": "3000",
          "size": "4 Gi",
          "throughput": "125",
          "volume_properties": "gp3",
          "volume_type": "gp3"
        },
        "superuser_access": false,
        "timeouts": null
      },
      "biganimal_id": "c2fe3895-ad8d-4207-abd0-c8112de6280e",
      "buckets": {
        "container": {
          "bucket": "logs-bucket-ziJPLQw3XxpR7nxV-us-east-2",
          "prefix": "kubernetes-logs/customer_postgresql_cluster.var.log.containers.p-vlv6ma7yjj"
        },
        "metrics": {
          "bucket": "metrics-bucket-ziJPLQw3XxpR7nxV-us-east-2"
        },
        "postgres": {
          "bucket": "pg-bucket-ziJPLQw3XxpR7nxV-us-east-2",
          "prefix": "p-vlv6ma7yjj"
        }
      },
      "cloud_provider": "aws",
      "cluster_architecture": {
        "id": "single",
        "name": "Single Node",
        "nodes": 1
      },
      "cluster_id": "p-vlv6ma7yjj",
      "cluster_name": "mydb2-f5d62b74",
      "cluster_type": "cluster",
      "connection_uri": "postgresql://edb_admin@p-vlv6ma7yjj.zijplqw3xxpr7nxv.biganimal.io:5432/edb_admin",
      "dbname": "edb_admin",
      "engine": "postgres",
      "instance_type": "aws:c5.large",
      "loadbalancer": {
        "dns": "a876e18e190434c8e97bf37574b22257-6cfd1673be8dbb20.elb.us-east-2.amazonaws.com",
        "name": "a876e18e190434c8e97bf37574b22257"
      },
      "password": "ndslniv&03ind**vDdjfnjv",
      "port": "5432",
      "private_ip": null,
      "project_id": "prj_ziJPLQw3XxpR7nxV",
      "public_ip": "p-vlv6ma7yjj.zijplqw3xxpr7nxv.biganimal.io",
      "read_only_uri": "",
      "region": "us-east-2",
      "resources": {
        "biganimal_cluster": {
          "instance": {
            "allowed_ip_ranges": [
              {
                "cidr_block": "127.0.0.1/32",
                "description": "localhost"
              }
            ],
            "backup_retention_period": "1d",
            "cloud_provider": "aws",
            "cluster_architecture": {
              "id": "single",
              "name": "Single Node",
              "nodes": 1
            },
            "cluster_id": "p-vlv6ma7yjj",
            "cluster_name": "mydb2-f5d62b74",
            "cluster_type": "cluster",
            "connection_uri": "postgresql://edb_admin@p-vlv6ma7yjj.zijplqw3xxpr7nxv.biganimal.io:5432/edb_admin",
            "created_at": "2023-11-04 16:23:43.309066 +0000 UTC",
            "csp_auth": false,
            "faraway_replica_ids": [],
            "first_recoverability_point_at": null,
            "id": "prj_ziJPLQw3XxpR7nxV/p-vlv6ma7yjj",
            "instance_type": "aws:c5.large",
            "logs_url": "https://logs-bucket-zijplqw3xxpr7nxv-us-east-2.s3.us-east-2.amazonaws.com",
            "maintenance_window": {
              "is_enabled": false,
              "start_day": 0,
              "start_time": "00:00"
            },
            "metrics_url": "https://m-awsuseast2-0.zijplqw3xxpr7nxv.biganimal.io:10902",
            "password": "ndslniv&03ind**vDdjfnjv",
            "pe_allowed_principal_ids": [],
            "pg_config": [
              {
                "name": "autovacuum_max_workers",
                "value": "5"
              },
              {
                "name": "autovacuum_vacuum_cost_limit",
                "value": "3000"
              },
              {
                "name": "checkpoint_completion_target",
                "value": "0.9"
              },
              {
                "name": "checkpoint_timeout",
                "value": "15min"
              },
              {
                "name": "cpu_tuple_cost",
                "value": "0.03"
              },
              {
                "name": "effective_cache_size",
                "value": "0.75 * ram"
              },
              {
                "name": "maintenance_work_mem",
                "value": "(0.15 * (ram - shared_buffers) / autovacuum_max_workers) > 1GB ? 1GB : (0.15 * (ram - shared_buffers) / autovacuum_max_workers)"
              },
              {
                "name": "random_page_cost",
                "value": "1.1"
              },
              {
                "name": "shared_buffers",
                "value": "((0.25 * ram) > 80GB) ? 80GB : (0.25 * ram)"
              },
              {
                "name": "tcp_keepalives_idle",
                "value": "120"
              },
              {
                "name": "tcp_keepalives_interval",
                "value": "30"
              },
              {
                "name": "wal_buffers",
                "value": "64MB"
              },
              {
                "name": "wal_compression",
                "value": "on"
              }
            ],
            "pg_type": "postgres",
            "pg_version": "15",
            "phase": "Cluster in healthy state",
            "private_networking": false,
            "project_id": "prj_ziJPLQw3XxpR7nxV",
            "read_only_connections": false,
            "region": "us-east-2",
            "resizing_pvc": [],
            "ro_connection_uri": "",
            "service_account_ids": [],
            "storage": {
              "iops": "3000",
              "size": "4 Gi",
              "throughput": "125",
              "volume_properties": "gp3",
              "volume_type": "gp3"
            },
            "superuser_access": false,
            "timeouts": null
          }
        },
        "toolbox_external": {
          "vpc": [
            {
              "create": true,
              "destroy": false,
              "id": "-",
              "program": [
                "bash",
                "-c",
                "# Execute Script\nCMD=\"aws ec2 describe-vpcs --filter Name=tag:Name,Values=vpc-ziJPLQw3XxpR7nxV-us-east-2 --query Vpcs[] --output json --region us-east-2\"\nRESULT=$($CMD)\nRC=$?\nif [[ $RC -ne 0 ]];\nthen\n  printf \"%s\\n\" \"$RESULT\" 1>&2\n  exit $RC\nfi\n\nVPC_ID=$(printf %s \"$RESULT\" | jq -r .[].VpcId)\nBIGANIMAL_ID=$(printf %s \"$RESULT\" | jq -r '.[].Tags[] | select(.Key == \"BAID\") | .Value')\n\n# BigAnimal main route table\nCMD=\"aws ec2 describe-route-tables --filter \"Name=vpc-id,Values=$VPC_ID\" --query RouteTables[?Associations[0].Main].RouteTableId --output text --region us-east-2\"\nRESULT=$($CMD)\nRC=$?\nif [[ $RC -ne 0 ]];\nthen\n  printf \"%s\\n%s\\n\" \"$CMD\" \"$RESULT\" 1>&2\n  exit $RC\nfi\n\nMAIN_ROUTE_TABLE=$RESULT\n\n# BigAnimal uses private 3 route tables with the tags ManagedBy=BigAnimal and Name=*private*\nCMD=\"aws ec2 describe-route-tables --filter \"Name=vpc-id,Values=$VPC_ID\" --filter \"Name=tag:ManagedBy,Values=BigAnimal\" --filter \"Name=tag:Name,Values=*private*\"  --query RouteTables[].RouteTableId --output json --region us-east-2\"\nRESULT=$($CMD)\nRC=$?\nif [[ $RC -ne 0 ]];\nthen\n  printf \"%s\\n%s\\n\" \"$CMD\" \"$RESULT\" 1>&2\n  exit $RC\nfi\n\nROUTE_TABLE_0=$(printf \"%s\" $RESULT | jq -r .[0])\nROUTE_TABLE_1=$(printf \"%s\" $RESULT | jq -r .[1])\nROUTE_TABLE_2=$(printf \"%s\" $RESULT | jq -r .[2])\n\n# BigAnimal has a loadbalancer attached to the projects vpc\nCMD=\"aws elbv2 describe-load-balancers --query \"LoadBalancers[?VpcId==\\'$VPC_ID\\']\" --region us-east-2 --output json\"\nRESULT=$($CMD)\nRC=$?\nif [[ $RC -ne 0 ]];\nthen\n  printf \"%s\\n%s\\n\" \"$CMD\" \"$RESULT\" 1>&2\n  exit $RC\nfi\n\nLOADBALANCER_NAME=$(printf \"%s\" $RESULT | jq -r .[0].LoadBalancerName)\nLOADBALANCER_DNS=$(printf \"%s\" $RESULT | jq -r .[0].DNSName)\n\njq -n --arg vpc_id \"$VPC_ID\" \\\n      --arg biganimal_id \"$BIGANIMAL_ID\" \\\n      --arg main_route_table_id \"$MAIN_ROUTE_TABLE\" \\\n      --arg route_0_id \"$ROUTE_TABLE_0\" \\\n      --arg route_1_id \"$ROUTE_TABLE_1\" \\\n      --arg route_2_id \"$ROUTE_TABLE_2\" \\\n      --arg loadbalancer_name \"$LOADBALANCER_NAME\" \\\n      --arg loadbalancer_dns \"$LOADBALANCER_DNS\" \\\n        '{\"vpc_id\": $vpc_id, \"biganimal_id\": $biganimal_id, \"main_route_table_id\": $main_route_table_id, \"route_0_id\": $route_0_id, \"route_1_id\": $route_1_id, \"route_2_id\": $route_2_id, \"loadbalancer_name\": $loadbalancer_name, \"loadbalancer_dns\": $loadbalancer_dns}'\n"
              ],
              "query": null,
              "result": {
                "biganimal_id": "c2fe3895-ad8d-4207-abd0-c8112de6280e",
                "loadbalancer_dns": "a876e18e190434c8e97bf37574b22257-6cfd1673be8dbb20.elb.us-east-2.amazonaws.com",
                "loadbalancer_name": "a876e18e190434c8e97bf37574b22257",
                "main_route_table_id": "rtb-0930cd20bad41ffb8",
                "route_0_id": "rtb-04dec91408f0d2966",
                "route_1_id": "rtb-0c726b78d69cd543d",
                "route_2_id": "rtb-018a4225d2a7c277f",
                "vpc_id": "vpc-04139b6d0d96667ac"
              },
              "working_dir": null
            }
          ]
        }
      },
      "tags": {
        "Name": "mydb2-Demo-Infra-9dYrdA",
        "cluster_name": "Demo-Infra",
        "created_by": "edb-terraform",
        "terraform_hex": "f5d62b74",
        "terraform_id": "9dYrdA",
        "terraform_time": "2023-11-04T16:23:14Z"
      },
      "username": "edb_admin",
      "version": "15",
      "vpc_id": "vpc-04139b6d0d96667ac",
      "vpc_name": "vpc-ziJPLQw3XxpR7nxV-us-east-2"
    }
  },
  "databases": {},
  "kubernetes": {},
  "machines": {}
}
```