### PR TITLE
LVM volumes

### DIFF
--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -200,7 +200,7 @@ resource "toolbox_external" "setup_volumes" {
     SSH_CMD="ssh $CONNECTION $ADDITIONAL_SSH_OPTIONS $SSH_OPTIONS"
 
     # Set script as executable
-    CMD="$SSH_CMD chmod a+x /tmp/setup_volume.sh 2>&1"
+    CMD="$SSH_CMD chmod a+x /tmp/setup_volume.sh"
     RESULT=$($CMD)
     RC=$?
     if [[ $RC -ne 0 ]];
@@ -210,7 +210,7 @@ resource "toolbox_external" "setup_volumes" {
     fi
 
     # Execute Script
-    CMD="$SSH_CMD /tmp/setup_volume.sh ${base64encode(jsonencode(local.script_variables))} >> /tmp/mount.log 2>&1"
+    CMD="$SSH_CMD /tmp/setup_volume.sh ${base64encode(jsonencode(local.script_variables))} >> /tmp/mount.log"
     RESULT=$($CMD)
     RC=$?
     if [[ $RC -ne 0 ]];

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -14,12 +14,15 @@ fi
 
 # Expects a base64encoded json object
 SCRIPT_INPUTS=$(printf %s "$1" | base64 -d | jq -rc '.[]')
+VOLUME_GROUPS=$(printf %s "$2" | base64 -d | jq -rc '.')
 
+_jq_key() {
+	printf %s "$1" | jq -rc "$2"
+}
+
+# Find volumes and create a filesystem or lvm volume groups
 for item in ${SCRIPT_INPUTS}
 do
-	_jq_key() {
-		printf %s "$1" | jq -rc "$2"
-	}
 	# Expected device paths: ["/dev/sdX","/dev/sdY"]
 	TARGET_DEVICES=$(_jq_key "$item" '.device_names[]')
 
@@ -29,6 +32,7 @@ do
 	N_NVME_DEVICE=$(_jq_key "$item" '.number_of_volumes')
 	FSTYPE=$(_jq_key "$item" '.filesystem')
 	FSMOUNTOPT=$(_jq_key "$item" '.mount_options')
+	VOLUME_GROUP=$(_jq_key "$item" '.volume_group')
 
 	TARGET_NVME_DEVICE=""
 	FSMOUNTOPT_ARG=""
@@ -82,15 +86,26 @@ do
 		exit 2
 	fi
 
-	if [ "${FSTYPE}" = "lvm" ]; then
-		if ! command -v lvm >/dev/null 2>&1 && [ -f /etc/redhat-release ]; then
+	if [ -n "${VOLUME_GROUP}" ] && [ "${VOLUME_GROUP}" != "null" ]
+	then
+		if ! command -v lvm >/dev/null 2>&1 && [ -f /etc/redhat-release ]
+		then
 			sudo yum install lvm2 -y
 		fi
-		if ! command -v lvm >/dev/null 2>&1 && [ -f /etc/debian_version ]; then
+		if ! command -v lvm >/dev/null 2>&1 && [ -f /etc/debian_version ]
+		then
 			export DEBIAN_FRONTEND="noninteractive"
 			sudo apt-get install lvm2 -y
 		fi
+		# Check if volume exists to either create or extend volume group
+		if sudo vgs ${VOLUME_GROUP} >/dev/null 2>&1
+		then
+			VG_CMD=vgextend
+		else
+			VG_CMD=vgcreate
+		fi
 		sudo pvcreate "${TARGET_NVME_DEVICE}"
+		sudo "${VG_CMD}" "${VOLUME_GROUP}" "${TARGET_NVME_DEVICE}"
 	else
 		# Mount point and volume creation
 		sudo "mkfs.${FSTYPE}" "${TARGET_NVME_DEVICE}"
@@ -103,4 +118,44 @@ do
 		sudo mount --all
 	fi
 
+done
+
+# Create logical volumes
+_jq_key "${VOLUME_GROUPS}" "keys[]" | \
+while read -r VOLUME_GROUP
+do
+	# Get the value of the key
+	VOLUME_DATA=$(_jq_key "${VOLUME_GROUPS}" ".\"${VOLUME_GROUP}\"")
+	_jq_key "${VOLUME_DATA}" "keys[]" | \
+	while read -r MOUNT_POINT
+	do
+		MOUNT_DATA=$(_jq_key "${VOLUME_DATA}" ".\"${MOUNT_POINT}\"")
+		SIZE=$(_jq_key "${MOUNT_DATA}" '.size')
+		FILESYSTEM=$(_jq_key "${MOUNT_DATA}" '.filesystem')
+		MOUNT_OPTIONS=$(_jq_key "${MOUNT_DATA}" '.mount_options')
+		VOLUME_COUNT=$(sudo vgs -o pv_count --noheadings $VOLUME_GROUP | tr -d ' ')
+		LV_NAME=$(printf "%s" "${MOUNT_POINT}" | tr '/' '_')
+		LV_PATH="/dev/${VOLUME_GROUP}/${LV_NAME}"
+		# Create the logical volume
+		case "${SIZE}" in
+			*%*)
+				SIZE_CMD="--extents"
+				;;
+			*)
+				SIZE_CMD="--size"
+				;;
+		esac
+		sudo lvcreate "${SIZE_CMD}" "${SIZE}" --name "${LV_NAME}" --type striped --stripes "${VOLUME_COUNT}" "${VOLUME_GROUP}"
+
+		# Create the filesystem
+		sudo "mkfs.${FILESYSTEM}" "${LV_PATH}"
+		# Create the mount point
+		sudo mkdir -p "${MOUNT_POINT}"
+		# Get device UUID with blkid as exported format:
+		# UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+		printf "%s\n" "Warning: Will be mounted by UUID in /etc/fstab"
+		UUID=$(sudo blkid "${LV_PATH}" -o export | grep -E "^UUID=")
+		printf "%s\n" "${UUID} ${MOUNT_POINT} ${FILESYSTEM} ${MOUNT_OPTIONS} 0 0" | sudo tee -a /etc/fstab
+		sudo mount --all
+	done
 done

--- a/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
+++ b/edbterraform/data/terraform/aws/modules/machine/setup_volume.sh
@@ -100,7 +100,7 @@ do
 		printf "%s\n" "Warning: Will be mounted by UUID in /etc/fstab"
 		UUID=$(sudo blkid ${TARGET_NVME_DEVICE} -o export | grep -E "^UUID=")
 		printf "%s\n" "${UUID} ${MOUNT_POINT} ${FSTYPE} ${FSMOUNTOPT} 0 0" | sudo tee -a /etc/fstab
-		eval "sudo mount -t ${FSTYPE} ${FSMOUNTOPT_ARG} ${TARGET_NVME_DEVICE} ${MOUNT_POINT}"
+		sudo mount --all
 	fi
 
 done

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -98,7 +98,7 @@ variable "spec" {
       # Use jbod_volumes which are meant to represent "Just a bunch of Disks(Volumes)" as an alternative
       # to manually manage per machine instance post-terraform
       additional_volumes = optional(list(object({
-        mount_point   = string
+        mount_point   = optional(string)
         size_gb       = number
         iops          = optional(number)
         throughput    = optional(number)
@@ -106,7 +106,13 @@ variable "spec" {
         encrypted     = optional(bool)
         filesystem    = optional(string)
         mount_options = optional(string)
+        volume_group  = optional(string)
       })), [])
+      volume_groups = optional(map(map(object({
+        size = optional(string)
+        filesystem = optional(string)
+        mount_options = optional(string)
+      }))), {})
       tags = optional(map(string), {})
     })), {})
     databases = optional(map(object({

--- a/infrastructure-examples/aws/machines-v2.yml
+++ b/infrastructure-examples/aws/machines-v2.yml
@@ -12,14 +12,14 @@ aws:
       owner: 136693071363
       ssh_user: admin
   regions:
-    us-east-1:
+    us-west-2:
       cidr_block: 10.2.0.0/16
       zones:
         proxy:
-          zone: us-east-1b
+          zone: us-west-2b
           cidr: 10.2.20.0/24
         main:
-          zone: us-east-1b
+          zone: us-west-2b
           cidr: 10.2.30.0/24
       service_ports:
         - port: 22
@@ -35,10 +35,11 @@ aws:
           description: "ranges"
   machines:
     dbt2_driver:
+      spot: true
       image_name: debian
-      region: us-east-1
+      region: us-west-2
       zone_name: proxy
-      instance_type: c5.4xlarge
+      instance_type: t3a.medium
       volume:
         type: gp2
         size_gb: 50
@@ -47,16 +48,15 @@ aws:
       tags:
         type: dbt2-driver
     pg1:
-      spot: true
       image_name: rocky
-      region: us-east-1
+      region: us-west-2
       zone_name: main
       ports:
         - protocol: icmp
           description: "ping"
           cidrs:
             - 10.2.20.0/24
-      instance_type: c5.4xlarge
+      instance_type: t3a.medium
       volume:
         type: gp2
         size_gb: 50
@@ -72,15 +72,38 @@ aws:
           size_gb: 100
           encrypted: false
       additional_volumes:
-        - mount_point: /opt/pg_data
-          size_gb: 20
-          type: io2
+        - size_gb: 20
+          type: gp3
+          iops: 4000
+          throughput: 1000
+          encrypted: false
+          volume_group: data
+        - size_gb: 20
+          type: gp2
           iops: 5000
           encrypted: false
-        - mount_point: /opt/pg_wal
+          volume_group: other
+        - mount_point: /opt/test
           size_gb: 20
-          type: io2
+          type: gp2
           iops: 5000
           encrypted: false
+          filesystem: xfs
+        - size_gb: 20
+          type: gp3
+          iops: 4000
+          throughput: 1000
+          encrypted: false
+          volume_group: data
+      volume_groups:
+        data:
+          /opt/data0:
+            size: "50%FREE"
+            filesystem: xfs
+          /opt/data1:
+            size: "50%FREE"
+            filesystem: xfs
+        other:
+          /opt/data2: {}
       tags:
         type: postgres


### PR DESCRIPTION
Allow for creation and formatting of volumes with LVM2. To start, this will assume a striping across all the `volume_group`'s devices.
A new option under `additional_volumes` was added, `volume_group`, to set which volume group it belongs to.
When using `volume_group`, use the `volume_groups` mapping with the `volume_group` as the first key followed by `mount_point` as a nested key to setup logical volumes, filesystem and mounting through `/etc/fstab`.

Example configuration:
```yaml
      additional_volumes:
        - size_gb: 20
          type: gp2
          iops: 5000
          encrypted: false
          volume_group: data
        - size_gb: 20
          type: gp2
          iops: 5000
          encrypted: false
          volume_group: other
        - mount_point: /opt/test
          size_gb: 20
          type: gp2
          iops: 5000
          encrypted: false
          filesystem: xfs
        - size_gb: 20
          type: gp2
          iops: 5000
          encrypted: false
          volume_group: data
      volume_groups:
        data:
          /opt/data0:
            size: "50%FREE"
            filesystem: xfs
          /opt/data1:
            size: "50%FREE"
            filesystem: xfs
        other:
          /opt/data2: {}
```

Final `devices` after mounting:
```json
$ terraform output -json servers | jq .machines.pg1.block_devices.final
{
  "blockdevices": [
    {
      "children": [
        {
          "fstype": "xfs",
          "kname": "nvme0n1p1",
          "label": null,
          "model": null,
          "mountpoint": "/",
          "name": "nvme0n1p1",
          "partlabel": null,
          "parttype": "0x83",
          "partuuid": "ec07056d-01",
          "rev": null,
          "sched": "none",
          "serial": null,
          "size": "50G",
          "type": "part",
          "uuid": "a15f4a29-7fb8-4725-ba35-a9a555640aaf",
          "vendor": null
        }
      ],
      "fstype": null,
      "kname": "nvme0n1",
      "label": null,
      "model": "AmazonElasticBlockStore",
      "mountpoint": null,
      "name": "nvme0n1",
      "partlabel": null,
      "parttype": null,
      "partuuid": null,
      "rev": null,
      "sched": "none",
      "serial": "vol0188e90991d666780",
      "size": "50G",
      "type": "disk",
      "uuid": null,
      "vendor": null
    },
    {
      "fstype": "xfs",
      "kname": "nvme1n1",
      "label": null,
      "model": "AmazonElasticBlockStore",
      "mountpoint": "/opt/test",
      "name": "nvme1n1",
      "partlabel": null,
      "parttype": null,
      "partuuid": null,
      "rev": null,
      "sched": "none",
      "serial": "vol0b032cc9e4817fdd5",
      "size": "20G",
      "type": "disk",
      "uuid": "9853747d-2bbe-44ff-a113-d936a2951a15",
      "vendor": null
    },
    {
      "children": [
        {
          "fstype": "xfs",
          "kname": "dm-0",
          "label": null,
          "model": null,
          "mountpoint": "/opt/data0",
          "name": "data-_opt_data0",
          "partlabel": null,
          "parttype": null,
          "partuuid": null,
          "rev": null,
          "sched": null,
          "serial": null,
          "size": "20G",
          "type": "lvm",
          "uuid": "17bf0930-9851-47ba-b6a3-149ae1eb6b32",
          "vendor": null
        },
        {
          "fstype": "xfs",
          "kname": "dm-1",
          "label": null,
          "model": null,
          "mountpoint": "/opt/data1",
          "name": "data-_opt_data1",
          "partlabel": null,
          "parttype": null,
          "partuuid": null,
          "rev": null,
          "sched": null,
          "serial": null,
          "size": "10G",
          "type": "lvm",
          "uuid": "614050bd-bd1c-4e78-bfae-1609b2352bb3",
          "vendor": null
        }
      ],
      "fstype": "LVM2_member",
      "kname": "nvme2n1",
      "label": null,
      "model": "AmazonElasticBlockStore",
      "mountpoint": null,
      "name": "nvme2n1",
      "partlabel": null,
      "parttype": null,
      "partuuid": null,
      "rev": null,
      "sched": "none",
      "serial": "vol0248941a07e6b8c2e",
      "size": "20G",
      "type": "disk",
      "uuid": "kUpua1-No8w-fgGM-Dx62-tP4p-CyvY-O5HibD",
      "vendor": null
    },
    {
      "children": [
        {
          "fstype": "xfs",
          "kname": "dm-0",
          "label": null,
          "model": null,
          "mountpoint": "/opt/data0",
          "name": "data-_opt_data0",
          "partlabel": null,
          "parttype": null,
          "partuuid": null,
          "rev": null,
          "sched": null,
          "serial": null,
          "size": "20G",
          "type": "lvm",
          "uuid": "17bf0930-9851-47ba-b6a3-149ae1eb6b32",
          "vendor": null
        },
        {
          "fstype": "xfs",
          "kname": "dm-1",
          "label": null,
          "model": null,
          "mountpoint": "/opt/data1",
          "name": "data-_opt_data1",
          "partlabel": null,
          "parttype": null,
          "partuuid": null,
          "rev": null,
          "sched": null,
          "serial": null,
          "size": "10G",
          "type": "lvm",
          "uuid": "614050bd-bd1c-4e78-bfae-1609b2352bb3",
          "vendor": null
        }
      ],
      "fstype": "LVM2_member",
      "kname": "nvme3n1",
      "label": null,
      "model": "AmazonElasticBlockStore",
      "mountpoint": null,
      "name": "nvme3n1",
      "partlabel": null,
      "parttype": null,
      "partuuid": null,
      "rev": null,
      "sched": "none",
      "serial": "vol0b28f4e4837789e74",
      "size": "20G",
      "type": "disk",
      "uuid": "lLblCz-CPqU-iBxe-Dch5-qHpm-mTIL-VnaJEf",
      "vendor": null
    },
    {
      "children": [
        {
          "fstype": "xfs",
          "kname": "dm-2",
          "label": null,
          "model": null,
          "mountpoint": "/opt/data2",
          "name": "other-_opt_data2",
          "partlabel": null,
          "parttype": null,
          "partuuid": null,
          "rev": null,
          "sched": null,
          "serial": null,
          "size": "20G",
          "type": "lvm",
          "uuid": "83b18151-027f-49ee-8631-91a59bdbb33f",
          "vendor": null
        }
      ],
      "fstype": "LVM2_member",
      "kname": "nvme4n1",
      "label": null,
      "model": "AmazonElasticBlockStore",
      "mountpoint": null,
      "name": "nvme4n1",
      "partlabel": null,
      "parttype": null,
      "partuuid": null,
      "rev": null,
      "sched": "none",
      "serial": "vol0b28849332d79c013",
      "size": "20G",
      "type": "disk",
      "uuid": "pHzqOe-2cJB-lGsI-UrKz-d0bN-sw0P-SpZZ27",
      "vendor": null
    }
  ]
}
```

`lsblk` on server:
```shell
[rocky@ip-10-2-30-70 ~]$ lsblk 
NAME               MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1            259:0    0  50G  0 disk 
└─nvme0n1p1        259:1    0  50G  0 part /
nvme1n1            259:2    0  20G  0 disk /opt/test
nvme2n1            259:3    0  20G  0 disk 
├─data-_opt_data0  253:0    0  20G  0 lvm  /opt/data0
└─data-_opt_data1  253:1    0  10G  0 lvm  /opt/data1
nvme3n1            259:4    0  20G  0 disk 
├─data-_opt_data0  253:0    0  20G  0 lvm  /opt/data0
└─data-_opt_data1  253:1    0  10G  0 lvm  /opt/data1
nvme4n1            259:5    0  20G  0 disk 
└─other-_opt_data2 253:2    0  20G  0 lvm  /opt/data2
```