### PR TITLE
Cloud CLIs

### DIFF
--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import shutil
 from urllib import request as Request
 import subprocess
-import stat
 import json
 import textwrap
 from typing import Union
@@ -14,7 +13,7 @@ from typing import Union
 from edbterraform import __dot_project__
 from edbterraform.utils.logs import logger
 from edbterraform.utils.files import checksum_verify
-from edbterraform.utils.script import execute_shell, get_binary
+from edbterraform.utils.script import execute_shell, binary_path
 
 Version = namedtuple('Version', ['major', 'minor', 'patch'])
 
@@ -33,21 +32,21 @@ class TerraformCLI:
     arch_alias = {
         'x86_64': 'amd64',
     }
-    DEFAULT_PATH = __dot_project__
+    DOT_PATH = __dot_project__
     plan_file = 'terraform.plan'
 
     def __init__(self, binary_dir=None, version=None):
-        self.bin_dir = binary_dir if binary_dir else self.DEFAULT_PATH
+        self.bin_dir = binary_dir if binary_dir else self.DOT_PATH
         self.skip_install = str(version) == "0"
         self.version = self.get_max_version() if not version or self.skip_install else version
-        self.default_path = f'{self.bin_dir}/terraform/{self.version}/bin'
-        self.bin_path = self.default_path if self.bin_dir == self.DEFAULT_PATH else os.path.join(self.bin_dir, 'bin')
+        self.default_path = f'{self.bin_dir}/{self.binary_name}/{self.version}/bin'
+        self.bin_path = self.default_path if self.bin_dir == self.DOT_PATH else os.path.join(self.bin_dir, 'bin')
         self.binary_full_path = os.path.join(self.bin_path, self.binary_name)
         self.architecture = self.arch_alias.get(platform.machine().lower(),platform.machine().lower())
         self.operating_system = platform.system().lower()
 
     def get_binary(self):
-        return get_binary(self.binary_name, self.bin_path, self.default_path)
+        return binary_path(self.binary_name, self.bin_path, self.default_path)
 
     def get_compatible_terraform(self):
         version = self.check_version()
@@ -190,6 +189,10 @@ class TerraformCLI:
     def get_max_version(cls):
         return join_version(cls.max_version, '.')
 
+    @classmethod
+    def get_min_version(cls):
+        return join_version(cls.min_version)
+
     def install(self):
         if self.skip_install:
             logger.info('Terraform 0 version used, skipping installation')
@@ -239,14 +242,14 @@ class JqCLI:
     arch_alias = {
         'x86_64': 'amd64',
     }
-    DEFAULT_PATH = __dot_project__
+    DOT_PATH = __dot_project__
 
     def __init__(self, binary_dir=None, version=None):
-        self.bin_dir = binary_dir if binary_dir else self.DEFAULT_PATH
+        self.bin_dir = binary_dir if binary_dir else self.DOT_PATH
         self.skip_install = str(version) == "0"
         self.version = self.get_max_version() if not version or self.skip_install else version
-        self.default_path = f'{self.bin_dir}/jq/{self.version}/bin'
-        self.bin_path =  self.default_path if self.bin_dir == self.DEFAULT_PATH else os.path.join(self.bin_dir, 'bin')
+        self.default_path = f'{self.bin_dir}/{self.binary_name}/{self.version}/bin'
+        self.bin_path =  self.default_path if self.bin_dir == self.DOT_PATH else os.path.join(self.bin_dir, 'bin')
         self.binary_full_path = os.path.join(self.bin_path, self.binary_name)
         self.architecture = self.arch_alias.get(platform.machine().lower(),platform.machine().lower())
         self.operating_system = platform.system().lower()
@@ -291,7 +294,7 @@ class JqCLI:
             raise e(f'version keyname was not found')
 
     def get_binary(self):
-        return get_binary(self.binary_name, self.bin_path, self.default_path)
+        return binary_path(self.binary_name, self.bin_path, self.default_path)
 
     def install(self):
 

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -11,7 +11,7 @@ from functools import partial
 import json
 
 from edbterraform.lib import generate_terraform
-from edbterraform.CLI import TerraformCLI, JqCLI, AwsCLI, AzureCLI, GoogleCLI
+from edbterraform.CLI import TerraformCLI, JqCLI, AwsCLI, AzureCLI, GoogleCLI, BigAnimalCLI
 from edbterraform import __project_name__, __dot_project__, __version__
 from edbterraform.utils import logs, files
 
@@ -222,7 +222,7 @@ JqVersion = ArgumentConfig(
 
 AwsVersion = ArgumentConfig(
     names = [f'--{AwsCLI.binary_name.lower()}-cli-version',],
-    metavar=f'--{AwsCLI.binary_name.upper()}_CLI_VERSION',
+    metavar=f'{AwsCLI.binary_name.upper()}_CLI_VERSION',
     dest=f'--{AwsCLI.binary_name.lower()}_cli_version',
     required=False,
     default=AwsCLI.max_version.to_string(),
@@ -255,6 +255,19 @@ GcloudVersion = ArgumentConfig(
     help=f'''
         GoogleCLI version to install or use. Set to 0 to skip.
         Compatible versions: {GoogleCLI.min_version.to_string()} <= x <= {GoogleCLI.max_version.to_string()}
+        Default: %(default)s
+        '''
+)
+
+BigAnimalVersion = ArgumentConfig(
+    names = [f'--{BigAnimalCLI.binary_name.lower()}-cli-version',],
+    metavar=f'{BigAnimalCLI.binary_name.upper()}_CLI_VERSION',
+    dest=f'{BigAnimalCLI.binary_name.lower()}_cli_version',
+    required=False,
+    default=BigAnimalCLI.max_version.to_string(),
+    help=f'''
+        BigAnimalCLI version to install or use. Set to 0 to skip.
+        Compatible versions: {BigAnimalCLI.min_version.to_string()} <= x <= {BigAnimalCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -400,6 +413,7 @@ class Arguments:
             AwsVersion,
             AzureVersion,
             GcloudVersion,
+            BigAnimalVersion,
         ]],
         'version': ['Print the version of edb-terraform\n', []],
     })
@@ -520,7 +534,7 @@ class Arguments:
 
         if self.command == 'setup':
             installed = {}
-            for tool in [TerraformCLI, JqCLI, AwsCLI, AzureCLI, GoogleCLI]:
+            for tool in [TerraformCLI, JqCLI, AwsCLI, AzureCLI, GoogleCLI, BigAnimalCLI]:
                 name = tool.binary_name
                 tool = tool(self.get_env('bin_path'), self.get_env(f'{name}_cli_version'))
                 tool.install()

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -310,9 +310,10 @@ LogLevel = ArgumentConfig(
     names = ['--log-level',],
     dest='log_level',
     required=False,
-    default="INFO",
-    help='''
-        Default: %(default)s
+    default=logs.LogLevel.INFO,
+    help=f'''
+        Default: %(default)s |
+        Options - {logs.LogLevel.available_options()}
         '''
 )
 

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -79,11 +79,11 @@ class ArgumentConfig:
 BinPath = ArgumentConfig(
     names = ['--bin-path'],
     dest  = 'bin_path',
-    default = TerraformCLI.DEFAULT_PATH,
+    default = __dot_project__,
     required = False,
     help = '''
-            Default location to install binaries.
-            It will default to users home directory.
+            Default location to install/check binaries.
+            When using the default, it will be updated per tool under $HOME/.edb-terraform/<TOOLNAME>/<VERSION>/bin/<TOOLNAME>
             Default: %(default)s
            ''',
 )

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -356,11 +356,11 @@ LogDirectory = ArgumentConfig(
 )
 
 LogStdout = ArgumentConfig(
-    names = ['--log-stdout',],
-    dest='log_stdout',
+    names = ['--no-console-log',],
+    dest='no_console_log',
     action='store_true',
     required=False,
-    default=True,
+    default=False,
     help='''
         Default: %(default)s
         '''
@@ -504,7 +504,7 @@ class Arguments:
             level=self.get_env('log_level'),
             file_name=self.get_env('log_file'),
             directory=self.get_env('log_directory'),
-            stdout=self.get_env('log_stdout'),
+            stdout=not self.get_env('no_console_log'),
         )
         if self.command == 'depreciated':
             outputs = generate_terraform(

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -531,6 +531,7 @@ class Arguments:
                 remote_state_type = self.get_env('remote_state_type'),
                 terraform_version=self.get_env('terraform_version'),
             )
+            print(json.dumps(outputs, separators=(',', ':')))
 
         if self.command == 'setup':
             installed = {}

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -200,8 +200,9 @@ TerraformVersion = ArgumentConfig(
     dest='terraform_version',
     required=False,
     default=TerraformCLI.max_version.to_string(),
-    help='''
+    help=f'''
         Terraform version to install/use. Set to 0 to skip.
+        Compatible versions: {TerraformCLI.min_version.to_string()} <= x <= {TerraformCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -212,8 +213,9 @@ JqVersion = ArgumentConfig(
     dest='jq_version',
     required=False,
     default=JqCLI.max_version.to_string(),
-    help='''
+    help=f'''
         JQ version to install or use. Set to 0 to skip.
+        Compatible versions: {JqCLI.min_version.to_string()} <= x <= {JqCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -224,8 +226,9 @@ AwsVersion = ArgumentConfig(
     dest=f'--{AwsCLI.binary_name.lower()}_cli_version',
     required=False,
     default=AwsCLI.max_version.to_string(),
-    help='''
+    help=f'''
         AwsCLIv2 version to install or use. Set to 0 to skip.
+        Compatible versions: {AwsCLI.min_version.to_string()} <= x <= {AwsCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -236,8 +239,9 @@ AzureVersion = ArgumentConfig(
     dest=f'{AzureCLI.binary_name.lower()}_cli_version',
     required=False,
     default=AzureCLI.max_version.to_string(),
-    help='''
+    help=f'''
         AzureCLI version to install or use. Set to 0 to skip.
+        Compatible versions: {AzureCLI.min_version.to_string()} <= x <= {AzureCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -248,8 +252,9 @@ GcloudVersion = ArgumentConfig(
     dest=f'{GoogleCLI.binary_name.lower()}_cli_version',
     required=False,
     default=GoogleCLI.max_version.to_string(),
-    help='''
+    help=f'''
         GoogleCLI version to install or use. Set to 0 to skip.
+        Compatible versions: {GoogleCLI.min_version.to_string()} <= x <= {GoogleCLI.max_version.to_string()}
         Default: %(default)s
         '''
 )
@@ -269,8 +274,8 @@ Validation = ArgumentConfig(
     action='store_true',
     required=False,
     default=False,
-    help='''
-        Requires terraform >= 1.3.6
+    help=f'''
+        Requires terraform {TerraformCLI.min_version} <= x <= {TerraformCLI.max_version}
         Validates the generated files by running:
         `terraform apply -target=null_resource.validation`
         If invalid, error will be displayed and project directory destroyed
@@ -285,7 +290,7 @@ Apply = ArgumentConfig(
     required=False,
     default=False,
     help='''
-        Requires terraform >= 1.3.6
+        Requires terraform {TerraformCLI.min_version} <= x <= {TerraformCLI.max_version}
         `terraform apply`
         If invalid, error will be displayed and project directory destroyed
         Default: %(default)s
@@ -299,7 +304,7 @@ Destroy = ArgumentConfig(
     required=False,
     default=False,
     help='''
-        Requires terraform >= 1.3.6
+        Requires terraform {TerraformCLI.min_version} <= x <= {TerraformCLI.max_version}
         Attempt to remove an existing project before creating a new one.
         If invalid, error will be displayed and project directory destroyed
         Default: %(default)s

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -199,7 +199,7 @@ TerraformVersion = ArgumentConfig(
     metavar='TERRAFORM_VERSION',
     dest='terraform_version',
     required=False,
-    default=TerraformCLI.get_max_version(),
+    default=TerraformCLI.max_version.to_string(),
     help='''
         Terraform version to install/use. Set to 0 to skip.
         Default: %(default)s
@@ -211,7 +211,7 @@ JqVersion = ArgumentConfig(
     metavar='JQ_VERSION',
     dest='jq_version',
     required=False,
-    default=JqCLI.get_max_version(),
+    default=JqCLI.max_version.to_string(),
     help='''
         JQ version to install or use. Set to 0 to skip.
         Default: %(default)s
@@ -466,8 +466,8 @@ class Arguments:
             jq = JqCLI(self.get_env('bin_path'), self.get_env('jq_version'))
             jq.install()
             installed = {
-                'terraform': terraform.get_binary(),
-                'jq': jq.get_binary(),
+                'terraform': str(terraform.get_binary()),
+                'jq': str(jq.get_binary()),
             }
             print(json.dumps(installed, separators=(',', ':')))
             return installed

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -19,7 +19,7 @@ from edbterraform import __version__, __python_version__, __virtual_env__, __dot
 from edbterraform.utils.dict import change_keys
 from edbterraform.utils.files import load_yaml_file, render_template
 from edbterraform.utils.logs import logger
-from edbterraform.CLI import TerraformCLI, join_version
+from edbterraform.CLI import TerraformCLI
 
 def tpl(template_name, dest, csp, vars={}):
     # Renders and saves a jinja2 template based on a given template name and
@@ -109,7 +109,7 @@ def update_terraform_blocks(file, template_vars, infra_vars, cloud_service_provi
                     data[block]['backend'][csp_terraform_backend.get(remote_state_type, remote_state_type)] = {}
 
                     # Set the required terraform version
-                    data[block]['required_version'] = '>= %s, <= %s' % (join_version(TerraformCLI.min_version), join_version(TerraformCLI.max_version))
+                    data[block]['required_version'] = '>= %s, <= %s' % (TerraformCLI.min_version.to_string(), TerraformCLI.max_version.to_string())
 
             f.write(json.dumps(data, indent=2, sort_keys=True))
     except Exception as e:
@@ -379,7 +379,7 @@ def generate_terraform(
         project_path: Path,
         csp: str,
         bin_path: Path,
-        terraform_version: str = TerraformCLI.get_max_version(),
+        terraform_version: str = TerraformCLI.max_version.to_string(),
         user_templates: Optional[List[Path]]=[],
         hcl_lock_file: Optional[Path]=None,
         run_validation: bool = False,

--- a/edbterraform/lib.py
+++ b/edbterraform/lib.py
@@ -397,6 +397,7 @@ def generate_terraform(
     """
     SERVERS_OUTPUT_NAME = 'servers'
     OUTPUT = {
+        'project_path': '',
         'terraform_output': '',
         'ssh_filename': '',
     }
@@ -457,6 +458,7 @@ def generate_terraform(
     OUTPUT['terraform_output'] = SERVERS_OUTPUT_NAME
     if 'ssh_key' in terraform_vars['spec'] and 'output_name' in terraform_vars['spec']['ssh_key']:
         OUTPUT['ssh_filename'] = terraform_vars['spec']['ssh_key']['output_name']
+    OUTPUT['project_path'] = str(project_path.resolve())
 
     run_terraform(project_path, bin_path, terraform_version, run_validation, apply)
 

--- a/edbterraform/utils/logs.py
+++ b/edbterraform/utils/logs.py
@@ -10,7 +10,7 @@ import itertools
 logger = logging.getLogger(__project_name__)
 
 class EnumDefaults(EnumMeta):
-    def __call__(cls, value, default=None, *args, **kwargs):
+    def __call__(cls, value='', default=None, *args, **kwargs):
         '''
         Always passthrough the initial call to super.
         If default is defined, attempt a second call with default instead of raising the error.
@@ -34,7 +34,7 @@ class LogLevel(Enum, metaclass=EnumDefaults):
 
     @classmethod
     def _missing_(cls, value):
-        if value is None or value == '':
+        if value == '':
             return cls.NOTSET
 
         if isinstance(value, str):

--- a/edbterraform/utils/logs.py
+++ b/edbterraform/utils/logs.py
@@ -1,6 +1,7 @@
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+from pathlib import Path
 import sys
 from datetime import datetime
 from enum import Enum, EnumMeta
@@ -67,15 +68,15 @@ def setup_logs(level=LogLevel.INFO, file_name=datetime.now().strftime('%Y-%m-%d'
     try:
         log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         date_format = '%Y-%m-%dT%H:%M:%S%z'
-
+        directory = Path(directory).resolve()
+        file_name = directory / file_name
         log_level = LogLevel(level, logging.WARNING)
 
         if stdout:
             logging.basicConfig(level=log_level.value, stream=sys.stdout, datefmt=date_format, format=log_format)
         else:
-            if not os.path.exists(directory):
-                os.makedirs(directory)
-            log_handler = RotatingFileHandler(file_name, maxBytes=10*1024*1024, backupCount=10, mode='a')
+            directory.mkdir(parents=True, exist_ok=True)
+            log_handler = RotatingFileHandler(str(file_name), maxBytes=10*1024*1024, backupCount=10, mode='a')
             logging.basicConfig(level=log_level.value, datefmt=date_format, format=log_format, handlers=[log_handler])
     except Exception as e:
         logger.error(f"Trouble setting up logger - ({e})")

--- a/edbterraform/utils/logs.py
+++ b/edbterraform/utils/logs.py
@@ -3,24 +3,80 @@ from logging.handlers import RotatingFileHandler
 import os
 import sys
 from datetime import datetime
+from enum import Enum, EnumMeta
 from edbterraform import __project_name__, __dot_project__
+import itertools
 
 logger = logging.getLogger(__project_name__)
 
-def setup_logs(level='INFO', file_name=datetime.now().strftime('%Y-%m-%d'), directory=f'{__dot_project__}/logs', stdout=True):
+class EnumDefaults(EnumMeta):
+    def __call__(cls, value, default=None, *args, **kwargs):
+        '''
+        Always passthrough the initial call to super.
+        If default is defined, attempt a second call with default instead of raising the error.
+        '''
+        try:
+            return super().__call__(value, *args, **kwargs)
+        except:
+            if default is not None:
+                return super().__call__(default, *args, **kwargs)
+            raise
+
+class LogLevel(Enum, metaclass=EnumDefaults):
+    NOTSET = logging.NOTSET
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARN = logging.WARN
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    FATAL = logging.FATAL
+    CRITICAL = logging.CRITICAL
+
+    @classmethod
+    def _missing_(cls, value):
+        if value is None or value == '':
+            return cls.NOTSET
+
+        if isinstance(value, str):
+            if value.isdigit():
+                return cls(int(value))
+
+            # Find the first alpha string in the value
+            not_isalpha = lambda x: not str.isalpha(x)
+            value = "".join(itertools.dropwhile(not_isalpha, value))
+            value = "".join(itertools.takewhile(str.isalpha, value))
+            # All values should be upper case
+            value = value.upper()
+            if value in dir(cls):
+                return cls[value]
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def __int__(self):
+        return self.value
+
+    @classmethod
+    def available_options(cls):
+        options = ""
+        for level in cls:
+            options += f"{level.name}: {level.value}\n"
+        return options
+
+def setup_logs(level=LogLevel.INFO, file_name=datetime.now().strftime('%Y-%m-%d'), directory=f'{__dot_project__}/logs', stdout=True):
     try:
         log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         date_format = '%Y-%m-%dT%H:%M:%S%z'
 
-        log_level = getattr(logging, level, logging.WARNING)
+        log_level = LogLevel(level, logging.WARNING)
 
         if stdout:
-            logging.basicConfig(level=log_level, stream=sys.stdout, datefmt=date_format, format=log_format)
+            logging.basicConfig(level=log_level.value, stream=sys.stdout, datefmt=date_format, format=log_format)
         else:
             if not os.path.exists(directory):
                 os.makedirs(directory)
             log_handler = RotatingFileHandler(file_name, maxBytes=10*1024*1024, backupCount=10, mode='a')
-            logging.basicConfig(level=log_level, datefmt=date_format, format=log_format, handlers=[log_handler])
+            logging.basicConfig(level=log_level.value, datefmt=date_format, format=log_format, handlers=[log_handler])
     except Exception as e:
-        logger.error("Trouble setting up logger")
+        logger.error(f"Trouble setting up logger - ({e})")
         sys.exit(1)

--- a/edbterraform/utils/script.py
+++ b/edbterraform/utils/script.py
@@ -1,0 +1,118 @@
+import os
+import subprocess
+from tempfile import mkstemp
+import stat
+
+from edbterraform.utils.logs import logger
+
+def execute_shell(args, environment=os.environ, cwd=None):
+    logger.info("Executing command: %s", ' '.join(args))
+    logger.debug("environment=%s", environment)
+    try:
+        process = subprocess.check_output(
+            ' '.join(args),
+            stderr=subprocess.STDOUT,
+            shell=True,
+            cwd=cwd,
+            env=environment,
+        )
+        return process
+    
+    except subprocess.CalledProcessError as e:
+        logger.error("Command failed: %s", e.cmd)
+        logger.error("Return code: %s", e.returncode)
+        logger.error("Output: %s", e.output)
+        raise Exception(
+            "If executable fails to execute, check the path."
+            "If options --destroy or --apply fail, manual intervention may be required to allow for a recovery."
+        )
+
+def execute_live_shell(args, environment=os.environ, cwd=None):
+    logger.info("Executing command: %s", ' '.join(args))
+    logger.debug("environment=%s", environment)
+    process = subprocess.Popen(
+        ' '.join(args),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=cwd,
+        env=environment
+    )
+
+    rc = 0
+    while True:
+        output = process.stdout.readline()
+        if output:
+            logger.info(output.decode("utf-8").strip())
+        rc = process.poll()
+        if rc is not None:
+            break
+
+    return rc
+
+def build_temporary_script(content):
+    """
+    Generate the installation script as an executable tempfile and returns its
+    path.
+    """
+    script_handle, script_name = mkstemp(suffix='.sh')
+    try:
+        with open(script_handle, 'w') as f:
+            f.write(content)
+        st = os.stat(script_name)
+        os.chmod(script_name, st.st_mode | stat.S_IEXEC)
+        return script_name
+    except Exception as e:
+        logger.error("Unable to generate the installation script")
+        logger.exception(str(e))
+        raise Exception("Unable to generate the installation script")
+
+def execute_temporary_script(script_name):
+    """
+    Execute an installation script
+    """
+    try:
+        output = execute_shell(['/bin/bash', script_name])
+        result = output.decode("utf-8")
+        os.unlink(script_name)
+        logger.debug("Command output: %s", result)
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to execute the command: %s", e.cmd)
+        logger.error("Return code is: %s", e.returncode)
+        logger.error("Output: %s", e.output)
+        raise Exception(
+            "Failed to execute the following command, please check the "
+            "logs for details: %s" % e.cmd
+        )
+
+def binary_path(name, bin_path=None):
+    """Returns the first seen binary
+
+    Order:
+    1. bin_path + name if it exists
+    2. PATH + name if it exists
+    3. Empty string
+
+    :param name: name of the binary
+    :param path: path to the binary
+    """
+    if bin_path and os.path.exists(bin_path):
+        binary_path = os.path.join(bin_path, name)
+        if os.path.exists(binary_path) and os.access(binary_path, os.X_OK):
+            return binary_path
+        
+    paths = os.getenv("PATH",'').split(os.pathsep)
+    for path in paths:
+        binary_path = os.path.join(path, name)
+        if os.path.exists(binary_path) and os.access(binary_path, os.X_OK):
+            return binary_path    
+    
+    return ''
+
+def get_binary(binary_name, bin_path=None, default_path=None):
+    binary = ""
+    if bin_path:
+        binary = binary_path(binary_name, bin_path)
+    if not binary and not default_path:
+        binary = binary_path(binary_name, default_path)
+    return binary

--- a/edbterraform/utils/script.py
+++ b/edbterraform/utils/script.py
@@ -3,22 +3,206 @@ from pathlib import Path
 import subprocess
 from tempfile import mkstemp
 import stat
+from dataclasses import dataclass, field
+from typing import Union
+from enum import Enum, auto
+from collections.abc import Sequence
+import itertools
+import re
 
 from edbterraform.utils.logs import logger
 
+class TaintHandle(Enum):
+    '''
+    Enum for handling tainted patch versions where releaselevel is part of the patch
+    By default, replace the tainted patch's releaselevel with the explicit releaselevel
+    '''
+    REPLACE = auto()
+    APPEND = auto()
+    PREPEND = auto()
+    KEEP = auto()
+
+    @classmethod
+    def _missing_(cls, value):
+        if value is None or value == '':
+            return cls.REPLACE
+
+        if isinstance(value, str):
+            value = value.upper()
+            if value in dir(cls):
+                return cls[value]
+
+    def __str__(self):
+        return f"{self.__class__.__name__}.{self.name}"
+
+
+@dataclass(order=True)
+class Version:
+
+    # Semvar strings are major.minor.patch-releaselevel+build
+    major: int = field(repr=True, init=False, default=0, compare=False)
+    minor: int = field(repr=True, init=False, default=0, compare=False)
+    patch: int = field(repr=True, init=False, default=0, compare=False)
+    releaselevel: str = field(repr=True, init=False, default='', compare=False)
+    build: str = field(repr=True, init=False, default=None, compare=False)
+    sort_index: tuple = field(repr=False, init=False, compare=True) # Use the sort_index as the comparison key
+    raw: Union[Sequence, str] = field(repr=False, init=True, default="0.0.0", compare=False)
+    version_type: str = field(repr=False, init=True, default="semvar", compare=False)
+    taint_handling: str = field(repr=False, init=True, default=TaintHandle.PREPEND.name, compare=False)
+    tainted_major: str = field(repr=False, init=True, default=None, compare=False)
+    tainted_minor: str = field(repr=False, init=True, default=None, compare=False)
+    tainted_patch: str = field(repr=False, init=True, default=None, compare=False)
+    untainted_releaselevel: str = field(repr=False, init=True, default=None, compare=False)
+    original: Union[Sequence, str] = field(repr=False, init=False, default=None, compare=False)
+
+    def __post_init__(self):
+        if not isinstance(self.raw, (Sequence, str)):
+            raise TypeError("Version must be a tuple or a string")
+
+        self.original = self.raw
+        if not isinstance(self.raw, str) and isinstance(self.raw, Sequence):
+            temp = self.raw
+            self.raw = ''
+            self.raw += f"{temp[0] if temp[0:] and temp[0] else str(0)}"
+            self.raw += f".{temp[1] if temp[1:] and temp[1] else str(0)}"
+            self.raw += f".{temp[2] if temp[2:] and temp[2] else str(0)}"
+            self.raw += f"-{temp[3]}" if temp[3:] and temp[3] else ''
+            self.raw += f"+{temp[4]}" if temp[4:] and temp[4] else ''
+
+        # Remove 'v' from start and split the string into major, minor, patch
+        # Tools such as jq release versions as x.xrc3
+        # Patch should only contain integers but will be handled later
+        version_parts = self.raw.lstrip('v').split('.', 2)
+        self.major, self.tainted_major = self.nonstandard_segment(version_parts[0] if version_parts[0:] and version_parts[0] is not None else 0)
+        self.minor, self.tainted_minor = self.nonstandard_segment(version_parts[1] if version_parts[1:] and version_parts[1] is not None else 0)
+        self.patch, self.tainted_patch = self.nonstandard_segment(version_parts[2] if version_parts[2:] and version_parts[2] is not None else 0)
+
+        if self.version_type == "semvar":
+            return self.__semvar_releaselevel(self.raw)
+
+        raise NotImplementedError("Only semvar is supported")
+
+    def __semvar_releaselevel(self, semvar_version):
+        '''
+        Extract the releaselevel and build metadata from the patch
+        Depending on the taint_handling, the releaselevel will be replaced, appended, prepended or kept with the tainted versions
+        '''
+        # Get the buildmeta data from the first seen '+' symbol
+        extract = semvar_version.split('+', 1)
+        self.build = extract[1] if len(extract) == 2 else ""
+
+        # Get the releaselevel
+        # Some versions may contain a series of identiers such as 1.0.0.[0-1.0.0]+1 
+        #   where the items in the brackets are the releaselevel 1.0.0-0-1.0.0+1
+        versions = extract[0].split('-', 1)
+        self.releaselevel = versions[1] if len(versions) == 2 else ""
+
+        extract = versions[0].split('.')
+        release = ".".join(extract[3:])
+        self.releaselevel = release if release and not self.releaselevel else self.releaselevel if not release and self.releaselevel else release + "-" + self.releaselevel if release and self.releaselevel else ""
+
+        if TaintHandle(self.taint_handling) == TaintHandle.KEEP:
+            self.releaselevel = self.tainted_major if self.tainted_major else ""
+            self.releaselevel += f".{self.tainted_minor}" if self.tainted_minor and self.releaselevel else self.tainted_minor if self.tainted_minor else ""
+            self.releaselevel += f".{self.tainted_patch}" if self.tainted_patch and self.releaselevel else self.tainted_patch if self.tainted_patch else ""
+        if TaintHandle(self.taint_handling) == TaintHandle.APPEND:
+            self.releaselevel += self.tainted_major if self.tainted_major else ""
+            self.releaselevel += f".{self.tainted_minor}" if self.tainted_minor and self.releaselevel else self.tainted_minor if self.tainted_minor else ""
+            self.releaselevel += f".{self.tainted_patch}" if self.tainted_patch and self.releaselevel else self.tainted_patch if self.tainted_patch else ""
+        elif TaintHandle(self.taint_handling) == TaintHandle.PREPEND:
+            temp = self.releaselevel
+            self.releaselevel = self.tainted_major if self.tainted_major else ""
+            self.releaselevel += f".{self.tainted_minor}" if self.tainted_minor and self.releaselevel else self.tainted_minor if self.tainted_minor else ""
+            self.releaselevel += f".{self.tainted_patch}" if self.tainted_patch and self.releaselevel else self.tainted_patch if self.tainted_patch else ""
+            self.releaselevel += f".{temp}" if temp and self.releaselevel else temp if temp else ""
+        else:
+            # Assumes TaintHandle(self.taint_handling) == TaintHandle.REPLACE
+            pass
+
+        self.sort_index = self.__sort_keys()
+
+    def nonstandard_segment(self, version):
+        '''
+        Given a non standard version with releaselevel, 1rc3-1.0.0+1,
+        return a standard semvar version and releaselevel (1, 'rc3')
+        '''
+        # Extract the patch number
+        patch_number = int("".join(itertools.takewhile(str.isdigit, str(version))))
+        extract = str(version).lstrip(str(patch_number))
+        patch_number = int(patch_number if patch_number else 0)
+
+        # Extract the releaselevel if it is part of the patch
+        releaselevel = "".join(itertools.takewhile(str.isalnum, extract))
+        releaselevel = releaselevel if releaselevel else ''
+        return (patch_number, releaselevel)
+
+    def __sort_keys(self) -> tuple:
+        '''
+        Compare the version (major, minor, patch)
+        '''
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+        )
+
+    def to_tuple(self):
+        return (self.major, self.minor, self.patch)
+
+    def to_tuple_semvar(self):
+        return self.to_tuple() + (
+            self.releaselevel,
+        )
+
+    def to_tuple_full(self):
+        return self.to_tuple() + (
+            self.releaselevel,
+            self.build,
+        )
+
+    def to_string(self, include_zero_patch=True, tainted=False):
+        '''
+        Return a string representation of the version.
+        If tainted is True, the version numbers will be replaced with the tainted versions
+        If include_zero_patch is False, the patch number will be omitted if it is 0 and the patch was not tainted
+        '''
+        versions = [str(self.major), str(self.minor), str(self.patch)]
+        if tainted:
+            versions = [versions[0]+self.tainted_major, versions[1]+self.tainted_minor, versions[2]+self.tainted_patch]
+        if not include_zero_patch \
+            and self.patch == 0 \
+            and not self.tainted_patch:
+            versions.pop()
+
+        return ".".join(versions)
+
+    def to_string_full(self, include_zero_patch=True, tainted=False):
+        version = self.to_string(include_zero_patch, tainted)
+        # Use the untainted releaselevel if using the tainted version to avoid duplicate releaselevel values
+        if self.untainted_releaselevel and tainted:
+            version += f"-{self.untainted_releaselevel}"
+        elif self.releaselevel and not tainted:
+            version += f"-{self.releaselevel}"
+
+        if self.build:
+            version += f"+{self.build}"
+
+        return version
+
 def execute_shell(args, environment=os.environ, cwd=None):
-    logger.info("Executing command: %s", ' '.join(args))
+    fmt_args = ' '.join([str(x) for x in args])
+    logger.info("Executing command: %s", fmt_args)
     logger.debug("environment=%s", environment)
     try:
         process = subprocess.check_output(
-            ' '.join(args),
+            fmt_args,
             stderr=subprocess.STDOUT,
             shell=True,
             cwd=cwd,
             env=environment,
         )
         return process
-    
+
     except subprocess.CalledProcessError as e:
         logger.error("Command failed: %s", e.cmd)
         logger.error("Return code: %s", e.returncode)
@@ -29,10 +213,11 @@ def execute_shell(args, environment=os.environ, cwd=None):
         )
 
 def execute_live_shell(args, environment=os.environ, cwd=None):
-    logger.info("Executing command: %s", ' '.join(args))
+    fmt_args = ' '.join([str(x) for x in args])
+    logger.info("Executing command: %s", fmt_args)
     logger.debug("environment=%s", environment)
     process = subprocess.Popen(
-        ' '.join(args),
+        fmt_args,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -109,7 +294,7 @@ def binary_path(name, bin_path=None, default_path=None, env_path="PATH",):
             return binary_path
 
     if env_path:
-        paths = os.getenv("PATH",'').split(os.pathsep)
+        paths = os.getenv(env_path,'').split(os.pathsep)
         for path in paths:
             binary_path = Path(path) / name
             if binary_path.exists() and os.access(binary_path, os.X_OK):


### PR DESCRIPTION
Changes:
  * `--help` overrides all command options
  * `version` can be passed as a command or as an argument `-v`/`--version`
  * `--no-console-log` can be set to pass logs to a file instead of the console
  * Cloud CLIs can be installed with `edb-terraform setup`
    * Aws - pip installation of git releases since v2 is not released to `pypi`, only v1
    * Azure - pip releases available
    * Gcloud - bundle python packages from google archives
    * BigAnimal - binary available for download and get-token.sh from git