### PR TITLE
edb-terraform cli - FIX - azure cli version command updated - backport to 1.7

### DIFF
--- a/edbterraform/CLI.py
+++ b/edbterraform/CLI.py
@@ -426,14 +426,15 @@ class AzureCLI:
 
     def check_version(self):
         try:
+            version_keyname='azure-cli'
             path = self.get_binary()
-            command = [path, '--version']
+            command = [path, 'version']
             output = execute_shell(
                 args=command,
                 environment=os.environ.copy(),
             )
-            result = output.decode("utf-8")
-            return Version(result.split('\n')[0].split()[-1])
+            result = json.loads(output.decode("utf-8"))
+            return Version(result[version_keyname])
         except KeyError as e:
             raise e(f'version keyname was not found')
 


### PR DESCRIPTION
'az --version' changes the text output when an update is available and '--output json' returns text.
'az version' must be used to return a json object.

Error:
Traceback (most recent call last):
  File "/home/user/.local/bin/edb-terraform", line 8, in <module>
    sys.exit(entry_point())
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/__main__.py", line 24, in entry_point
    main()
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/__main__.py", line 17, in main
    outputs = arg_parser.process_args()
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/args.py", line 576, in process_args
    tool.install()
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/CLI.py", line 454, in install
    and self.check_version().to_tuple() == self.version.to_tuple():
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/CLI.py", line 439, in check_version
    return Version(result.split('\n')[0].split()[-1])
  File "<string>", line 10, in __init__
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/utils/script.py", line 76, in __post_init__
    self.major, self.tainted_major = self.nonstandard_segment(version_parts[0] if version_parts[0:] and version_parts[0] is not None else 0)
  File "/home/user/.local/lib/python3.10/site-packages/edbterraform/utils/script.py", line 130, in nonstandard_segment
    patch_number = int("".join(itertools.takewhile(str.isdigit, str(version))))
ValueError: invalid literal for int() with base 10: ''

Ref PR: https://github.com/EnterpriseDB/edb-terraform/pull/121
Ref Commit: 9cca08301e31110fb1dd4ec4ea2cf48d241700fc

---

Original PR: https://github.com/EnterpriseDB/edb-terraform/pull/174