### PR TITLE
`help` command for hcl2 variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A tool for generating Terraform projects using pre-defined templates and modules
 
 The following components must be installed on the system:
 - [Terraform >= 1.3.6, <= 1.5.5](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform)
-- Python >= 3.6
+- Python >= 3.8
 - Bash
-- [JQ](https://jqlang.github.io/jq/download/)
+- [JQ >= 1.6](https://jqlang.github.io/jq/download/)
 - Cloud provider cli tool with credentials configured
   - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   - [GCloud CLI](https://cloud.google.com/sdk/docs/install-sdk)

--- a/edbterraform/parser/hcl2.py
+++ b/edbterraform/parser/hcl2.py
@@ -1,0 +1,65 @@
+import hcl2
+from pathlib import Path
+from typing import Union
+import logging
+
+TERRAFORM_PYTHON_TYPES = {
+    "${string}": str,
+    "${number}": float,
+    "${bool}": bool,
+    "${list(string)}": list[str],
+    "${list(number)}": list[float],
+    "${map(string)}": dict[str, str],
+}
+
+def load_hcl2(project_path: Union[str, Path] = None, load_tf = True, load_tf_vars = False, load_json = False,):
+    try:
+        results = {}
+        project_path = (Path(project_path)).resolve()
+        files = (
+            project_path.glob('*.tf') if load_tf else []
+            + project_path.glob('*.tf.json') if load_tf and load_json else []
+            + project_path.glob('*.tfvars') if load_tf_vars else []
+            + project_path.glob('*.tfvars.json') if load_tf_vars and load_json else []
+        )
+        for file in files:
+            data = hcl2.loads(file.read_text())
+            results[file] = data
+        return results
+
+    except Exception as e:
+        raise Exception("ERROR: could not load hcl2 data - %s - (%s)" % (project_path, repr(e))) from e
+
+def load_variables(project_path: Union[str, Path] = None,):
+    '''
+    Extract variables from terraform data
+    '''
+    KEYNAME = "variable"
+    variables = {}
+    try:
+        data = load_hcl2(project_path, load_tf = True)
+        for _, data in data.items():
+            for variable in data.get(KEYNAME, []):
+                for key, value in variable.items():
+                    if key in variables:
+                        logging.warning(f"Duplicate variable ({key}) exists with value ({variables[key]}) and overriding")
+                    variables[key] = value
+        return variables
+
+    except Exception as e:
+        raise
+
+def variable_help_message(variables):
+    '''
+    Format variables for use as a help message
+    '''
+    message = "Variables:\n"
+    for key, value in variables.items():
+        message += f"  {key}:\n"
+        message += f"    type: {value.get('type').lstrip('${').rstrip('}')}\n" if value.get('type', False) else ""
+        message += f"    description: {value.get('description')}\n" if value.get('description', False) else ""
+        message += f"    default: {value.get('default')}\n" if value.get('default', False) else ""
+        message += f"    nullable: {value.get('nullable')}\n" if value.get('nullable', False) else ""
+        message += f"    environment variable: TF_VAR_{key}=<value>\n"
+        message += f"    command line argument: -var \"{key}=<value>\" \n"
+    return message

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cryptography
-dataclasses~=0.8;python_version~="3.6.0"
 PyYaml >= 6.0.1, < 7.0.0
 jinja2 >= 3.0.0, < 4.0.0
 python-hcl2~=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cryptography
 dataclasses~=0.8;python_version~="3.6.0"
 PyYaml >= 6.0.1, < 7.0.0
 jinja2 >= 3.0.0, < 4.0.0
+python-hcl2~=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
             'data/terraform/*.tf.json',
             'data/terraform/*/modules/*/*',
             'data/templates/*/*',
-            'utils/*'
+            'utils/*',
+            'parser/*',
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "Topic :: Database",
     ],
     keywords="terraform cloud yaml edb cli aws rds aurora azure aks gcloud gke kubernetes k8s",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=get_requirements(),
     extras_require={},
     data_files=[],


### PR DESCRIPTION
BREAKING CHANGE:
- python minimum version bumped to 3.8 to match cloud provider cli python minimum versions.

Changes:
- Experimental new option `help` added to display a terraform projects root level variables.
  - ex: `edb-terraform help --project-path <TERRAFORM-PROJECT>`
Fix:
- Update argparse to make use of environment variables by appending it to the command if not already supplied.
  - action store arguments allowed as environment variables by supplying truthy values
    - ex: `--destroy` can be set as `ET_DESTROY=1`