### PR TITLE
setuptools context

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 import os.path
-import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
 
 from setuptools import setup
 from textwrap import dedent
+import shutil
 
 def get_version():
     cur_dir = os.path.dirname(__file__)
@@ -26,47 +29,66 @@ def get_requirements():
     with open(requirements_path) as f:
         return f.read().splitlines()
 
-setup(
-    name="edb-terraform",
-    version=get_version(),
-    author="EDB",
-    author_email="edb-devops@enterprisedb.com",
-    packages=[
-        "edbterraform",
-    ],
-    url="https://github.com/EnterpriseDB/edb-terraform/",
-    entry_points = {
-        'console_scripts': [
-            'edb-terraform = edbterraform.__main__:entry_point',
-        ]
-    },
-    license="BSD",
-    description=dedent("""
-    Terraform templates aimed to provide easy to use YAML configuration file
-    describing the target cloud infrastrure.
-    """),
-    long_description=get_long_description(),
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3",
-        "Topic :: Database",
-    ],
-    keywords="terraform cloud yaml edb cli aws rds aurora azure aks gcloud gke kubernetes k8s",
-    python_requires=">=3.6",
-    install_requires=get_requirements(),
-    extras_require={},
-    data_files=[],
-    package_data={
-        'edbterraform': [
-            'data/terraform/*/*',
-            'data/terraform/*.tf',
-            'data/terraform/*.tf.json',
-            'data/terraform/*/modules/*/*',
-            'data/templates/*/*',
-            'utils/*'
-        ]
-    }
-)
+
+@contextmanager
+def temp_directory_context():
+    '''
+    Create a temporary directory with the source code.
+    This is needed to avoid leftover artifacts from the build process.
+    '''
+    cwd = Path.cwd().resolve()
+    with TemporaryDirectory(prefix='setuptools', dir=cwd) as temp_dir:
+        try:
+            temp_dir = Path(temp_dir).resolve()
+            temp_src = temp_dir / 'src'
+            shutil.copytree(src=cwd, dst=temp_src, symlinks=True, ignore=lambda dir, file: str(temp_dir))
+            os.chdir(temp_src)
+            yield
+        finally:
+            os.chdir(cwd)
+
+with temp_directory_context():
+    setup(
+        name="edb-terraform",
+        version=get_version(),
+        author="EDB",
+        author_email="edb-devops@enterprisedb.com",
+        packages=[
+            "edbterraform",
+        ],
+        url="https://github.com/EnterpriseDB/edb-terraform/",
+        entry_points = {
+            'console_scripts': [
+                'edb-terraform = edbterraform.__main__:entry_point',
+            ]
+        },
+        license="BSD",
+        description=dedent("""
+        Terraform templates aimed to provide easy to use YAML configuration file
+        describing the target cloud infrastrure.
+        """),
+        long_description=get_long_description(),
+        long_description_content_type="text/markdown",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Environment :: Console",
+            "License :: OSI Approved :: BSD License",
+            "Programming Language :: Python :: 3",
+            "Topic :: Database",
+        ],
+        keywords="terraform cloud yaml edb cli aws rds aurora azure aks gcloud gke kubernetes k8s",
+        python_requires=">=3.6",
+        install_requires=get_requirements(),
+        extras_require={},
+        data_files=[],
+        package_data={
+            'edbterraform': [
+                'data/terraform/*/*',
+                'data/terraform/*.tf',
+                'data/terraform/*.tf.json',
+                'data/terraform/*/modules/*/*',
+                'data/templates/*/*',
+                'utils/*'
+            ]
+        },
+    )


### PR DESCRIPTION
Issue:
Setuptools leaves behind build artifacts instead of cleaning them up. This can cause unexpected errors due to old build artifacts being re-used.

Solution:
Use a context manager to setup a directory with all the source code and set the `setup()` context. The context manager handles removal of the directory when the process finishes.
This might need to be updated if we move to different types of releases, such as pipy, but at the moment we use `pip install` from the source directory or directly from github with `git` or `zip`.
- While we can use `cmdclass` to override some of the behavior of `setuptools`, it requires class overrides and setuptools handles the execution.
- `atexit` can be used to setup a function to cleanup directories but it is a blind removal based on directory name and still requires removal of pre-existing build artifacts. There is supposed to be a `pip` marker, but it is missing.