### PR TITLE
AWS module updates to reduce the number of created resources

### DIFF
--- a/docs/examples/aws/machines-cross-region.yml
+++ b/docs/examples/aws/machines-cross-region.yml
@@ -1,0 +1,221 @@
+aws:
+  tags:
+    cluster_name: Demo-Infra
+    created_by: edb-terraform
+  images:
+    rocky:
+      name: Rocky-9-EC2-Base-9.2-20230513.0.x86_64
+      owner: 679593333241
+      ssh_user: rocky
+  regions:
+    us-west-1:
+      cidr_block: 10.1.0.0/16
+      zones:
+        a:
+          zone: us-west-1b
+          cidr: 10.1.10.0/24
+      ports:
+        - port: 22
+          defaults: service
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
+        - protocol: icmp
+          defaults: internal
+          description: "pinging"
+    us-west-2:
+      cidr_block: 10.2.0.0/16
+      zones:
+        a:
+          zone: us-west-2a
+          cidr: 10.2.10.0/24
+      ports:
+        - port: 22
+          defaults: service
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
+        - protocol: icmp
+          defaults: internal
+          description: "pinging"
+    us-east-1:
+      cidr_block: 10.3.0.0/16
+      zones:
+        a:
+          zone: us-east-1a
+          cidr: 10.3.10.0/24
+      ports:
+        - port: 22
+          defaults: service
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
+        - protocol: icmp
+          defaults: internal
+          description: "pinging"
+    us-east-2:
+      cidr_block: 10.4.0.0/16
+      zones:
+        a:
+          zone: us-east-2a
+          cidr: 10.4.10.0/24
+      ports:
+        - port: 22
+          defaults: service
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
+        - protocol: icmp
+          defaults: internal
+          description: "pinging"
+    ca-central-1:
+      cidr_block: 10.5.0.0/16
+      zones:
+        a:
+          zone: ca-central-1a
+          cidr: 10.5.10.0/24
+      ports:
+        - port: 22
+          defaults: service
+          protocol: tcp
+          description: "SSH"
+          type: ingress
+          cidrs:
+            - 0.0.0.0/0
+        - protocol: icmp
+          defaults: internal
+          description: "pinging"
+  machines:
+    primary_1:
+      image_name: rocky
+      region: us-west-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    subscribers_1:
+      count: 20
+      image_name: rocky
+      region: us-west-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    primary_2:
+      image_name: rocky
+      region: us-west-2
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    subscribers_2:
+      count: 20
+      image_name: rocky
+      region: us-west-2
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    primary_3:
+      image_name: rocky
+      region: us-east-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    subscribers_3:
+      count: 20
+      image_name: rocky
+      region: us-east-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    primary_4:
+      image_name: rocky
+      region: us-east-2
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    subscribers_4:
+      count: 20
+      image_name: rocky
+      region: us-east-2
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    primary_5:
+      image_name: rocky
+      region: ca-central-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres
+    subscribers_5:
+      count: 20
+      image_name: rocky
+      region: ca-central-1
+      zone_name: a
+      instance_type: m6a.large
+      volume:
+        type: gp3
+        size_gb: 50
+        iops: 150
+        encrypted: false
+      tags:
+        type: postgres

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -18,7 +18,6 @@ module "machine_{{ region_ }}" {
   public_cidrblocks        = var.public_cidrblocks
   service_cidrblocks       = local.service_cidrblocks
   internal_cidrblocks      = module.spec.region_cidrblocks
-  force_ssh_access         = var.force_service_machines
 
   depends_on = [module.key_pair_{{ region_ }}, module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -1,3 +1,24 @@
+# Default outbound rules for use with machines
+resource "aws_security_group" "default_{{ region_ }}" {
+  name = format("default_outbound")
+  vpc_id = module.vpc_{{ region_ }}.vpc_id
+
+  tags = merge({
+    Name = format("default_outbound")
+  }, module.spec.base.tags)
+
+  provider = aws.{{ region_ }}
+}
+
+resource "aws_vpc_security_group_egress_rule" "out_{{ region_ }}" {
+  security_group_id = aws_security_group.default_{{ region_ }}.id
+  description = "Default outbound"
+  ip_protocol = -1
+  cidr_ipv4   = "0.0.0.0/0"
+
+  provider = aws.{{ region_ }}
+}
+
 # Find the AMI id, which varies by region.
 # This must be done outside of the module to avoid the data source being called per machine.
 # If set within the module, it will delay calling the data source and causes terraform to re-create resources since it is unknown.
@@ -33,6 +54,7 @@ module "machine_{{ region_ }}" {
   machine                  = each.value
   image_info               = data.aws_ami.default_{{ region_ }}
   custom_security_group_ids = module.security_{{ region_ }}.security_group_ids
+  outbound_security_groups = [aws_security_group.default_{{ region_ }}.id]
   ssh_pub_key              = module.spec.public_key
   ssh_priv_key             = module.spec.private_key
   use_agent                = module.spec.base.ssh_key.use_agent

--- a/edbterraform/data/templates/aws/machine.tf.j2
+++ b/edbterraform/data/templates/aws/machine.tf.j2
@@ -1,3 +1,25 @@
+# Find the AMI id, which varies by region.
+# This must be done outside of the module to avoid the data source being called per machine.
+# If set within the module, it will delay calling the data source and causes terraform to re-create resources since it is unknown.
+data "aws_ami" "default_{{ region_ }}" {
+  for_each = var.spec.images
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["${each.value.name}*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["${each.value.owner}"]
+
+  provider = aws.{{ region_ }}
+}
+
 module "machine_{{ region_ }}" {
   source = "./modules/machine"
 
@@ -9,6 +31,7 @@ module "machine_{{ region_ }}" {
   cidr_block               = each.value.spec.cidr
   az                       = each.value.spec.zone
   machine                  = each.value
+  image_info               = data.aws_ami.default_{{ region_ }}
   custom_security_group_ids = module.security_{{ region_ }}.security_group_ids
   ssh_pub_key              = module.spec.public_key
   ssh_priv_key             = module.spec.private_key

--- a/edbterraform/data/templates/aws/main.tf.j2
+++ b/edbterraform/data/templates/aws/main.tf.j2
@@ -83,7 +83,7 @@ locals {
 
   # Collect all machine ips for re-use
   machine_cidrblocks = {
-    for machine, values in coalesce(one(local.machines), {}):
+    for machine, values in merge(local.machines...):
       machine => formatlist("%s/32", [values.public_ip, values.private_ip])
   }
 }

--- a/edbterraform/data/templates/aws/validation.tf.j2
+++ b/edbterraform/data/templates/aws/validation.tf.j2
@@ -5,6 +5,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  force_ssh_access = var.force_service_machines
 }
 
 # All modules should use the last created module in their depends_on through jinja

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -24,7 +24,6 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = local.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
-  force_ssh_access                = var.force_service_machines
 
   depends_on = [
     module.key_pair_{{ region_ }},

--- a/edbterraform/data/templates/azure/main.tf.j2
+++ b/edbterraform/data/templates/azure/main.tf.j2
@@ -76,7 +76,7 @@ locals {
 
   # Collect all machine ips for re-use
   machine_cidrblocks = {
-    for machine, values in coalesce(one(local.machines), {}):
+    for machine, values in merge(local.machines...):
       machine => formatlist("%s/32", [values.public_ip, values.private_ip])
   }
 }

--- a/edbterraform/data/templates/azure/validation.tf.j2
+++ b/edbterraform/data/templates/azure/validation.tf.j2
@@ -6,6 +6,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  force_ssh_access = var.force_service_machines
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -20,7 +20,6 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = var.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
-  force_ssh_access                = var.force_service_machines
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/templates/gcloud/main.tf.j2
+++ b/edbterraform/data/templates/gcloud/main.tf.j2
@@ -76,7 +76,7 @@ locals {
 
   # Collect all machine ips for re-use
   machine_cidrblocks = {
-    for machine, values in coalesce(one(local.machines), {}):
+    for machine, values in merge(local.machines...):
       machine => formatlist("%s/32", [values.public_ip, values.private_ip])
   }
 }

--- a/edbterraform/data/templates/gcloud/validation.tf.j2
+++ b/edbterraform/data/templates/gcloud/validation.tf.j2
@@ -6,6 +6,7 @@ module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+  force_ssh_access = var.force_service_machines
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -1,19 +1,3 @@
-data "aws_ami" "default" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["${var.operating_system.name}*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["${var.operating_system.owner}"]
-}
-
 module "machine_ports" {
   source = "../security"
 
@@ -24,11 +8,10 @@ module "machine_ports" {
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
   internal_cidrblocks = var.internal_cidrblocks
-
 }
 
 resource "aws_instance" "machine" {
-  ami                    = data.aws_ami.default.id
+  ami                    = var.image_info[var.machine.spec.image_name].id
   instance_type          = var.machine.spec.instance_type
   key_name               = var.key_name
   subnet_id              = var.subnet_id
@@ -59,8 +42,6 @@ resource "aws_instance" "machine" {
 
   lifecycle {
     ignore_changes = [
-      # AMI is ignored because the data source forces the resource to be re-created when apply is used again
-      ami,
       # Tags appear as null during re-applys
       tags["Owner"],
       root_block_device[0].tags["Owner"],

--- a/edbterraform/data/terraform/aws/modules/machine/main.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/main.tf
@@ -3,7 +3,7 @@ module "machine_ports" {
 
   vpc_id           = var.vpc_id
   cluster_name     = var.machine.name
-  ports            = local.machine_ports
+  ports            = var.machine.spec.ports
   tags             = var.tags
   public_cidrblocks = var.public_cidrblocks
   service_cidrblocks = var.service_cidrblocks
@@ -15,7 +15,7 @@ resource "aws_instance" "machine" {
   instance_type          = var.machine.spec.instance_type
   key_name               = var.key_name
   subnet_id              = var.subnet_id
-  vpc_security_group_ids = flatten([var.custom_security_group_ids, module.machine_ports.security_group_ids])
+  vpc_security_group_ids = flatten([local.security_group_ids, module.machine_ports.security_group_ids])
 
   dynamic "instance_market_options" {
     for_each = var.machine.spec.spot == true ? [1] : []

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -2,22 +2,11 @@ variable "machine" {}
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
-variable "force_ssh_access" {
-  description = "Force append a service rule for ssh access"
-  default = false
-  type = bool
-  nullable = false
-}
 locals {
   # Allow machine default outbound access if no egress is defined
   egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])
-  ssh_defined = anytrue([for port in var.machine.spec.ports: port.port == var.machine.spec.ssh_port])
   machine_ports = concat(var.machine.spec.ports, 
       (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "to_port": null, "description": "Default Egress if not defined"}]),
-      (!var.force_ssh_access || local.ssh_defined ? [] : [
-        {"type": "ingress", "defaults": "service", "cidrs": [], "protocol": "tcp", "port": var.machine.spec.ssh_port, "to_port": var.machine.spec.ssh_port, "description": "Force SSH Access"},
-        {"type": "egress", "defaults": "service", "cidrs": [], "protocol": "tcp", "port": var.machine.spec.ssh_port, "to_port": var.machine.spec.ssh_port, "description": "Force SSH Access"},
-      ])
     )
 }
 

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -26,6 +26,7 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+variable "image_info" {}
 
 locals {
   additional_volumes_length = length(lookup(var.machine.spec, "additional_volumes", []))

--- a/edbterraform/data/terraform/aws/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/machine/variables.tf
@@ -2,12 +2,11 @@ variable "machine" {}
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
+variable "outbound_security_groups" {}
 locals {
   # Allow machine default outbound access if no egress is defined
   egress_defined = anytrue([for port in var.machine.spec.ports: port.type=="egress"])
-  machine_ports = concat(var.machine.spec.ports, 
-      (local.egress_defined ? [] : [{"type"="egress", "cidrs"=["0.0.0.0/0"], "protocol"="-1", "port": null, "to_port": null, "description": "Default Egress if not defined"}]),
-    )
+  security_group_ids = concat(var.custom_security_group_ids, local.egress_defined ? [] : var.outbound_security_groups)
 }
 
 variable "vpc_id" {}

--- a/edbterraform/data/terraform/aws/modules/security/main.tf
+++ b/edbterraform/data/terraform/aws/modules/security/main.tf
@@ -7,23 +7,62 @@ resource "aws_security_group" "rules" {
   }, var.tags)
 }
 
-resource "aws_security_group_rule" "rule" {
-  for_each = local.rules
+resource "aws_vpc_security_group_ingress_rule" "in" {
+  for_each = { for name, rule in local.rules : name => rule if rule.type == "ingress" }
+
   security_group_id = aws_security_group.rules.id
   description = each.value.description
-  type = each.value.type
 
   from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
   to_port     = (
-      each.value.to_port != null && each.value.protocol != "icmp"  ? each.value.to_port : 
+      each.value.to_port != null && each.value.protocol != "icmp"  ? each.value.to_port :
       each.value.port != null && each.value.protocol != "icmp" ? each.value.port : -1
     )
-  protocol    = each.value.protocol
-  cidr_blocks = each.value.cidrs
+  ip_protocol = each.value.protocol
+  cidr_ipv4   = one(each.value.cidrs)
 
   lifecycle {
     precondition {
-      condition     = each.value.type == "ingress" || each.value.type == "egress"
+      condition     = each.value.type == "ingress"
+      error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
+    }
+
+    precondition {
+      error_message = "port defaults must be one of: service, public, internal or an empty string ('')"
+      condition = contains(["service", "internal", "public", ""], try(each.value.defaults, ""))
+    }
+
+    precondition {
+      condition     = each.value.cidrs != null && length(each.value.cidrs) > 0
+      error_message = <<-EOT
+        Cidr blocks cannot be an empty list.
+        - AWS Security groups are an allow list meaning an empty list is the same as not having the rule itself.
+        - When defaults is set to 'service' and has no cidrs defined, it is removed from the list to avoid creation.
+        The AWS API will return the following error after 5-10 minutes:
+          Error: waiting for Security Group (sg-xxxx) Rule (sgrule-xxxx) create: couldn't find resource
+        Rule: ${jsonencode(each.value)}
+      EOT
+    }
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "out" {
+  for_each = { for name, rule in local.rules : name => rule if rule.type == "egress" }
+
+  security_group_id = aws_security_group.rules.id
+  description = each.value.description
+
+  from_port   = each.value.protocol == "icmp" ? 8 : each.value.port != null ? each.value.port : -1
+  to_port     = (
+      each.value.to_port != null && each.value.protocol != "icmp"  ? each.value.to_port :
+      each.value.port != null && each.value.protocol != "icmp" ? each.value.port : -1
+    )
+  ip_protocol = each.value.protocol
+  cidr_ipv4   = one(each.value.cidrs)
+
+  lifecycle {
+    precondition {
+      condition     = each.value.type == "egress"
       error_message = "${each.key} has type ${each.value.type}. Must be ingress or egress."
     }
 

--- a/edbterraform/data/terraform/aws/modules/security/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/security/variables.tf
@@ -61,12 +61,14 @@ locals {
   }
   # Expand the list back out with 1 rule per cidrblock since AWS fails to track the rules properly
   # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/29797
+  # New resources aws_vpc_security_group_egress_rule and aws_vpc_security_group_ingress_rule manages rules per cidrblock
   rules = merge([
     for name, rule in local.merged_rules: {
-      for cidr in rule.cidrs: 
-        format("%s_%s", name, cidr) => merge(rule, {
+      for cidr in rule.cidrs: format("%s_%s", name, cidr) => merge(rule,
+        {
           cidrs = [cidr]
-        })
+        }
+      )
     }
   ]...)
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -191,6 +191,13 @@ variable "spec" {
   })
 }
 
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "AWS-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-AWS"

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -32,12 +32,6 @@ variable "machine" {
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
-variable "force_ssh_access" {
-  description = "Force append a service rule for ssh access"
-  default = false
-  type = bool
-  nullable = false
-}
 variable "ports" {
   type = list
   default = []

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -8,15 +8,38 @@ locals {
     cluster_name    = local.cluster_name
   })
 
-  # each regions cidrblock, should not overlap since we perform VPC peering
-  region_cidrblocks = flatten([
-    for region, values in var.spec.regions:
-      values.cidr_block
+  machine_ssh_ports = distinct([for machine, values in var.spec.machines: values.ssh_port])
+  region_ssh_exists = {
+    for region, values in var.spec.regions: region => anytrue([
+      for port in values.ports: contains(local.machine_ssh_ports, coalesce(port.port, -2)) || contains(local.machine_ssh_ports, coalesce(port.to_port, -2)) if port.defaults == "service"
+    ])
+  }
+  machine_ssh_rules = flatten([
+    for port in local.machine_ssh_ports: [
+      {
+        "type": "ingress",
+        "defaults": "service",
+        "cidrs": [],
+        "protocol": "tcp",
+        "port": port,
+        "to_port": port,
+        "description": "Force SSH Access"
+      },
+      {
+        "type": "egress",
+        "defaults": "service",
+        "cidrs": [],
+        "protocol": "tcp",
+        "port": port,
+        "to_port": port,
+        "description": "Force SSH Access"
+      },
+    ]
   ])
 
   # save ports per region
   region_ports = {
-    for region, values in var.spec.regions: region => values.ports
+    for region, values in var.spec.regions: region => concat(values.ports, (local.region_ssh_exists[region] ? [] : local.machine_ssh_rules))
   }
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -157,6 +157,13 @@ variable "spec" {
 
 }
 
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "Azure-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-Azure"

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -2,12 +2,6 @@ variable "machine" {}
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
-variable "force_ssh_access" {
-  description = "Force append a service rule for ssh access"
-  default = false
-  type = bool
-  nullable = false
-}
 locals {
   ssh_defined = anytrue([for port in var.machine.spec.ports: port.port == var.machine.spec.ssh_port])
   machine_ports = concat(var.machine.spec.ports, (!var.force_ssh_access || local.ssh_defined ? [] : [

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -8,15 +8,38 @@ locals {
     cluster_name    = local.cluster_name
   })
 
-  # each regions cidrblock, should not overlap since we perform VPC peering
-  region_cidrblocks = flatten([
-    for region, values in var.spec.regions:
-      values.cidr_block
+  machine_ssh_ports = distinct([for machine, values in var.spec.machines: values.ssh_port])
+  region_ssh_exists = {
+    for region, values in var.spec.regions: region => anytrue([
+      for port in values.ports: contains(local.machine_ssh_ports, coalesce(port.port, -2)) || contains(local.machine_ssh_ports, coalesce(port.to_port, -2)) if port.defaults == "service"
+    ])
+  }
+  machine_ssh_rules = flatten([
+    for port in local.machine_ssh_ports: [
+      {
+        "type": "ingress",
+        "defaults": "service",
+        "cidrs": [],
+        "protocol": "tcp",
+        "port": port,
+        "to_port": port,
+        "description": "Force SSH Access"
+      },
+      {
+        "type": "egress",
+        "defaults": "service",
+        "cidrs": [],
+        "protocol": "tcp",
+        "port": port,
+        "to_port": port,
+        "description": "Force SSH Access"
+      },
+    ]
   ])
 
   # save ports per region
   region_ports = {
-    for region, values in var.spec.regions: region => values.ports
+    for region, values in var.spec.regions: region => concat(values.ports, (local.region_ssh_exists[region] ? [] : local.machine_ssh_rules))
   }
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -165,6 +165,13 @@ variable "spec" {
 
 }
 
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "GCloud-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-GCloud"


### PR DESCRIPTION
Changes:
- Single egress security group created per VPC and used within each machine if egress is not configured.
- `force_service_machine` creates a single ssh rule at the VPC level instead of per machine
- AMI data source moved outside of the machine module which fixes issues where it tried to re-create the resource each time since the data source appeared as an unknown value.

Fixes:
- Use `aws_route` since combining it with in-line rules will cause the provider to plan to remove the routes before adding it again in the next `terraform apply`