### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ Since this is a json file,
 This avoids the need to also maintain a .terraform.hcl.lock file
 
 ### :handbag: Setup tools
-There is a `setup` command available to download terraform or jq.
-The final line in the output will be stringified json with any found binaries: `{"terraform":"/home/user/.edb-terraform/terraform/1.5.5/bin/terraform","jq":"/home/user/.edb-terraform/jq/1.7.1/bin/jq"}`
-  These should be added to the path by linking, moving or manually installing the needed tool.
+There is a `setup` command available to download terraform, jq and each providers cli.
+The final line in the output will be stringified json with any installed binaries path: `{"terraform":"/home/user/.edb-terraform/terraform/1.5.5/bin/terraform","jq":"/home/user/.edb-terraform/jq/1.7.1/bin/jq"}`
+  These should be added to your path by linking, moving or manually installing the needed tool.
 By default the maximum allowed versions are installed and to skip the installation of any tool, set `--<tool>-version` to `0`.
+To avoid the need for sudo, the default install directory is: `$HOME/.edb-terraform/<tool>/<semvar-version>/bin/<tool>`
 ```
 edb-terraform setup --help
 edb-terraform setup

--- a/README.md
+++ b/README.md
@@ -217,5 +217,5 @@ edb-terraform setup
 │   └── inventory.yml.tftpl
 ├── terraform.tfstate # Terraform state - used as a terraform project marker for edb-terraform when state is remote
 ├── terraform.tfvars.json # Automatically detected Terraform variables. Original values under `edb-terraform/terraform.tfvars.yml`
-└── variables.tf # Terraform placeholder variables
+└── common_vars.tf # Terraform placeholder variables used by all providers
 ```

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -195,9 +195,9 @@ ProjectName = ArgumentConfig(
 )
 
 TerraformVersion = ArgumentConfig(
-    names = ['--terraform-version',],
-    metavar='TERRAFORM_VERSION',
-    dest='terraform_version',
+    names = [f'--{TerraformCLI.binary_name.lower()}-cli-version',],
+    metavar=f'{TerraformCLI.binary_name.upper()}_CLI_VERSION',
+    dest=f'{TerraformCLI.binary_name.lower()}_cli_version',
     required=False,
     default=TerraformCLI.max_version.to_string(),
     help=f'''
@@ -208,9 +208,9 @@ TerraformVersion = ArgumentConfig(
 )
 
 JqVersion = ArgumentConfig(
-    names = ['--jq-version',],
-    metavar='JQ_VERSION',
-    dest='jq_version',
+    names = [f'--{JqCLI.binary_name.lower()}-cli-version',],
+    metavar=f'{JqCLI.binary_name.upper()}_CLI_VERSION',
+    dest=f'{JqCLI.binary_name.lower()}_cli_version',
     required=False,
     default=JqCLI.max_version.to_string(),
     help=f'''
@@ -223,7 +223,7 @@ JqVersion = ArgumentConfig(
 AwsVersion = ArgumentConfig(
     names = [f'--{AwsCLI.binary_name.lower()}-cli-version',],
     metavar=f'{AwsCLI.binary_name.upper()}_CLI_VERSION',
-    dest=f'--{AwsCLI.binary_name.lower()}_cli_version',
+    dest=f'{AwsCLI.binary_name.lower()}_cli_version',
     required=False,
     default=AwsCLI.max_version.to_string(),
     help=f'''

--- a/edbterraform/data/terraform/aws/modules/aurora/main.tf
+++ b/edbterraform/data/terraform/aws/modules/aurora/main.tf
@@ -59,7 +59,12 @@ resource "aws_rds_cluster" "aurora_cluster" {
     # We recommend specifying 3 AZs or using the lifecycle configuration block ignore_changes argument if necessary.
     # cluster_identifier_prefix - (Optional, Forces new resources)
     # Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
-    ignore_changes = [availability_zones, cluster_identifier_prefix]
+    ignore_changes = [
+      availability_zones,
+      cluster_identifier_prefix,
+      # Tags appear as null during re-applys
+      tags["Owner"],
+    ]
   }
 }
 

--- a/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.6.0"
+      version = "~> 0.7.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/aws/modules/database/main.tf
+++ b/edbterraform/data/terraform/aws/modules/database/main.tf
@@ -57,6 +57,13 @@ resource "aws_db_instance" "rds_server" {
   skip_final_snapshot     = true
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      # Tags appear as null during re-applys
+      tags["Owner"],
+    ]
+  }
 }
 
 resource "aws_db_parameter_group" "edb_rds_db_params" {

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -54,9 +54,14 @@ resource "aws_instance" "machine" {
   tags = var.tags
 
   lifecycle {
-    # AMI is ignored because the data source
-    # forces the resource to be re-created when apply is used again
-    ignore_changes = [ami]
+    ignore_changes = [
+      # AMI is ignored because the data source forces the resource to be re-created when apply is used again
+      ami,
+      # Tags appear as null during re-applys
+      tags["Owner"],
+      root_block_device[0].tags["Owner"],
+      root_block_device[0].tags["AttachedInstance"],
+    ]
   }
 }
 

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -61,6 +61,11 @@ resource "aws_instance" "machine" {
       tags["Owner"],
       root_block_device[0].tags["Owner"],
       root_block_device[0].tags["AttachedInstance"],
+      # Block devices are attached after this resource but fail to be ignored
+      # Using terraform apply a second time will track the devices within this resource and will no longer appear as a diff.
+      # No workaround available at this time.
+      # https://github.com/hashicorp/terraform-provider-aws/issues/33850
+      # ebs_block_device,
     ]
   }
 }

--- a/edbterraform/data/terraform/azure/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.6.0"
+      version = "~> 0.7.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.6.0"
+      version = "~> 0.7.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/versions.tf
+++ b/edbterraform/data/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     biganimal = {
       source = "registry.terraform.io/EnterpriseDB/biganimal"
-      version = "<= 0.6.1"
+      version = "<= 0.7.1"
     }
     # https://github.com/EnterpriseDB/terraform-provider-toolbox/issues/44
     toolbox = {

--- a/edbterraform/data/terraform/versions.tf
+++ b/edbterraform/data/terraform/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "registry.terraform.io/EnterpriseDB/biganimal"
       version = "<= 0.6.1"
     }
-
+    # https://github.com/EnterpriseDB/terraform-provider-toolbox/issues/44
     toolbox = {
       source = "registry.terraform.io/bryan-bar/toolbox"
       version = "<= 0.2.2"


### PR DESCRIPTION
fixes:
* ignore Owner and AttachedInstance tags to avoid unexpected diffs
* BigAnimal provider updated to `0.7.1`
* jq and terraform versions can be specified

No fix:
* ebs volumes are detected by the aws instance resource during a second apply and cannot be ignored. Once picked up, it will no longer appear in the plan diff.
* toolbox provider shows the stage change form `create` to `read` in the plan diff for terraform v1.3.6 but not v1.5.5. Since aws requires a second apply due to its provider issue, this is a non-issue for now.