### PR TITLE
BigAnimal/Machine Module networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ edb-terraform generate \
   --infra-file edb-terraform/docs/examples/aws/edb-ra-3.yml
 cd example
 terraform init
+edb-terraform help --project-path .
 terraform apply -var "force_dynamic_ip=true"
 terraform destroy
 ```
@@ -232,6 +233,15 @@ This is meant for single time use and in most cases you should set the pre-defin
 > Only AWS supports security groups, which allows for more flexibility with port configurations.  
 > We mimic the functionality of security groups for Azure and GCloud to allow ports to be defined per instance.  
 
+#### BigAnimal
+BigAnimal controls a single VPC per project for its cluster.
+Pairing can be done by setting the allow list for the provider or using vpc-peering/provider-private-connections.
+- VPC peering can fail if not careful since you must not overlap the address space of each VPC.
+- By default, it will allow connections from all machine instances created.
+  - `allowed_machines` is a configuration option which accepts a list of machine names which are allowed to access the database.
+    - Default is a wildcard to append all machine ips: `["*"]`
+  - To change the allow list after provisioning, the file `terraform.tfvars.json` can be directly modified and use `terraform apply` again.
+
 ### Environment variables
 Terraform allows for top-level variables to be defined with cli arguments or environment variables.
 
@@ -240,10 +250,13 @@ For any variable you can define:
 - Environment variables for a targetted stage: `TF_VAR_ARGS_<stage>=<CLI ARGS>`
 - Environment variables for root variables: `TF_VAR_<variable>=<ARGS>`
 - CLI Arguments for root variables: `-var <variable>=<ARGS>`
+Terraform will surface an error if an invalid variable is set with `-var` but will continue if it is set with environment variables for root variables.
 
 Example variable:
 - `TF_VAR_force_dynamic_ip=true` is the same as `-var force_dynamic_ip=true`
 - `TF_VAR_service_cidrblocks='["0.0.0.0/0"]'`
+- `-var "force_service_biganimal=true"`
+- `-var "force_service_machines=true"`
 
 ### :open_file_folder: Project directory layout
 ```

--- a/README.md
+++ b/README.md
@@ -144,6 +144,107 @@ edb-terraform setup --help
 edb-terraform setup
 ```
 
+## Configurations
+Each provider has a:
+- set of example configurations available under the docs directory.
+- spec object within `variables.tf` of its specification module.
+
+AWS
+- [spec](./edbterraform/data/terraform/aws/modules/specification/variables.tf)
+- [examples](./docs/examples/aws/machines-v2.yml)
+
+Azure
+- [spec](./edbterraform/data/terraform/azure/modules/specification/variables.tf)
+- [examples](./docs/examples/azure/machines-v2.yml)
+
+GCloud
+- [spec](./edbterraform/data/terraform/gcloud/modules/specification/variables.tf)
+- [examples](./docs/examples/gcloud/machines-v2.yml)
+
+### Networking
+To open up ports,
+they must be defined per region or per instance under the keyname `ports`.
+
+> :warning:  
+> SSH is currently required when configuring `machines` so that volumes can be formatted and mounted.  
+> In the near future, we will attempt to move to provider-specific connection agents to:  
+> - remove ssh requirement for machines  
+> - avoid blocked connections due to improperly configured port rules or account policy restricitions.
+
+Example:
+```yaml
+      # If defined under a region configuration, it will apply the rules to that region's address space.
+      # If defined under a machine configuration, it will apply the rules to that instance's address space.
+      ports:
+        # Allow ssh access without cidrs defined since the service IPs are unknown.
+        # This will require the use of cli arguments, service_cidrblocks or force_dynamic_ip, to setup the allow list.
+        # force_service_machines option can be used to dynamically set ssh access per machine
+        #   and if both explicit and dynamic ips are needed, set defaults to "" or omit it to avoid duplicate rules.
+        - port: 22
+          protocol: tcp
+          description: "SSH"
+          defaults: service
+        # Allow instances, including cross-region, to ping.
+        # Allow 9.8.7.6 to ping.
+        - protocol: icmp
+          description: ping
+          defaults: internal
+          cidrs:
+            - 9.8.7.6/32
+        # Allow https connections from anywhere
+        - port: 443
+          protocol: tcp
+          description: Web service
+          defaults: public
+        # Allow 1.2.3.4 to connect to the postgres service
+        - protocol: 5432
+          protocol: tcp
+          description: Postgres service
+          cidrs:
+            - 1.2.3.4/32
+```
+
+The keyname `defaults` can be set to reference a set of cidrblocks.
+It will append a set of predefined cidrblocks to the rule's `cidrs` list:
+- [`public`](./edbterraform/data/terraform/common_vars.tf) - Public cidrblocks
+- [`service`](./edbterraform/data/terraform/common_vars.tf) - Service cidrblocks and dynamic ip, if configured
+- `internal` - All Region cidrblocks defined within the configuration: `regions.*.cidr_block`
+- `""` - No Defaults (Default)
+
+When defining ports,
+users can use 4 variables to dynamically update the allowed ips on top of adding values under the `cidrs` key.
+This is meant for single time use and in most cases you should set the pre-defined cidr range.
+- `service_cidrblocks` - a list of cidrblocks for service access when `defaults=service`
+- `force_dynamic_ip` - use an http endpoint to get the current public ip and appended to service_cidrblocks.
+- `force_service_biganimal` - append service_cidrblocks to biganimal's allow list
+- `force_service_machines` - create an ssh access rule and append service_cidrblocks to each machines port rules.
+  - Avoid setting a vpc-level ssh rule with `defaults` to `service` if making use of this option.
+    This can cause duplicate rule conflicts depending on provider.
+
+> :warning:  
+> Policy rules might block generic rules such as `0.0.0.0/0`,  
+>   which is often used by users with changing ips.  
+> This can cause unexpected ssh errors since resources are available before policies are applied.  
+> If possible, make use of a jump host to have a set of persistent ips.  
+> Otherwise, make use of the `force_dynamic_ip` or `service_cidrblocks` options to dynamically set service ips.
+
+> :warning:  
+> Only AWS supports security groups, which allows for more flexibility with port configurations.  
+> We mimic the functionality of security groups for Azure and GCloud to allow ports to be defined per instance.  
+
+### Environment variables
+Terraform allows for top-level variables to be defined with cli arguments or environment variables.
+
+For any variable you can define:
+- Environment variables for all stages: `TF_VAR_ARGS=<CLI ARGS>`
+- Environment variables for a targetted stage: `TF_VAR_ARGS_<stage>=<CLI ARGS>`
+- Environment variables for root variables: `TF_VAR_<variable>=<ARGS>`
+- CLI Arguments for root variables: `-var <variable>=<ARGS>`
+
+Example variable:
+- `TF_VAR_force_dynamic_ip=true` is the same as `-var force_dynamic_ip=true`
+- `TF_VAR_service_cidrblocks='["0.0.0.0/0"]'`
+
 ### :open_file_folder: Project directory layout
 ```
 .
@@ -219,98 +320,3 @@ edb-terraform setup
 ├── terraform.tfvars.json # Automatically detected Terraform variables. Original values under `edb-terraform/terraform.tfvars.yml`
 └── common_vars.tf # Terraform placeholder variables used by all providers
 ```
-
-## Configurations
-Each provider has a:
-- set of example configurations available under the docs directory.
-- spec object within `variables.tf` of its specification module.
-
-AWS
-- [spec](./edbterraform/data/terraform/aws/modules/specification/variables.tf)
-- [examples](./docs/examples/aws/machines-v2.yml)
-
-Azure
-- [spec](./edbterraform/data/terraform/azure/modules/specification/variables.tf)
-- [examples](./docs/examples/azure/machines-v2.yml)
-
-GCloud
-- [spec](./edbterraform/data/terraform/gcloud/modules/specification/variables.tf)
-- [examples](./docs/examples/gcloud/machines-v2.yml)
-
-### Networking
-To open up ports,
-they must be defined per region or per instance under the keyname `ports`.
-
-> :warning:  
-> SSH is currently required when configuring `machines` so that volumes can be formatted and mounted.  
-> In the near future, we will attempt to move to provider-specific connection agents to:  
-> - remove ssh requirement for machines  
-> - avoid blocked connections due to improperly configured port rules or account policy restricitions.
-
-Example:
-```yaml
-      # If defined under a region configuration, it will apply the rules to that region's address space.
-      # If defined under a machine configuration, it will apply the rules to that instance's address space.
-      ports:
-        # Allow ssh access without cidrs defined since the service IPs are unknown.
-        # This will require the use of cli arguments, service_cidrblocks or force_dynamic_ip, to setup the allow list.
-        - port: 22
-          protocol: tcp
-          description: "SSH"
-          defaults: service
-        # Allow instances, including cross-region, to ping.
-        # Allow 9.8.7.6 to ping.
-        - protocol: icmp
-          description: ping
-          defaults: internal
-          cidrs:
-            - 9.8.7.6/32
-        # Allow https connections from anywhere
-        - port: 443
-          protocol: tcp
-          description: Web service
-          defaults: public
-        # Allow 1.2.3.4 to connect to the postgres service
-        - protocol: 5432
-          protocol: tcp
-          description: Postgres service
-          cidrs:
-            - 1.2.3.4/32
-```
-
-The keyname `defaults` can be set to reference a set of cidrblocks.
-It will append a set of predefined cidrblocks to the rule's `cidrs` list:
-- [`public`](./edbterraform/data/terraform/common_vars.tf) - Public cidrblocks
-- [`service`](./edbterraform/data/terraform/common_vars.tf) - Service cidrblocks and dynamic ip, if configured
-- `internal` - All Region cidrblocks defined within the configuration: `regions.*.cidr_block`
-- `""` - No Defaults (Default)
-
-When defining `service` ports,
-users can use 2 variables to dynamically update the allowed ips on top of adding values under the `cidrs` key.
-This is meant for single time use and in most cases you should set the expected cidr ranges.
-- `service_cidrblocks` - a list of cidrblocks for service access.
-- `force_dynamic_ip` - use an http endpoint to get the current public ip and appended to service_cidrblocks.
-
-> :warning:  
-> Policy rules might block generic rules such as `0.0.0.0/0`,  
->   which is often used by users with changing ips.  
-> This can cause unexpected ssh errors since resources are available before policies are applied.  
-> If possible, make use of a jump host to have a set of persistent ips.  
-> Otherwise, make use of the `force_dynamic_ip` or `service_cidrblocks` options to dynamically set service ips.
-
-> :warning:  
-> Only AWS supports security groups, which allows for more flexibility with port configurations.  
-> We mimic the functionality of security groups for Azure and GCloud to allow ports to be defined per instance.  
-
-### Environment variables
-Terraform allows for top-level variables to be defined with cli arguments or environment variables.
-
-For any variable you can define:
-- Environment variables for all stages: `TF_VAR_ARGS=<CLI ARGS>`
-- Environment variables for a targetted stage: `TF_VAR_ARGS_<stage>=<CLI ARGS>`
-- Environment variables for root variables: `TF_VAR_<variable>=<ARGS>`
-- CLI Arguments for root variables: `-var <variable>=<ARGS>`
-
-Example variable:
-- `TF_VAR_force_dynamic_ip=true` is the same as `-var force_dynamic_ip=true`
-- `TF_VAR_service_cidrblocks='["0.0.0.0/0"]'`

--- a/docs/examples/aws/biganimal.yml
+++ b/docs/examples/aws/biganimal.yml
@@ -37,3 +37,7 @@ aws:
         - cidr_block: 10.0.0.0/24
         - cidr_block: 127.0.0.1/32
           description: localhost
+      allowed_machines:
+        - "*"
+      tags:
+        foo: bar

--- a/docs/examples/azure/biganimal.yml
+++ b/docs/examples/azure/biganimal.yml
@@ -37,3 +37,7 @@ azure:
         - cidr_block: 10.0.0.0/24
         - cidr_block: 127.0.0.1/32
           description: localhost
+      allowed_machines:
+        - "*"
+      tags:
+        foo: bar

--- a/docs/examples/gcloud/biganimal.yml
+++ b/docs/examples/gcloud/biganimal.yml
@@ -39,5 +39,7 @@ gcloud:
         - cidr_block: 10.2.0.0/24
         - cidr_block: 127.0.0.1/32
           description: localhost
+      allowed_machines:
+        - "*"
       tags:
         foo: bar

--- a/edbterraform/data/templates/aws/biganimal.tf.j2
+++ b/edbterraform/data/templates/aws/biganimal.tf.j2
@@ -23,7 +23,9 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  allowed_machines          = each.value.spec.allowed_machines
   service_cidrblocks        = local.biganimal_service_cidrblocks
+  machine_cidrblocks        = local.machine_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/aws/biganimal.tf.j2
+++ b/edbterraform/data/templates/aws/biganimal.tf.j2
@@ -21,8 +21,9 @@ module "biganimal_{{ region_ }}" {
   volume                    = each.value.spec.volume
   wal_volume                = each.value.spec.wal_volume
   password                  = each.value.spec.password
+  pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
-  
+
   settings                  = each.value.spec.settings
 
   tags                     = each.value.spec.tags

--- a/edbterraform/data/templates/aws/biganimal.tf.j2
+++ b/edbterraform/data/templates/aws/biganimal.tf.j2
@@ -23,6 +23,7 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  service_cidrblocks        = local.biganimal_service_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -18,6 +18,7 @@ module "machine_{{ region_ }}" {
   public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
+  force_ssh_access         = var.force_service_machines
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -80,6 +80,12 @@ locals {
     biganimal = local.biganimal
     kubernetes = local.kubernetes
   }
+
+  # Collect all machine ips for re-use
+  machine_cidrblocks = {
+    for machine, values in coalesce(one(local.machines), {}):
+      machine => formatlist("%s/32", [values.public_ip, values.private_ip])
+  }
 }
 
 output "modules" {

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -64,15 +64,21 @@
 locals {
   # Module names set with jinja2 in edb-terraform
   # Modules cannot be referenced dynamically.
-  modules = {
 {% for type, attributes in boxes.items() %}
-    {{ type }} = flatten([
+  {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-      {{ module }},
+    {{ module }},
 {%   endfor %}
-    ])
+  ])
 {% endfor %}
+
+  modules = {
+    machines = local.machines
+    databases = local.databases
+    aurora = local.aurora
+    biganimal = local.biganimal
+    kubernetes = local.kubernetes
   }
 }
 

--- a/edbterraform/data/templates/azure/biganimal.tf.j2
+++ b/edbterraform/data/templates/azure/biganimal.tf.j2
@@ -23,7 +23,9 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  allowed_machines          = each.value.spec.allowed_machines
   service_cidrblocks        = local.biganimal_service_cidrblocks
+  machine_cidrblocks        = local.machine_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/azure/biganimal.tf.j2
+++ b/edbterraform/data/templates/azure/biganimal.tf.j2
@@ -21,6 +21,7 @@ module "biganimal_{{ region_ }}" {
   volume                    = each.value.spec.volume
   wal_volume                = each.value.spec.wal_volume
   password                  = each.value.spec.password
+  pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
 
   settings                  = each.value.spec.settings

--- a/edbterraform/data/templates/azure/biganimal.tf.j2
+++ b/edbterraform/data/templates/azure/biganimal.tf.j2
@@ -23,6 +23,7 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  service_cidrblocks        = local.biganimal_service_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -24,6 +24,7 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = local.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
+  force_ssh_access                = var.force_service_machines
 
   depends_on = [
     module.key_pair_{{ region_ }},

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -73,6 +73,12 @@ locals {
     biganimal = local.biganimal
     kubernetes = local.kubernetes
   }
+
+  # Collect all machine ips for re-use
+  machine_cidrblocks = {
+    for machine, values in coalesce(one(local.machines), {}):
+      machine => formatlist("%s/32", [values.public_ip, values.private_ip])
+  }
 }
 output "modules" {
   description = "Variable which holds all final modules."

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -58,18 +58,22 @@
 locals {
   # Module names set with jinja2 in edb-terraform
   # Modules cannot be referenced dynamically.
-  modules = {
 {% for type, attributes in boxes.items() %}
-    {{ type }} = flatten([
+  {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-      {{ module }},
+    {{ module }},
 {%   endfor %}
-    ])
+  ])
 {% endfor %}
+
+  modules = {
+    machines = local.machines
+    databases = local.databases
+    biganimal = local.biganimal
+    kubernetes = local.kubernetes
   }
 }
-
 output "modules" {
   description = "Variable which holds all final modules."
   value = local.modules

--- a/edbterraform/data/templates/gcloud/biganimal.tf.j2
+++ b/edbterraform/data/templates/gcloud/biganimal.tf.j2
@@ -23,7 +23,9 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  allowed_machines          = each.value.spec.allowed_machines
   service_cidrblocks        = local.biganimal_service_cidrblocks
+  machine_cidrblocks        = local.machine_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/gcloud/biganimal.tf.j2
+++ b/edbterraform/data/templates/gcloud/biganimal.tf.j2
@@ -21,8 +21,9 @@ module "biganimal_{{ region_ }}" {
   volume                    = each.value.spec.volume
   wal_volume                = each.value.spec.wal_volume
   password                  = each.value.spec.password
+  pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
-  
+
   settings                  = each.value.spec.settings
 
   tags                     = each.value.spec.tags

--- a/edbterraform/data/templates/gcloud/biganimal.tf.j2
+++ b/edbterraform/data/templates/gcloud/biganimal.tf.j2
@@ -23,6 +23,7 @@ module "biganimal_{{ region_ }}" {
   password                  = each.value.spec.password
   pgvector                  = each.value.spec.pgvector
   allowed_ip_ranges         = each.value.spec.allowed_ip_ranges
+  service_cidrblocks        = local.biganimal_service_cidrblocks
 
   settings                  = each.value.spec.settings
 

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -20,6 +20,7 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = var.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
+  force_ssh_access                = var.force_service_machines
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -57,15 +57,21 @@
 locals {
   # Module names set with jinja2 in edb-terraform
   # Modules cannot be referenced dynamically.
-  modules = {
 {% for type, attributes in boxes.items() %}
-    {{ type }} = flatten([
+  {{ type }} = flatten([
 {%   for region in attributes["regions"] -%}
 {%   set module = attributes["module_base"] ~ region | replace('-', '_') %}
-      {{ module }},
+    {{ module }},
 {%   endfor %}
-    ])
+  ])
 {% endfor %}
+
+  modules = {
+    machines = local.machines
+    databases = local.databases
+    alloy = local.alloy
+    biganimal = local.biganimal
+    kubernetes = local.kubernetes
   }
 }
 

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -73,6 +73,12 @@ locals {
     biganimal = local.biganimal
     kubernetes = local.kubernetes
   }
+
+  # Collect all machine ips for re-use
+  machine_cidrblocks = {
+    for machine, values in coalesce(one(local.machines), {}):
+      machine => formatlist("%s/32", [values.public_ip, values.private_ip])
+  }
 }
 
 output "modules" {

--- a/edbterraform/data/terraform/aws/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/main.tf
@@ -11,6 +11,7 @@ resource "biganimal_cluster" "instance" {
     password = var.password
     pg_type = var.engine
     pg_version = var.engine_version
+    pgvector = var.pgvector
     project_id = var.project.id
     region = var.region
     storage {

--- a/edbterraform/data/terraform/aws/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/main.tf
@@ -25,7 +25,7 @@ resource "biganimal_cluster" "instance" {
 
     # optional
     dynamic "allowed_ip_ranges" {
-        for_each = var.allowed_ip_ranges
+        for_each = local.allowed_ip_ranges
         content {
             cidr_block = allowed_ip_ranges.value.cidr_block
             description = allowed_ip_ranges.value.description

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -86,6 +86,18 @@ variable "allowed_ip_ranges" {
   default = []
 }
 
+variable "allowed_machines" {
+  type = list(string)
+  nullable = false
+  default = ["*"]
+}
+
+variable "machine_cidrblocks" {
+  type = map(list(string))
+  default = {}
+  nullable = false
+}
+
 variable "service_cidrblocks" {
   description = "Default cidr blocks for service ports"
   type = list(string)
@@ -106,9 +118,19 @@ locals {
       description = "Service CIDR"
     }
   ]
+  machine_cidrblock_wildcard = anytrue([for machine in var.allowed_machines : machine == "*"])
+  machine_names = local.machine_cidrblock_wildcard ? [for machine in keys(var.machine_cidrblocks) : machine] : var.allowed_machines
+  machine_cidrblocks = flatten([
+    for machine_name in local.machine_names : flatten([
+      for cidr in var.machine_cidrblocks[machine_name] : {
+          cidr_block = cidr
+          description = "Machine CIDR - ${machine_name}"
+        }
+    ])
+  ])
   # Private networking blocks setting of allowed_ip_ranges and forces private endpoints or vpc peering to be used.
   # The provider overrides with 0.0.0.0/0 but fails to create if allowed_ip_ranges is not an empty list.
-  allowed_ip_ranges = var.publicly_accessible ? concat(local.mod_ip_ranges, local.service_cidrblocks) : []
+  allowed_ip_ranges = var.publicly_accessible ? concat(local.mod_ip_ranges, local.service_cidrblocks, local.machine_cidrblocks) : []
 }
 
 variable "tags" {

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -86,6 +86,31 @@ variable "allowed_ip_ranges" {
   default = []
 }
 
+variable "service_cidrblocks" {
+  description = "Default cidr blocks for service ports"
+  type = list(string)
+  nullable = false
+  default = []
+}
+
+locals {
+  # If cidrblocks are not set, biganimal opens service to all ips.
+  # Block traffic if it is an empty list to avoid accidental exposure of the database
+  mod_ip_ranges = length(var.allowed_ip_ranges) >= 1 ? var.allowed_ip_ranges : [{
+    cidr_block = "127.0.0.1/32"
+    description = "private default"
+  }]
+  service_cidrblocks = [
+    for cidr in var.service_cidrblocks : {
+      cidr_block = cidr
+      description = "Service CIDR"
+    }
+  ]
+  # Private networking blocks setting of allowed_ip_ranges and forces private endpoints or vpc peering to be used.
+  # The provider overrides with 0.0.0.0/0 but fails to create if allowed_ip_ranges is not an empty list.
+  allowed_ip_ranges = var.publicly_accessible ? concat(local.mod_ip_ranges, local.service_cidrblocks) : []
+}
+
 variable "tags" {
   type = map(any)
   default = {}
@@ -115,7 +140,7 @@ locals {
     clusterName = local.cluster_name
     instanceType = { instanceTypeId = local.instance_type }
     allowedIpRanges = [
-      for key, value in var.allowed_ip_ranges :
+      for key, value in local.allowed_ip_ranges :
         {
           cidrBlock = value.cidr_block
           description = value.description

--- a/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/variables.tf
@@ -4,6 +4,12 @@ variable "project" {
   })
 }
 
+variable "pgvector" {
+  type = bool
+  default = false
+  nullable = false
+}
+
 variable "name" {}
 variable "name_id" {}
 variable "cloud_account" {

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -2,12 +2,22 @@ variable "machine" {}
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
-
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
 locals {
   # Allow machine default outbound access if no egress is defined
   egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])
+  ssh_defined = anytrue([for port in var.machine.spec.ports: port.port == var.machine.spec.ssh_port])
   machine_ports = concat(var.machine.spec.ports, 
-      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "to_port": null, "description": "Default Egress if not defined"}])
+      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "to_port": null, "description": "Default Egress if not defined"}]),
+      (!var.force_ssh_access || local.ssh_defined ? [] : [
+        {"type": "ingress", "defaults": "service", "cidrs": [], "protocol": "tcp", "port": var.machine.spec.ssh_port, "to_port": var.machine.spec.ssh_port, "description": "Force SSH Access"},
+        {"type": "egress", "defaults": "service", "cidrs": [], "protocol": "tcp", "port": var.machine.spec.ssh_port, "to_port": var.machine.spec.ssh_port, "description": "Force SSH Access"},
+      ])
     )
 }
 

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "rules" {
 }
 
 resource "aws_security_group_rule" "rule" {
-  for_each = local.merged_rules
+  for_each = local.rules
   security_group_id = aws_security_group.rules.id
   description = each.value.description
   type = each.value.type

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -59,4 +59,14 @@ locals {
         "description": join(" _ ", distinct(local.port_rules_descriptions[name]))
       })
   }
+  # Expand the list back out with 1 rule per cidrblock since AWS fails to track the rules properly
+  # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/29797
+  rules = merge([
+    for name, rule in local.merged_rules: {
+      for cidr in rule.cidrs: 
+        format("%s_%s", name, cidr) => merge(rule, {
+          cidrs = [cidr]
+        })
+    }
+  ]...)
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -170,6 +170,7 @@ variable "spec" {
         throughput = optional(number)
       }))
       password       = string
+      pgvector       = optional(bool)
       settings = optional(list(object({
         name  = string
         value = string

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -179,6 +179,7 @@ variable "spec" {
         cidr_block = string
         description = optional(string, "default description")
       })))
+      allowed_machines = optional(list(string))
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({

--- a/edbterraform/data/terraform/azure/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/main.tf
@@ -12,6 +12,7 @@ resource "biganimal_cluster" "instance" {
     password = var.password
     pg_type = var.engine
     pg_version = var.engine_version
+    pgvector = var.pgvector
     project_id = var.project.id
     region = var.region
     storage {

--- a/edbterraform/data/terraform/azure/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/main.tf
@@ -26,7 +26,7 @@ resource "biganimal_cluster" "instance" {
 
     # optional
     dynamic "allowed_ip_ranges" {
-        for_each = { for key,values in var.allowed_ip_ranges: key=>values }
+        for_each = local.allowed_ip_ranges
         content {
             cidr_block = allowed_ip_ranges.value.cidr_block
             description = allowed_ip_ranges.value.description

--- a/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/variables.tf
@@ -4,6 +4,12 @@ variable "project" {
   })
 }
 
+variable "pgvector" {
+  type = bool
+  default = false
+  nullable = false
+}
+
 variable "name" {}
 variable "name_id" {}
 variable "cloud_account" {

--- a/edbterraform/data/terraform/azure/modules/machine/main.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/main.tf
@@ -95,7 +95,7 @@ module "machine_ports" {
   name_id          = "${var.name}-${var.name_id}"
   region           = var.machine.region
   resource_name    = var.resource_name
-  ports            = var.ports
+  ports            = local.machine_ports
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
   internal_cidrblocks = var.internal_cidrblocks

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -138,6 +138,7 @@ variable "spec" {
         cidr_block = string
         description = optional(string, "default description")
       })))
+      allowed_machines = optional(list(string))
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -129,6 +129,7 @@ variable "spec" {
         throughput = optional(number)
       }))
       password       = string
+      pgvector       = optional(bool)
       settings = optional(list(object({
         name  = string
         value = string

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -27,6 +27,12 @@ variable "force_dynamic_ip" {
   default = false
 }
 
+variable "force_service_machines" {
+  description = "Force the use of service_cidrblocks and set up an ssh rule for the machines"
+  type = bool
+  default = false
+}
+
 variable "force_service_biganimal" {
   description = "Force the use of service_cidrblocks in biganimals allowed_ip_ranges"
   type = bool

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -27,6 +27,12 @@ variable "force_dynamic_ip" {
   default = false
 }
 
+variable "force_service_biganimal" {
+  description = "Force the use of service_cidrblocks in biganimals allowed_ip_ranges"
+  type = bool
+  default = false
+}
+
 variable "dynamic_service_ip_mask" {
   type = number
   default = 32
@@ -62,4 +68,5 @@ locals {
     }/${var.dynamic_service_ip_mask}"
   ] : []
   service_cidrblocks = concat(var.service_cidrblocks, local.dynamic_ip)
+  biganimal_service_cidrblocks = var.force_service_biganimal ? local.service_cidrblocks : []
 }

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
@@ -12,6 +12,7 @@ resource "biganimal_cluster" "instance" {
     password = var.password
     pg_type = var.engine
     pg_version = var.engine_version
+    pgvector = var.pgvector
     project_id = var.project.id
     region = var.region
     storage {

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/main.tf
@@ -24,7 +24,7 @@ resource "biganimal_cluster" "instance" {
 
     # optional
     dynamic "allowed_ip_ranges" {
-        for_each = { for key,values in var.allowed_ip_ranges: key=>values }
+        for_each = local.allowed_ip_ranges
         content {
             cidr_block = allowed_ip_ranges.value.cidr_block
             description = allowed_ip_ranges.value.description

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
@@ -76,6 +76,31 @@ variable "allowed_ip_ranges" {
   default = []
 }
 
+variable "service_cidrblocks" {
+  description = "Default cidr blocks for service ports"
+  type = list(string)
+  nullable = false
+  default = []
+}
+
+locals {
+  # If cidrblocks are not set, biganimal opens service to all ips.
+  # Block traffic if it is an empty list to avoid accidental exposure of the database
+  mod_ip_ranges = length(var.allowed_ip_ranges) >= 1 ? var.allowed_ip_ranges : [{
+    cidr_block = "127.0.0.1/32"
+    description = "private default"
+  }]
+  service_cidrblocks = [
+    for cidr in var.service_cidrblocks : {
+      cidr_block = cidr
+      description = "Service CIDR"
+    }
+  ]
+  # Private networking blocks setting of allowed_ip_ranges and forces private endpoints or vpc peering to be used.
+  # The provider overrides with 0.0.0.0/0 but fails to create if allowed_ip_ranges is not an empty list.
+  allowed_ip_ranges = var.publicly_accessible ? concat(local.mod_ip_ranges, local.service_cidrblocks) : []
+}
+
 variable "tags" {
   type = map(any)
   default = {}
@@ -105,7 +130,7 @@ locals {
     clusterName = local.cluster_name
     instanceType = { instanceTypeId = local.instance_type }
     allowedIpRanges = [
-      for key, value in var.allowed_ip_ranges :
+      for key, value in local.allowed_ip_ranges :
         {
           cidrBlock = value.cidr_block
           description = value.description

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/variables.tf
@@ -4,6 +4,12 @@ variable "project" {
   })
 }
 
+variable "pgvector" {
+  type = bool
+  default = false
+  nullable = false
+}
+
 variable "name" {}
 variable "name_id" {}
 variable "cloud_account" {

--- a/edbterraform/data/terraform/gcloud/modules/machine/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/main.tf
@@ -59,7 +59,7 @@ module "machine_ports" {
   source = "../security"
 
   network_name     = var.network_name
-  ports            = var.machine.spec.ports
+  ports            = local.machine_ports
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
   internal_cidrblocks = var.internal_cidrblocks

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -151,6 +151,7 @@ variable "spec" {
         cidr_block = string
         description = optional(string, "default description")
       })))
+      allowed_machines = optional(list(string))
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -142,6 +142,7 @@ variable "spec" {
         throughput = optional(number)
       }))
       password       = string
+      pgvector       = optional(bool)
       settings = optional(list(object({
         name  = string
         value = string

--- a/edbterraform/parser/hcl2.py
+++ b/edbterraform/parser/hcl2.py
@@ -12,6 +12,7 @@ TERRAFORM_PYTHON_TYPES = {
     "${map(string)}": dict[str, str],
 }
 
+# TODO: Fix breaking changes or use a different library such as https://github.com/hashicorp/terraform-config-inspect
 def load_hcl2(project_path: Union[str, Path] = None, load_tf = True, load_tf_vars = False, load_json = False,):
     try:
         results = {}


### PR DESCRIPTION
Root module changes:
- `force_service_biganimal` - option to dynamically append service_cidrblocks to biganimal's allow list.
- `force_service_machines` - option to dynamically create an ssh port rule for each machine.
Once you no longer need the open access, `terraform apply` without `-var` can be used to remove the ssh ports from each machine or service_cidrblocks from biganimal's allow list.

BigAnimal changes:
- spec:
  - `pgvector` - enable pgvector extension.
  - `allowed_machines` - list of machine keynames that should have access to the biganimal cluster. By default, all machines will have access.
- No public access - by default biganimal will allow all-access if the allow list is empty. This is overwritten with `["127.0.0.1/32"]` to restrict access unless a user sets a non-empty list.

Fixes

Ref: https://github.com/hashicorp/terraform-provider-aws/issues/29797