### PR TITLE
Biganimal module - remove colon from `random_password`

### DIFF
--- a/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
@@ -249,7 +249,7 @@ variable "image" {
 resource "random_password" "password" {
   length          = 32
   special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  override_special = "!#$%&*()-_=+[]{}<>?"
 }
 
 locals {


### PR DESCRIPTION
pgpass requies escaping of colon (`:`) and backslash (`\`) characters with a backslash (`\`).

ref docs: https://www.postgresql.org/docs/current/libpq-pgpass.html