### PR TITLE
Network security groups

### DIFF
--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -9,8 +9,11 @@
 
 ## AWS
 #### CLI Installation
+PIPY's v2 release is `NOT` maintained by AWS
+Instead, install it directly from git or through your package manager.
+If v1 is installled it will have the same executable name as v2.
 ```console
-$ sudo pip3 install awscli
+$ sudo pip3 install https://github.com/aws/aws-cli/archive/refs/heads/v2.zip
 ```
 
 #### CLI Credentials

--- a/docs/examples/aws/machines-v2.yml
+++ b/docs/examples/aws/machines-v2.yml
@@ -21,16 +21,21 @@ aws:
         main:
           zone: us-west-2a
           cidr: 10.2.30.0/24
-      service_ports:
+      ports:
         - port: 22
+          defaults: 'service'
           protocol: tcp
           description: "SSH"
           type: ingress
           cidrs:
             - 0.0.0.0/0
-      region_ports:
+        - port: 443
+          defaults: 'public'
+          protocol: tcp
+          description: "HTTPS"
         - port: 22
           to_port: 65
+          defaults: 'internal'
           protocol: tcp
           description: "ranges"
   machines:

--- a/docs/examples/azure/machines-v2.yml
+++ b/docs/examples/azure/machines-v2.yml
@@ -34,9 +34,13 @@ azure:
           access: allow
           cidrs:
             - 0.0.0.0/0
-      region_ports:
+        - port: 443
+          defaults: 'public'
+          protocol: tcp
+          description: "HTTPS"
         - port: 22
           to_port: 65
+          defaults: 'internal'
           protocol: tcp
           description: "ranges"
   machines:

--- a/docs/examples/gcloud/machines-v2.yml
+++ b/docs/examples/gcloud/machines-v2.yml
@@ -19,17 +19,22 @@ gcloud:
         main:
           zone: us-west4-b
           cidr: 10.2.30.0/24
-      service_ports:
+      ports:
         - port: 22
           protocol: tcp
+          defaults: 'service'
           description: "SSH"
           type: ingress
           access: allow
           cidrs:
             - 0.0.0.0/0
-      region_ports:
+        - port: 443
+          defaults: 'public'
+          protocol: tcp
+          description: "HTTPS"
         - port: 22
           to_port: 65
+          defaults: 'internal'
           protocol: tcp
           description: "ranges"
   machines:

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -16,7 +16,7 @@ module "machine_{{ region_ }}" {
   key_name                 = module.key_pair_{{ region_ }}.key_pair_id
   tags                     = each.value.spec.tags
   public_cidrblocks        = [var.public_cidrblock]
-  service_cidrblocks       = var.service_cidrblocks
+  service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -15,7 +15,7 @@ module "machine_{{ region_ }}" {
   use_agent                = module.spec.base.ssh_key.use_agent
   key_name                 = module.key_pair_{{ region_ }}.key_pair_id
   tags                     = each.value.spec.tags
-  public_cidrblocks        = [var.public_cidrblock]
+  public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
 

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -15,6 +15,9 @@ module "machine_{{ region_ }}" {
   use_agent                = module.spec.base.ssh_key.use_agent
   key_name                 = module.key_pair_{{ region_ }}.key_pair_id
   tags                     = each.value.spec.tags
+  public_cidrblocks        = [var.public_cidrblock]
+  service_cidrblocks       = var.service_cidrblocks
+  internal_cidrblocks      = module.spec.region_cidrblocks
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -34,7 +34,7 @@ module "routes_{{ region_ }}" {
 
   subnet_count       = length([for a, s in lookup(module.spec.region_zone_networks, "{{ region }}", {}) : a])
   vpc_id             = module.vpc_{{ region_ }}.vpc_id
-  public_cidrblock   = var.public_cidrblock
+  public_cidrblock   = "0.0.0.0/0" # Allow all routing
   cluster_name       = module.spec.base.tags.cluster_name
   tags               = module.spec.base.tags
 
@@ -51,7 +51,7 @@ module "security_{{ region_ }}" {
   vpc_id           = module.vpc_{{ region_ }}.vpc_id
   cluster_name     = module.spec.base.tags.cluster_name
   ports            = try(module.spec.region_ports["{{ region }}"], [])
-  public_cidrblocks = [var.public_cidrblock]
+  public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = local.service_cidrblocks
   internal_cidrblocks = module.spec.region_cidrblocks
   tags             = module.spec.base.tags

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -51,8 +51,9 @@ module "security_{{ region_ }}" {
   vpc_id           = module.vpc_{{ region_ }}.vpc_id
   cluster_name     = module.spec.base.tags.cluster_name
   ports            = try(module.spec.region_ports["{{ region }}"], [])
-  ingress_cidrs    = module.spec.region_cidrblocks
-  egress_cidrs     = module.spec.region_cidrblocks
+  public_cidrblocks = [var.public_cidrblock]
+  service_cidrblocks = var.service_cidrblocks
+  internal_cidrblocks = module.spec.region_cidrblocks
   tags             = module.spec.base.tags
 
   depends_on = [module.routes_{{ region_ }}]

--- a/edbterraform/data/templates/aws/network.tf.j2
+++ b/edbterraform/data/templates/aws/network.tf.j2
@@ -52,7 +52,7 @@ module "security_{{ region_ }}" {
   cluster_name     = module.spec.base.tags.cluster_name
   ports            = try(module.spec.region_ports["{{ region }}"], [])
   public_cidrblocks = [var.public_cidrblock]
-  service_cidrblocks = var.service_cidrblocks
+  service_cidrblocks = local.service_cidrblocks
   internal_cidrblocks = module.spec.region_cidrblocks
   tags             = module.spec.base.tags
 

--- a/edbterraform/data/templates/aws/validation.tf.j2
+++ b/edbterraform/data/templates/aws/validation.tf.j2
@@ -5,7 +5,6 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
-  service_cidrblocks = var.service_cidrblocks
 }
 
 # All modules should use the last created module in their depends_on through jinja

--- a/edbterraform/data/templates/aws/validation.tf.j2
+++ b/edbterraform/data/templates/aws/validation.tf.j2
@@ -5,6 +5,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  service_cidrblocks = var.service_cidrblocks
 }
 
 # All modules should use the last created module in their depends_on through jinja

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -22,7 +22,7 @@ module "machine_{{ region_ }}" {
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
   public_cidrblocks               = [var.public_cidrblock]
-  service_cidrblocks              = var.service_cidrblocks
+  service_cidrblocks              = local.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
 
   depends_on = [

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -21,7 +21,7 @@ module "machine_{{ region_ }}" {
   use_agent                       = module.spec.base.ssh_key.use_agent
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
-  public_cidrblocks               = [var.public_cidrblock]
+  public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = local.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
 

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -21,6 +21,9 @@ module "machine_{{ region_ }}" {
   use_agent                       = module.spec.base.ssh_key.use_agent
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
+  public_cidrblocks               = [var.public_cidrblock]
+  service_cidrblocks              = var.service_cidrblocks
+  internal_cidrblocks             = module.spec.region_cidrblocks
 
   depends_on = [
     module.key_pair_{{ region_ }},

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -43,7 +43,7 @@ module "security_{{ region_ }}" {
   region            = module.vpc_{{ region_ }}.region
   resource_name     = module.vpc_{{ region_ }}.resource_name
   ports             = try(module.spec.region_ports["{{ region }}"], [])
-  public_cidrblocks        = [var.public_cidrblock]
+  public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
   tags              = module.spec.base.tags

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -44,7 +44,7 @@ module "security_{{ region_ }}" {
   resource_name     = module.vpc_{{ region_ }}.resource_name
   ports             = try(module.spec.region_ports["{{ region }}"], [])
   public_cidrblocks        = [var.public_cidrblock]
-  service_cidrblocks       = var.service_cidrblocks
+  service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
   tags              = module.spec.base.tags
 

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -46,6 +46,7 @@ module "security_{{ region_ }}" {
   public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
+  target_cidrblocks        = [module.spec.base.regions["{{ region }}"].cidr_block]
   tags              = module.spec.base.tags
 
   depends_on = [module.network_{{ region_ }}]

--- a/edbterraform/data/templates/azure/network.tf.j2
+++ b/edbterraform/data/templates/azure/network.tf.j2
@@ -43,8 +43,9 @@ module "security_{{ region_ }}" {
   region            = module.vpc_{{ region_ }}.region
   resource_name     = module.vpc_{{ region_ }}.resource_name
   ports             = try(module.spec.region_ports["{{ region }}"], [])
-  ingress_cidrs     = module.spec.region_cidrblocks
-  egress_cidrs      = module.spec.region_cidrblocks
+  public_cidrblocks        = [var.public_cidrblock]
+  service_cidrblocks       = var.service_cidrblocks
+  internal_cidrblocks      = module.spec.region_cidrblocks
   tags              = module.spec.base.tags
 
   depends_on = [module.network_{{ region_ }}]

--- a/edbterraform/data/templates/azure/validation.tf.j2
+++ b/edbterraform/data/templates/azure/validation.tf.j2
@@ -6,6 +6,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  service_cidrblocks = var.service_cidrblocks
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/templates/azure/validation.tf.j2
+++ b/edbterraform/data/templates/azure/validation.tf.j2
@@ -6,7 +6,6 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
-  service_cidrblocks = var.service_cidrblocks
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -17,6 +17,9 @@ module "machine_{{ region_ }}" {
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone_name].name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
+  public_cidrblocks               = [var.public_cidrblock]
+  service_cidrblocks              = var.service_cidrblocks
+  internal_cidrblocks             = module.spec.region_cidrblocks
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -17,7 +17,7 @@ module "machine_{{ region_ }}" {
   subnet_name                     = module.network_{{ region_ }}[each.value.spec.zone_name].name
   name_id                         = module.spec.hex_id
   tags                            = each.value.spec.tags
-  public_cidrblocks               = [var.public_cidrblock]
+  public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = var.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
 

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -61,6 +61,7 @@ module "security_{{ region_ }}" {
   public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
+  target_cidrblocks        = [module.spec.base.regions["{{ region }}"].cidr_block]
   region        = "{{ region }}"
   name_id       = module.spec.hex_id
 

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -59,7 +59,7 @@ module "security_{{ region_ }}" {
   network_name  = module.vpc_{{ region_ }}.vpc_id
   ports         = try(module.spec.region_ports["{{ region }}"], [])
   public_cidrblocks        = [var.public_cidrblock]
-  service_cidrblocks       = var.service_cidrblocks
+  service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
   region        = "{{ region }}"
   name_id       = module.spec.hex_id

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -58,7 +58,7 @@ module "security_{{ region_ }}" {
 
   network_name  = module.vpc_{{ region_ }}.vpc_id
   ports         = try(module.spec.region_ports["{{ region }}"], [])
-  public_cidrblocks        = [var.public_cidrblock]
+  public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
   region        = "{{ region }}"

--- a/edbterraform/data/templates/gcloud/network.tf.j2
+++ b/edbterraform/data/templates/gcloud/network.tf.j2
@@ -58,8 +58,9 @@ module "security_{{ region_ }}" {
 
   network_name  = module.vpc_{{ region_ }}.vpc_id
   ports         = try(module.spec.region_ports["{{ region }}"], [])
-  ingress_cidrs = module.spec.region_cidrblocks
-  egress_cidrs  = module.spec.region_cidrblocks
+  public_cidrblocks        = [var.public_cidrblock]
+  service_cidrblocks       = var.service_cidrblocks
+  internal_cidrblocks      = module.spec.region_cidrblocks
   region        = "{{ region }}"
   name_id       = module.spec.hex_id
 

--- a/edbterraform/data/templates/gcloud/validation.tf.j2
+++ b/edbterraform/data/templates/gcloud/validation.tf.j2
@@ -6,6 +6,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  service_cidrblocks = var.service_cidrblocks
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/templates/gcloud/validation.tf.j2
+++ b/edbterraform/data/templates/gcloud/validation.tf.j2
@@ -6,7 +6,6 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
-  service_cidrblocks = var.service_cidrblocks
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -21,6 +21,10 @@ module "machine_ports" {
   cluster_name     = var.machine.name
   ports            = local.machine_ports
   tags             = var.tags
+  public_cidrblocks = var.public_cidrblocks
+  service_cidrblocks = var.service_cidrblocks
+  internal_cidrblocks = var.internal_cidrblocks
+
 }
 
 resource "aws_instance" "machine" {

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -1,4 +1,8 @@
 variable "machine" {}
+variable "public_cidrblocks" {}
+variable "service_cidrblocks" {}
+variable "internal_cidrblocks" {}
+
 locals {
   # Allow machine default outbound access if no egress is defined
   egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -28,6 +28,11 @@ resource "aws_security_group_rule" "rule" {
     }
 
     precondition {
+      error_message = "port defaults must be one of: service, public, internal or an empty string ('')"
+      condition = contains(["service", "internal", "public", ""], try(each.value.defaults, ""))
+    }
+
+    precondition {
       condition     = each.value.cidrs != null && length(each.value.cidrs) > 0
       error_message = <<-EOT
         Cidr blocks cannot be an empty list.

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -14,22 +14,9 @@ locals {
       values.cidr_block
   ])
 
-  # Set defaults when cidrs list is not set
-  # service ports should be set to service_cidrblocks
-  # region ports should be set to region_cidrblocks
+  # save ports per region
   region_ports = {
-    for region, values in var.spec.regions: region => flatten([
-      [
-        for port in values.service_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, var.service_cidrblocks)
-        })
-      ],
-      [
-        for port in values.region_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, local.region_cidrblocks)
-        })
-      ]
-    ])
+    for region, values in var.spec.regions: region => values.ports
   }
 }
 

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -41,15 +41,8 @@ variable "spec" {
       # 0.0.0.0/0 defaults can be blocked by IT.
       # Instead, use region_ports as the default and if user wants access,
       # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
-      service_ports = optional(list(object({
-        port        = optional(number)
-        to_port     = optional(number)
-        protocol    = string
-        description = optional(string, "default")
-        type = optional(string, "ingress")
-        cidrs = optional(list(string))
-      })), [])
-      region_ports = optional(list(object({
+      ports = optional(list(object({
+        defaults     = optional(string, "service")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -66,6 +59,7 @@ variable "spec" {
       region        = string
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
+        defaults    = optional(string, "internal")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -197,12 +191,6 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
-}
-
-variable "service_cidrblocks" {
-  default = ["0.0.0.0/0"]
-  type = list(string)
-  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -38,7 +38,7 @@ variable "spec" {
         cidr = optional(string)
       })), {})
       ports = optional(list(object({
-        defaults     = optional(string, "service")
+        defaults     = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -55,7 +55,7 @@ variable "spec" {
       region        = string
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
-        defaults    = optional(string, "internal")
+        defaults    = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -47,7 +47,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
-        cidrs = optional(list(string), ["0.0.0.0/0"])
+        cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
@@ -197,6 +197,12 @@ variable "spec" {
       tags          = optional(map(string), {})
     })), {})
   })
+}
+
+variable "service_cidrblocks" {
+  default = ["0.0.0.0/0"]
+  type = list(string)
+  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -37,10 +37,6 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
-      # TODO: Collapse service and regions ports into one
-      # 0.0.0.0/0 defaults can be blocked by IT.
-      # Instead, use region_ports as the default and if user wants access,
-      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       ports = optional(list(object({
         defaults     = optional(string, "service")
         port        = optional(number)
@@ -48,7 +44,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
-        cidrs = optional(list(string))
+        cidrs = optional(list(string), [])
       })), [])
     }))
     machines = optional(map(object({
@@ -65,7 +61,7 @@ variable "spec" {
         protocol    = string
         description = optional(string, "default")
         type = optional(string, "ingress")
-        cidrs = optional(list(string))
+        cidrs = optional(list(string), [])
         })), []
       )
       zone_name     = string

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -96,8 +96,9 @@ module "machine_ports" {
   region           = var.machine.region
   resource_name    = var.resource_name
   ports            = var.ports
-  ingress_cidrs    = flatten([azurerm_linux_virtual_machine.main.public_ip_address, azurerm_linux_virtual_machine.main.private_ip_addresses])  
-  egress_cidrs     = flatten([azurerm_linux_virtual_machine.main.public_ip_address, azurerm_linux_virtual_machine.main.private_ip_addresses])
+  public_cidrblocks = var.public_cidrblocks
+  service_cidrblocks = var.service_cidrblocks
+  internal_cidrblocks = var.internal_cidrblocks
   tags             = var.tags
 }
 

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -99,6 +99,10 @@ module "machine_ports" {
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
   internal_cidrblocks = var.internal_cidrblocks
+  target_cidrblocks = formatlist("%s/32",[
+    azurerm_linux_virtual_machine.main.public_ip_address,
+    azurerm_linux_virtual_machine.main.private_ip_address,
+  ])
   tags             = var.tags
 }
 

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -29,6 +29,9 @@ variable "machine" {
     })
   })
 }
+variable "public_cidrblocks" {}
+variable "service_cidrblocks" {}
+variable "internal_cidrblocks" {}
 variable "ports" {
   type = list
   default = []

--- a/edbterraform/data/terraform/azure/modules/security/main.tf
+++ b/edbterraform/data/terraform/azure/modules/security/main.tf
@@ -39,5 +39,10 @@ resource "azurerm_network_security_rule" "rules" {
       condition     = each.value.type == "ingress" || each.value.type == "egress"
       error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
     }
+
+    precondition {
+      error_message = "port defaults must be one of: service, public, internal or an empty string ('')"
+      condition = contains(["service", "internal", "public", ""], try(each.value.defaults, ""))
+    }
   }
 }

--- a/edbterraform/data/terraform/azure/modules/security/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/security/variables.tf
@@ -4,11 +4,20 @@ variable "region" {}
 variable "ports" {
     type = list
 }
-variable "ingress_cidrs" {
-    type = list(string)
+variable "public_cidrblocks" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+  nullable = false
 }
-variable "egress_cidrs" {
-    type = list(string)
+variable "internal_cidrblocks" {
+  type = list(string)
+  default = []
+  nullable = false
+}
+variable "service_cidrblocks" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+  nullable = false
 }
 variable "name_id" {
     type = string

--- a/edbterraform/data/terraform/azure/modules/security/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/security/variables.tf
@@ -16,10 +16,20 @@ variable "internal_cidrblocks" {
 }
 variable "service_cidrblocks" {
   type = list(string)
-  default = ["0.0.0.0/0"]
+  default = []
   nullable = false
 }
 variable "name_id" {
     type = string
 }
 variable "tags" {}
+
+variable "target_cidrblocks" {
+  type = list(string)
+  default = []
+  nullable = false
+}
+
+locals {
+  target_cidrblocks = length(var.target_cidrblocks) > 0 ? var.target_cidrblocks : var.internal_cidrblocks
+}

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -14,22 +14,9 @@ locals {
       values.cidr_block
   ])
 
-  # Set defaults when cidrs list is not set
-  # service ports should be set to service_cidrblocks
-  # region ports should be set to region_cidrblocks
+  # save ports per region
   region_ports = {
-    for region, values in var.spec.regions: region => flatten([
-      [
-        for port in values.service_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, var.service_cidrblocks)
-        })
-      ],
-      [
-        for port in values.region_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, local.region_cidrblocks)
-        })
-      ]
-    ])
+    for region, values in var.spec.regions: region => values.ports
   }
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -40,10 +40,6 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
-      # TODO: Collapse service and regions ports into one
-      # 0.0.0.0/0 defaults can be blocked by IT.
-      # Instead, use region_ports as the default and if user wants access,
-      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       ports = optional(list(object({
         defaults    = optional(string, "service")
         port        = optional(number)
@@ -52,7 +48,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs = optional(list(string))
+        cidrs = optional(list(string), [])
       })), [])
     }))
     machines = optional(map(object({
@@ -71,7 +67,7 @@ variable "spec" {
         description = optional(string, "default")
         type        = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs       = optional(list(string))
+        cidrs       = optional(list(string), [])
         })), []
       )
       volume = object({

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -44,16 +44,8 @@ variable "spec" {
       # 0.0.0.0/0 defaults can be blocked by IT.
       # Instead, use region_ports as the default and if user wants access,
       # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
-      service_ports = optional(list(object({
-        port        = optional(number)
-        to_port     = optional(number)
-        protocol    = string
-        description = optional(string, "default")
-        type = optional(string, "ingress")
-        access      = optional(string, "allow")
-        cidrs = optional(list(string))
-      })), [])
-      region_ports = optional(list(object({
+      ports = optional(list(object({
+        defaults    = optional(string, "service")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -72,6 +64,7 @@ variable "spec" {
       instance_type = string
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
+        defaults    = optional(string, "internal")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -164,12 +157,6 @@ variable "spec" {
     })), {})
   })
 
-}
-
-variable "service_cidrblocks" {
-  default = ["0.0.0.0/0"]
-  type = list(string)
-  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -41,7 +41,7 @@ variable "spec" {
         cidr = optional(string)
       })), {})
       ports = optional(list(object({
-        defaults    = optional(string, "service")
+        defaults    = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -60,7 +60,7 @@ variable "spec" {
       instance_type = string
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
-        defaults    = optional(string, "internal")
+        defaults    = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -51,7 +51,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs = optional(list(string), ["0.0.0.0/0"])
+        cidrs = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
@@ -60,7 +60,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs = optional(list(string), [])
+        cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({
@@ -78,7 +78,7 @@ variable "spec" {
         description = optional(string, "default")
         type        = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs       = optional(list(string), [])
+        cidrs       = optional(list(string))
         })), []
       )
       volume = object({
@@ -164,6 +164,12 @@ variable "spec" {
     })), {})
   })
 
+}
+
+variable "service_cidrblocks" {
+  default = ["0.0.0.0/0"]
+  type = list(string)
+  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -9,10 +9,10 @@ variable "spec" {
   nullable    = false
 }
 
-variable "public_cidrblock" {
+variable "public_cidrblocks" {
   description = "Public CIDR block"
-  type        = string
-  default     = "0.0.0.0/0"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 
 variable "service_cidrblocks" {
@@ -52,7 +52,7 @@ data "http" "instance_ip" {
 
 locals {
   # format the ip with the mask to get a valid cidr block
-  # ex: cidrhost("1.2.3.4/32",0) => 1.2.3.4 | cidrhost("1.2.3.4/24",0) => 1.2.3.0 | cidrhost("1.2.3.4/16",0) => 1.2.0.0 | cidrhost("1.2.3.4/32",0) => 1.0.0.0
+  # ex: cidrhost("1.2.3.4/32",0) => 1.2.3.4 | cidrhost("1.2.3.4/24",0) => 1.2.3.0 | cidrhost("1.2.3.4/16",0) => 1.2.0.0 | cidrhost("1.2.3.4/8",0) => 1.0.0.0
   dynamic_ip = var.force_dynamic_ip ? [
     "${cidrhost(
         format("%s/%s",

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -9,7 +9,6 @@ variable "spec" {
   nullable    = false
 }
 
-# VPC
 variable "public_cidrblock" {
   description = "Public CIDR block"
   type        = string

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -18,5 +18,48 @@ variable "public_cidrblock" {
 variable "service_cidrblocks" {
   description = "Default cidr blocks for service ports"
   type = list(string)
-  default = ["0.0.0.0/0"]
+  default = []
+}
+
+variable "force_dynamic_ip" {
+  description = "Force the use of a dynamic IP address which will be appended to service_cidrblocks"
+  type = bool
+  default = false
+}
+
+variable "dynamic_service_ip_mask" {
+  type = number
+  default = 32
+  nullable = false
+}
+
+variable "dynamic_service_ip_url" {
+  type = string
+  default = "https://ipinfo.io/ip"
+  nullable = false
+}
+
+# Keep at the root level so that it is always a known value.
+# Data sources within modules are not computed until the module is instantiated,
+#  which causes for_each loops to fail since it is an unknown computed value.
+data "http" "instance_ip" {
+  count = var.force_dynamic_ip ? 1 : 0
+  url = var.dynamic_service_ip_url
+  request_headers = {
+    Accept = "application/text"
+  }
+}
+
+locals {
+  # format the ip with the mask to get a valid cidr block
+  # ex: cidrhost("1.2.3.4/32",0) => 1.2.3.4 | cidrhost("1.2.3.4/24",0) => 1.2.3.0 | cidrhost("1.2.3.4/16",0) => 1.2.0.0 | cidrhost("1.2.3.4/32",0) => 1.0.0.0
+  dynamic_ip = var.force_dynamic_ip ? [
+    "${cidrhost(
+        format("%s/%s",
+          split("/", data.http.instance_ip[0].response_body)[0], # Drop any prefined masks
+          var.dynamic_service_ip_mask),
+        0)
+    }/${var.dynamic_service_ip_mask}"
+  ] : []
+  service_cidrblocks = concat(var.service_cidrblocks, local.dynamic_ip)
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -63,6 +63,10 @@ module "machine_ports" {
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
   internal_cidrblocks = var.internal_cidrblocks
+  target_cidrblocks = formatlist("%s/32", [
+    google_compute_instance.machine.network_interface.0.access_config.0.nat_ip,
+    google_compute_instance.machine.network_interface.0.network_ip,
+  ])
   region           = var.machine.spec.region
   name_id          = "${var.machine.name}-${var.name_id}"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -60,8 +60,9 @@ module "machine_ports" {
 
   network_name     = var.network_name
   ports            = var.machine.spec.ports
-  ingress_cidrs    = flatten([google_compute_instance.machine.network_interface.*.network_ip, google_compute_instance.machine.network_interface[*].access_config.*.nat_ip])
-  egress_cidrs     = flatten([google_compute_instance.machine.network_interface.*.network_ip, google_compute_instance.machine.network_interface[*].access_config.*.nat_ip])
+  public_cidrblocks = var.public_cidrblocks
+  service_cidrblocks = var.service_cidrblocks
+  internal_cidrblocks = var.internal_cidrblocks
   region           = var.machine.spec.region
   name_id          = "${var.machine.name}-${var.name_id}"
 }

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -1,4 +1,7 @@
 variable "machine" {}
+variable "public_cidrblocks" {}
+variable "service_cidrblocks" {}
+variable "internal_cidrblocks" {}
 variable "zone" {}
 variable "ssh_priv_key" {}
 variable "ssh_pub_key" {}

--- a/edbterraform/data/terraform/gcloud/modules/security/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/main.tf
@@ -46,5 +46,10 @@ resource "google_compute_firewall" "rules" {
       condition     = each.value.type == "ingress" || each.value.type == "egress"
       error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
     }
+
+    precondition {
+      error_message = "port defaults must be one of: service, public, internal or an empty string ('')"
+      condition = contains(["service", "internal", "public", ""], try(each.value.defaults, ""))
+    }
   }
 }

--- a/edbterraform/data/terraform/gcloud/modules/security/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/main.tf
@@ -28,20 +28,18 @@ resource "google_compute_firewall" "rules" {
     }
   }
   direction = lower(each.value.type) == "ingress" ? "INGRESS" : "EGRESS"
-  source_ranges = lower(each.value.type) != "ingress" ? var.public_cidrblocks :
-                    coalesce(each.value.cidrs,
-                              try(port.defaults, "") == "service" ? var.service_cidrblocks :
-                              try(port.defaults, "") == "public" ? var.public_cidrblocks :
-                              try(port.defaults, "") == "internal" ? var.internal_cidrblocks :
+  source_ranges = lower(each.value.type) == "ingress" ? concat(each.value.cidrs,
+                              try(each.value.defaults, "") == "service" ? var.service_cidrblocks :
+                              try(each.value.defaults, "") == "public" ? var.public_cidrblocks :
+                              try(each.value.defaults, "") == "internal" ? var.internal_cidrblocks :
                               []
-                            )...
-  destination_ranges = lower(each.value.type) != "egress" ? var.public_cidrblocks :
-                         coalesce(each.value.cidrs,
-                                   try(port.defaults, "") == "service" ? var.service_cidrblocks :
-                                   try(port.defaults, "") == "public" ? var.public_cidrblocks :
-                                   try(port.defaults, "") == "internal" ? var.internal_cidrblocks :
+                            ) : local.target_cidrblocks
+  destination_ranges = lower(each.value.type) == "ingress" ? local.target_cidrblocks : concat(each.value.cidrs,
+                                   try(each.value.defaults, "") == "service" ? var.service_cidrblocks :
+                                   try(each.value.defaults, "") == "public" ? var.public_cidrblocks :
+                                   try(each.value.defaults, "") == "internal" ? var.internal_cidrblocks :
                                    []
-                                 )...
+                                 )
 
   lifecycle {
     precondition {

--- a/edbterraform/data/terraform/gcloud/modules/security/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/variables.tf
@@ -2,9 +2,18 @@ variable "network_name" {}
 variable "name_id" {}
 variable "region" {}
 variable "ports" {}
-variable "ingress_cidrs" {
+variable "public_cidrblocks" {
   type = list(string)
+  default = ["0.0.0.0/0"]
+  nullable = false
 }
-variable "egress_cidrs" {
+variable "internal_cidrblocks" {
   type = list(string)
+  default = []
+  nullable = false
+}
+variable "service_cidrblocks" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+  nullable = false
 }

--- a/edbterraform/data/terraform/gcloud/modules/security/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/security/variables.tf
@@ -14,6 +14,16 @@ variable "internal_cidrblocks" {
 }
 variable "service_cidrblocks" {
   type = list(string)
-  default = ["0.0.0.0/0"]
+  default = []
   nullable = false
+}
+
+variable "target_cidrblocks" {
+  type = list(string)
+  default = []
+  nullable = false
+}
+
+locals {
+  target_cidrblocks = length(var.target_cidrblocks) > 0 ? var.target_cidrblocks : var.internal_cidrblocks
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -7,6 +7,30 @@ locals {
     created_by      = local.created_by
     cluster_name    = local.cluster_name
   })
+
+  # each regions cidrblock, should not overlap since we perform VPC peering
+  region_cidrblocks = flatten([
+    for region, values in var.spec.regions:
+      values.cidr_block
+  ])
+
+  # Set defaults when cidrs list is not set
+  # service ports should be set to service_cidrblocks
+  # region ports should be set to region_cidrblocks
+  region_ports = {
+    for region, values in var.spec.regions: region => flatten([
+      [
+        for port in values.service_ports: merge(port, {
+          cidrs = coalesce(port.cidrs, var.service_cidrblocks)
+        })
+      ],
+      [
+        for port in values.region_ports: merge(port, {
+          cidrs = coalesce(port.cidrs, local.region_cidrblocks)
+        })
+      ]
+    ])
+  }
 }
 
 output "base" {
@@ -135,16 +159,10 @@ output "region_zone_networks" {
 
 output "region_cidrblocks" {
   description = "list of all cidrs from each defined zone"
-  value = flatten([
-    for region, values in var.spec.regions:
-      values.cidr_block
-  ])
+  value = local.region_cidrblocks
 }
 
 output "region_ports" {
   description = "mapping of region to its list of port rules"
-  value = {
-    for region, values in var.spec.regions:
-      region => flatten([values.service_ports, values.region_ports])
-  }
+  value = local.region_ports
 }

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -14,22 +14,9 @@ locals {
       values.cidr_block
   ])
 
-  # Set defaults when cidrs list is not set
-  # service ports should be set to service_cidrblocks
-  # region ports should be set to region_cidrblocks
+  # save ports per region
   region_ports = {
-    for region, values in var.spec.regions: region => flatten([
-      [
-        for port in values.service_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, var.service_cidrblocks)
-        })
-      ],
-      [
-        for port in values.region_ports: merge(port, {
-          cidrs = coalesce(port.cidrs, local.region_cidrblocks)
-        })
-      ]
-    ])
+    for region, values in var.spec.regions: region => values.ports
   }
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -38,10 +38,6 @@ variable "spec" {
         zone = optional(string)
         cidr = optional(string)
       })), {})
-      # TODO: Collapse service and regions ports into one
-      # 0.0.0.0/0 defaults can be blocked by IT.
-      # Instead, use region_ports as the default and if user wants access,
-      # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
       ports = optional(list(object({
         defaults    = optional(string, "service")
         port        = optional(number)
@@ -50,7 +46,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs       = optional(list(string))
+        cidrs       = optional(list(string), [])
       })), [])
     }))
     machines = optional(map(object({
@@ -70,7 +66,7 @@ variable "spec" {
         description = optional(string, "default")
         type        = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs       = optional(list(string))
+        cidrs       = optional(list(string), [])
       })), [])
       volume = object({
         type      = string

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -42,7 +42,8 @@ variable "spec" {
       # 0.0.0.0/0 defaults can be blocked by IT.
       # Instead, use region_ports as the default and if user wants access,
       # they will need to specify the allowed ranges: home ip, elastic IPs, VPN/Proxy IPs
-      service_ports = optional(list(object({
+      ports = optional(list(object({
+        defaults    = optional(string, "service")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -50,15 +51,6 @@ variable "spec" {
         type = optional(string, "ingress")
         access      = optional(string, "allow")
         cidrs       = optional(list(string))
-      })), [])
-      region_ports = optional(list(object({
-        port        = optional(number)
-        to_port     = optional(number)
-        protocol    = string
-        description = optional(string, "default")
-        type = optional(string, "ingress")
-        access      = optional(string, "allow")
-        cidrs = optional(list(string))
       })), [])
     }))
     machines = optional(map(object({
@@ -71,6 +63,7 @@ variable "spec" {
       ip_forward    = optional(bool)
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
+        defaults      = optional(string, "internal")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -172,12 +165,6 @@ variable "spec" {
     })), {})
   })
 
-}
-
-variable "service_cidrblocks" {
-  default = ["0.0.0.0/0"]
-  type = list(string)
-  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -49,7 +49,7 @@ variable "spec" {
         description = optional(string, "default")
         type = optional(string, "ingress")
         access      = optional(string, "allow")
-        cidrs = optional(list(string), ["0.0.0.0/0"])
+        cidrs       = optional(list(string))
       })), [])
       region_ports = optional(list(object({
         port        = optional(number)
@@ -172,6 +172,12 @@ variable "spec" {
     })), {})
   })
 
+}
+
+variable "service_cidrblocks" {
+  default = ["0.0.0.0/0"]
+  type = list(string)
+  nullable = false
 }
 
 locals {

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -39,7 +39,7 @@ variable "spec" {
         cidr = optional(string)
       })), {})
       ports = optional(list(object({
-        defaults    = optional(string, "service")
+        defaults    = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string
@@ -59,7 +59,7 @@ variable "spec" {
       ip_forward    = optional(bool)
       ssh_port      = optional(number, 22)
       ports         = optional(list(object({
-        defaults      = optional(string, "internal")
+        defaults      = optional(string, "")
         port        = optional(number)
         to_port     = optional(number)
         protocol    = string

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -629,6 +629,19 @@ def spec_compatability(infrastructure_variables, cloud_service_provider):
                         'cidr': cidr,
                     }
                 spec_variables['regions'][region]['zones'] = temp
+            # Handle ports as a single list of ports
+            ports = []
+            for port in spec_variables['regions'][region].get('service_ports', []):
+                ports.append({'defaults': 'service' ,**port})
+            if spec_variables['regions'][region].get('service_ports', []):
+                del spec_variables['regions'][region]['service_ports']
+            for port in spec_variables['regions'][region].get('region_ports', []):
+                ports.append({'defaults': 'internal' ,**port})
+            if spec_variables['regions'][region].get('region_ports', []):
+                del spec_variables['regions'][region]['region_ports']
+            if 'ports' not in spec_variables['regions'][region]:
+                spec_variables['regions'][region]['ports'] = []
+            spec_variables['regions'][region]['ports'].extend(ports)
 
     if 'machines' in spec_variables:
         for machine in spec_variables['machines']:


### PR DESCRIPTION
BREAKING CHANGES:
- `service_cidrblocks` default open access removed. This can lead to unexpected open ports and expose resources that are not properly secured. You can still manually set `0.0.0.0/0` or make use of the new cli options to dynamically set the service cidr blocks.

Changes:
- `service_cidrblocks` can be updated with a list of cidrs to amend the ip allowlist for service connections.
  - `TF_VAR_service_cidrblocks='["100.100.200.4/32"]' terraform apply`
- `force_dynamic_ip` can be set to fetch the controller's ip to be appended to the `service_cidrblocks`.
  - `TF_VAR_force_dynamic_ip=true terraform apply`
- region_ports merged under port with defaults = internal
- service_ports merged under port with defaults = service
- port `defaults` is unused by default to avoid unexpected open connections.
- 4 port `defaults` options available:
  - `internal` - region cidrblocks for internal networking
  - `public` - any access cidrblocks
  - `service` - service access cidrblocks
  - `""` - no cidrblock defaults