### PR TITLE
PLAT-65 - Biganimal custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ BigAnimal specific environment variables that can be used during `terraform plan
       - Expired token is reused
 - `TF_VAR_ba_project_id` - Biganimal project id if not defined within the yaml configuration.
   - For persistence, a tfvars file can be created with `ba_project_id` defined.
+- Custom Image (Only available for dev environments)
+  - `TF_VAR_ba_pg_image` - Biganimal postgres image if not defined within the yaml configuration
+  - `TF_VAR_ba_proxy_image` - Biganimal proxy image if not defined within the yaml configuration
+  - `TF_VAR_ba_ignore_image` - Ignore image values (Default: `false`)
 
 ### Environment variables
 Terraform allows for top-level variables to be defined with cli arguments or environment variables.

--- a/docs/examples/aws/biganimal.yml
+++ b/docs/examples/aws/biganimal.yml
@@ -11,7 +11,11 @@ aws:
       #   or it can be configured per cluster configuration:
       #project:
       #  id: prj_1234567890
-      # password: "ndslniv&03ind**vDdjfnjv" # auto-generated if not provided
+      # password: "" # auto-generated if not provided
+      # Only available for dev environments and can be set as environment variables
+      #image:
+      #  pg: ""
+      #  proxy: ""
       data_groups:
         one:
           cloud_account: false

--- a/edbterraform/data/templates/aws/biganimal.tf.j2
+++ b/edbterraform/data/templates/aws/biganimal.tf.j2
@@ -11,6 +11,7 @@ module "biganimal" {
 
   cluster_name       = module.spec.base.tags.cluster_name
   password           = each.value.password
+  image              = each.value.image
   data_groups        = each.value.data_groups
   witness_groups     = each.value.witness_groups
   service_cidrblocks = local.biganimal_service_cidrblocks

--- a/edbterraform/data/templates/aws/validation.tf.j2
+++ b/edbterraform/data/templates/aws/validation.tf.j2
@@ -1,12 +1,19 @@
 # All modules should reference this module's outputs
-# During terraform plan, will act as basic validation of yaml input(var.spec) with variable validation and preconditions
-# During terraform apply, will check for availability of resources with data sources and postconditions
+# During terraform plan, will act as basic validation of yaml input(var.spec) with:
+# - variable validation
+# - preconditions
+# - data sources as long as there is no resource dependency, which then postpones it to 'terraform apply'
 module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+
   force_ssh_access = var.force_service_machines
+
   ba_project_id_default = var.ba_project_id
+  ba_ignore_image_default = var.ba_ignore_image
+  ba_pg_image_default = var.ba_pg_image
+  ba_proxy_image_default = var.ba_proxy_image
 }
 
 # All modules should use the last created module in their depends_on through jinja

--- a/edbterraform/data/templates/azure/biganimal.tf.j2
+++ b/edbterraform/data/templates/azure/biganimal.tf.j2
@@ -11,6 +11,7 @@ module "biganimal" {
 
   cluster_name       = module.spec.base.tags.cluster_name
   password           = each.value.password
+  image              = each.value.image
   data_groups        = each.value.data_groups
   witness_groups     = each.value.witness_groups
   service_cidrblocks = local.biganimal_service_cidrblocks

--- a/edbterraform/data/templates/azure/validation.tf.j2
+++ b/edbterraform/data/templates/azure/validation.tf.j2
@@ -1,13 +1,19 @@
-# All modules should reference this module's outputs for input from user
-# All modules should reference this module in depends_on
-# During terraform plan, will act as basic validation of yaml input(var.spec) with variable validation and preconditions
-# During terraform apply, will check for availability of resources with data sources and postconditions
+# All modules should reference this module's outputs
+# During terraform plan, will act as basic validation of yaml input(var.spec) with:
+# - variable validation
+# - preconditions
+# - data sources as long as there is no resource dependency, which then postpones it to 'terraform apply'
 module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+
   force_ssh_access = var.force_service_machines
+
   ba_project_id_default = var.ba_project_id
+  ba_ignore_image_default = var.ba_ignore_image
+  ba_pg_image_default = var.ba_pg_image
+  ba_proxy_image_default = var.ba_proxy_image
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/templates/gcloud/biganimal.tf.j2
+++ b/edbterraform/data/templates/gcloud/biganimal.tf.j2
@@ -11,6 +11,7 @@ module "biganimal" {
 
   cluster_name       = module.spec.base.tags.cluster_name
   password           = each.value.password
+  image              = each.value.image
   data_groups        = each.value.data_groups
   witness_groups     = each.value.witness_groups
   service_cidrblocks = local.biganimal_service_cidrblocks

--- a/edbterraform/data/templates/gcloud/validation.tf.j2
+++ b/edbterraform/data/templates/gcloud/validation.tf.j2
@@ -1,13 +1,19 @@
-# All modules should reference this module's outputs for input from user
-# All modules should reference this module in depends_on
-# During terraform plan, will act as basic validation of yaml input(var.spec) with variable validation and preconditions
-# During terraform apply, will check for availability of resources with data sources and postconditions
+# All modules should reference this module's outputs
+# During terraform plan, will act as basic validation of yaml input(var.spec) with:
+# - variable validation
+# - preconditions
+# - data sources as long as there is no resource dependency, which then postpones it to 'terraform apply'
 module "spec" {
   source = "./modules/specification"
 
   spec = var.spec
+
   force_ssh_access = var.force_service_machines
+
   ba_project_id_default = var.ba_project_id
+  ba_ignore_image_default = var.ba_ignore_image
+  ba_pg_image_default = var.ba_pg_image
+  ba_proxy_image_default = var.ba_proxy_image
 }
 
 resource "null_resource" "validation" {

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -139,7 +139,13 @@ output "region_auroras" {
 output "biganimal" {
   value = {
     for name, biganimal_spec in var.spec.biganimal : name => merge(biganimal_spec, {
-        project = biganimal_spec.project.id == null ? {"id":"${var.ba_project_id_default}"} : biganimal_spec.project
+        project = {
+          id = biganimal_spec.project.id == null || biganimal_spec.project.id == "" ? var.ba_project_id_default : biganimal_spec.project.id
+        }
+        image = var.ba_ignore_image_default ? { pg = null, proxy = null } : {
+          pg    = biganimal_spec.image.pg == null || biganimal_spec.image.pg == "" ? var.ba_pg_image_default : biganimal_spec.image.pg
+          proxy = biganimal_spec.image.proxy == null || biganimal_spec.image.proxy == "" ? var.ba_proxy_image_default : biganimal_spec.image.proxy
+        }
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -160,6 +160,10 @@ variable "spec" {
         id = optional(string)
       }), {})
       password       = optional(string)
+      image = optional(object({
+        pg    = optional(string)
+        proxy = optional(string)
+      }), {})
       data_groups = optional(map(object({
         cloud_account = optional(bool)
         type           = string

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -226,6 +226,27 @@ variable "ba_project_id_default" {
   nullable = true
 }
 
+variable "ba_pg_image_default" {
+  description = "Dev only: BigAnimal postgres image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_proxy_image_default" {
+  description = "Dev only: BigAnimal proxy image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_ignore_image_default" {
+  description = "Ignore biganimal custom images"
+  type = bool
+  nullable = false
+  default = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "AWS-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-AWS"

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -127,7 +127,13 @@ output "region_databases" {
 output "biganimal" {
   value = {
     for name, biganimal_spec in var.spec.biganimal : name => merge(biganimal_spec, {
-        project = biganimal_spec.project.id == null ? {"id":"${var.ba_project_id_default}"} : biganimal_spec.project
+        project = {
+          id = biganimal_spec.project.id == null || biganimal_spec.project.id == "" ? var.ba_project_id_default : biganimal_spec.project.id
+        }
+        image = var.ba_ignore_image_default ? { pg = null, proxy = null } : {
+          pg    = biganimal_spec.image.pg == null || biganimal_spec.image.pg == "" ? var.ba_pg_image_default : biganimal_spec.image.pg
+          proxy = biganimal_spec.image.proxy == null || biganimal_spec.image.proxy == "" ? var.ba_proxy_image_default : biganimal_spec.image.proxy
+        }
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -181,6 +181,27 @@ variable "ba_project_id_default" {
   nullable = true
 }
 
+variable "ba_pg_image_default" {
+  description = "Dev only: BigAnimal postgres image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_proxy_image_default" {
+  description = "Dev only: BigAnimal proxy image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_ignore_image_default" {
+  description = "Ignore biganimal custom images"
+  type = bool
+  nullable = false
+  default = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "Azure-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-Azure"

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -108,6 +108,10 @@ variable "spec" {
         id = optional(string)
       }), {})
       password       = optional(string)
+      image = optional(object({
+        pg    = optional(string)
+        proxy = optional(string)
+      }), {})
       data_groups = optional(map(object({
         cloud_account = optional(bool)
         type           = string

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
@@ -202,6 +202,8 @@ resource "toolbox_external" "api_biganimal" {
       delete)
         CLUSTER_ID=$(printf "%s" "$input" | jq -r '.old_result.data.clusterId')
         delete_stage "$CLUSTER_ID"
+        # Wait for cluster to be deleted to avoid destroy-create race condition
+        sleep 60
         ;;
       *)
         printf "Input: %s\n" "$input" 1>&2

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
@@ -264,7 +264,7 @@ resource "toolbox_external" "api_status" {
       then
         printf "Cluster creation timed out\n" 1>&2
         printf "Last phase: $PHASE\n" 1>&2
-        printf "Cluster data: $CLUSTER_DATA\n" 1>&2
+        printf "Cluster data: $RESULT\n" 1>&2
         exit 1
       fi
 

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
@@ -416,11 +416,13 @@ locals {
 
   // Create an object that excludes any null objects
   TERRAFORM_API_MAPPING = {
-    iops = "iops"
-    throughput = "throughput"
-    size_gb = "size"
-    properties = "volumePropertiesId"
-    type = "volumeTypeId"
+    storage = {
+      iops = "iops"
+      throughput = "throughput"
+      size_gb = "size"
+      properties = "volumePropertiesId"
+      type = "volumeTypeId"
+    }
   }
 
   // Remove null values from the volume properties and save with the api variable naming as the key
@@ -443,11 +445,11 @@ locals {
           }
       ]
       storage = {
-        for key, value in group_values.volume : local.TERRAFORM_API_MAPPING[key] =>
+        for key, value in group_values.volume : local.TERRAFORM_API_MAPPING.storage[key] =>
           key == "size_gb" ? "${value} Gi" : tostring(value) if value != null
       }
       walStorage = {
-        for key, value in group_values.wal_volume == null ? {} : group_values.wal_volume : local.TERRAFORM_API_MAPPING[key] =>
+        for key, value in group_values.wal_volume == null ? {} : group_values.wal_volume : local.TERRAFORM_API_MAPPING.storage[key] =>
           key == "size_gb" ? "${value} Gi" : tostring(value) if value != null
       }
       # required
@@ -470,9 +472,10 @@ locals {
         startDay = group_values.maintenance_window.start_day
         startTime = group_values.maintenance_window.start_time
       }
-    }][0]
+    }
+  ][0]
 
-    API_DATA_PGD = {
+  API_DATA_PGD = {
     clusterName = local.cluster_name
     clusterType = "cluster"
     password = local.password
@@ -488,11 +491,11 @@ locals {
             }
         ]
         storage = {
-          for key, value in group_values.volume : local.TERRAFORM_API_MAPPING[key] =>
+          for key, value in group_values.volume : local.TERRAFORM_API_MAPPING.storage[key] =>
             key == "size_gb" ? "${value} Gi" : tostring(value) if value != null
         }
         walStorage = {
-          for key, value in group_values.wal_volume == null ? {} : group_values.wal_volume : local.TERRAFORM_API_MAPPING[key] =>
+          for key, value in group_values.wal_volume == null ? {} : group_values.wal_volume : local.TERRAFORM_API_MAPPING.storage[key] =>
             key == "size_gb" ? "${value} Gi" : tostring(value) if value != null
         }
         # required 
@@ -525,6 +528,7 @@ locals {
         instanceType = { instanceTypeId = group_values.instance_type }
         provider = { cloudProviderId = group_values.cloud_provider_id }
         region = { regionId = group_values.region }
+        # Storage values prefetched from the api for witness groups
         storage = {
           volumePropertiesId = group_values.storage.properties
           volumeTypeId = group_values.storage.type
@@ -536,6 +540,7 @@ locals {
           startTime = group_values.maintenance_window.start_time
         }
       }],
+    # Remove null/empty groups
     ]): obj if obj != null && obj != {}]
   }
 

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -26,6 +26,27 @@ variable "ba_project_id" {
   default = null
 }
 
+variable "ba_pg_image" {
+  description = "Dev only: BigAnimal postgres image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_proxy_image" {
+  description = "Dev only: BigAnimal proxy image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_ignore_image" {
+  description = "Ignore biganimal custom images"
+  type = bool
+  nullable = false
+  default = false
+}
+
 variable "public_cidrblocks" {
   description = "Public CIDR block"
   type        = list(string)

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -130,7 +130,13 @@ output "region_alloys" {
 output "biganimal" {
   value = {
     for name, biganimal_spec in var.spec.biganimal : name => merge(biganimal_spec, {
-        project = biganimal_spec.project.id == null ? {"id":"${var.ba_project_id_default}"} : biganimal_spec.project
+        project = {
+          id = biganimal_spec.project.id == null || biganimal_spec.project.id == "" ? var.ba_project_id_default : biganimal_spec.project.id
+        }
+        image = var.ba_ignore_image_default ? { pg = null, proxy = null } : {
+          pg    = biganimal_spec.image.pg == null || biganimal_spec.image.pg == "" ? var.ba_pg_image_default : biganimal_spec.image.pg
+          proxy = biganimal_spec.image.proxy == null || biganimal_spec.image.proxy == "" ? var.ba_proxy_image_default : biganimal_spec.image.proxy
+        }
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -191,6 +191,27 @@ variable "ba_project_id_default" {
   nullable = true
 }
 
+variable "ba_pg_image_default" {
+  description = "Dev only: BigAnimal postgres image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_proxy_image_default" {
+  description = "Dev only: BigAnimal proxy image to use if not defined within the biganimal configuration"
+  type = string
+  nullable = true
+  default = null
+}
+
+variable "ba_ignore_image_default" {
+  description = "Ignore biganimal custom images"
+  type = bool
+  nullable = false
+  default = false
+}
+
 locals {
   cluster_name = can(var.spec.tags.cluster_name) ? var.spec.tags.cluster_name : "GCloud-Cluster-default"
   created_by = can(var.spec.tags.created_by) ? var.spec.tags.created_by : "EDB-Terraform-GCloud"

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -123,6 +123,10 @@ variable "spec" {
         id = optional(string)
       }), {})
       password       = optional(string)
+      image = optional(object({
+        pg    = optional(string)
+        proxy = optional(string)
+      }), {})
       data_groups = optional(map(object({
         cloud_account = optional(bool)
         type           = string


### PR DESCRIPTION
Allow a custom image to be defined for biganimal clusters. Can be set within each configuration or set as a global default with an environment variable/top-level variable.

Custom Image with environment variables:
`TF_VAR_ba_pg_image` - Biganimal postgres image if not defined within the yaml configuration
`TF_VAR_ba_proxy_image` - Biganimal proxy image if not defined within the yaml configuration
`TF_VAR_ba_ignore_image` - Ignore image values (Default: false)

Configuration:

```yaml
aws:
  biganimal:
    example_cluster:
      image:
        pg: "example_one"
        proxy: "example_two"
      data_groups: ...
```
