### PR TITLE
BigAnimal Access Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ The following components must be installed on the system:
   - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   - [GCloud CLI](https://cloud.google.com/sdk/docs/install-sdk)
   - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
-  - [BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/) currently optional since the terraform provider relies on the environment variable `BA_BEARER_TOKEN` and it requires manual authentication.
-    - For automation, [get-token.sh script](https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/api/get-token.sh) requires manual intervention every:
-      - 30 days
-      - Expired token is reused
+  - [BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/)
+    - `BA_ACCESS_KEY` environment variable (priority)
+      - Go to `https://portal.biganimal.com/access-keys` to create an access token that last 1-365 days.
+    - `BA_BEARER_TOKEN` environment variable (deprecated).
+      - [get-token.sh script](https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/api/get-token.sh) requires manual intervention every:
+        - New token request
+        - 30 days since initial token request
+        - Expired token is reused
 
 > :information_source:  
 > Refer to official documentation for credential management and environment specific installation.  

--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/data/terraform/aws/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/main.tf
@@ -55,12 +55,14 @@ resource "toolbox_external" "api" {
     "bash",
     "-c",
     <<EOT
+    set -eou pipefail
+
     create_stage() {
       URI="https://portal.biganimal.com/"
       ENDPOINT="api/v3/projects/${var.project.id}/clusters"
       REQUEST_TYPE="POST"
       DATA='${jsonencode(local.API_DATA)}'
-      RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "authorization: Bearer $BA_BEARER_TOKEN" --url "$URI$ENDPOINT" --data "$DATA")
+      RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "$AUTH_HEADER" --url "$URI$ENDPOINT" --data "$DATA")
       RC=$?
       if [[ $RC -ne 0 ]];
       then
@@ -80,7 +82,7 @@ resource "toolbox_external" "api" {
       SLEEP_TIME=15
       while [[ $PHASE != *"healthy"* ]]
       do
-        RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "authorization: Bearer $BA_BEARER_TOKEN" --url "$URI$ENDPOINT")
+        RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "$AUTH_HEADER" --url "$URI$ENDPOINT")
         RC=$?
         if [[ $RC -ne 0 ]]
         then
@@ -108,7 +110,7 @@ resource "toolbox_external" "api" {
       URI="https://portal.biganimal.com/"
       ENDPOINT="api/v3/projects/${var.project.id}/clusters/$1"
       REQUEST_TYPE="DELETE"
-      RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "authorization: Bearer $BA_BEARER_TOKEN" --url "$URI$ENDPOINT")
+      RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "$AUTH_HEADER" --url "$URI$ENDPOINT")
       RC=$?
       if [[ $RC -ne 0 ]];
       then
@@ -120,7 +122,17 @@ resource "toolbox_external" "api" {
     }
 
     # Get json object from stdin
-    read input
+    IFS='' read -r input || [ -n "$input" ]
+
+    # BigAnimal API accepts either an access key or a bearer token
+    # The access token should be preferred if set and non-empty.
+    AUTH_HEADER=""
+    if [ ! -z "$${BA_ACCESS_KEY:+''}" ]
+    then
+      AUTH_HEADER="x-access-key: $BA_ACCESS_KEY"
+    else
+      AUTH_HEADER="authorization: Bearer $BA_BEARER_TOKEN"
+    fi
 
     # Check CRUD stage from terraform
     # and make appropriate calls

--- a/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/aws/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.7.1"
+      version = "~> 0.8.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/azure/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/azure/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.7.1"
+      version = "~> 0.8.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/gcloud/modules/biganimal/providers.tf
+++ b/edbterraform/data/terraform/gcloud/modules/biganimal/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "~> 0.7.1"
+      version = "~> 0.8.1"
     }
     toolbox = {
       source = "bryan-bar/toolbox"

--- a/edbterraform/data/terraform/versions.tf
+++ b/edbterraform/data/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     biganimal = {
       source = "registry.terraform.io/EnterpriseDB/biganimal"
-      version = "<= 0.7.1"
+      version = "<= 0.8.1"
     }
     # https://github.com/EnterpriseDB/terraform-provider-toolbox/issues/44
     toolbox = {


### PR DESCRIPTION
BigAnimal now supports access keys and should be used instead of an access token.
The environment variable is `BA_ACCESS_KEY` though some of the provider docs show `EDB_TF_ACCESS_KEY` which is invalid.