### PR TITLE
FIX Azure/Gcloud networking - re-add force_ssh_access

### DIFF
--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.4"
+__version__ = "1.7.5"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/data/templates/azure/machine.tf.j2
+++ b/edbterraform/data/templates/azure/machine.tf.j2
@@ -24,6 +24,7 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = local.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
+  force_ssh_access                = var.force_service_machines
 
   depends_on = [
     module.key_pair_{{ region_ }},

--- a/edbterraform/data/templates/gcloud/machine.tf.j2
+++ b/edbterraform/data/templates/gcloud/machine.tf.j2
@@ -20,6 +20,7 @@ module "machine_{{ region_ }}" {
   public_cidrblocks               = var.public_cidrblocks
   service_cidrblocks              = var.service_cidrblocks
   internal_cidrblocks             = module.spec.region_cidrblocks
+  force_ssh_access                = var.force_service_machines
 
   depends_on = [module.security_{{ region_ }}]
 

--- a/edbterraform/data/terraform/azure/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/machine/variables.tf
@@ -32,6 +32,12 @@ variable "machine" {
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
 variable "ports" {
   type = list
   default = []

--- a/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/machine/variables.tf
@@ -2,6 +2,12 @@ variable "machine" {}
 variable "public_cidrblocks" {}
 variable "service_cidrblocks" {}
 variable "internal_cidrblocks" {}
+variable "force_ssh_access" {
+  description = "Force append a service rule for ssh access"
+  default = false
+  type = bool
+  nullable = false
+}
 locals {
   ssh_defined = anytrue([for port in var.machine.spec.ports: port.port == var.machine.spec.ssh_port])
   machine_ports = concat(var.machine.spec.ports, (!var.force_ssh_access || local.ssh_defined ? [] : [


### PR DESCRIPTION
Differs from aws machine module due to aws limitations when duplicate port rules are defined: https://github.com/EnterpriseDB/edb-terraform/pull/133

Original Commit: 3f8f635900f70dde1c12de500e4fd32acc39d89b