### PR TITLE
Biganimal module - remove `<>&` from `random_password`

### DIFF
--- a/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/variables.tf
@@ -249,7 +249,7 @@ variable "image" {
 resource "random_password" "password" {
   length          = 32
   special          = true
-  override_special = "!#$%&*()-_=+[]{}<>?"
+  override_special = "!#$%*()-_=+[]{}?"
 }
 
 locals {


### PR DESCRIPTION
terraform's json encoding/decoding may change the representation of characters. ex: '<' => '\u003'

Ref: https://discuss.hashicorp.com/t/password-generated-has-unicode-in-it-in-terraform-state-file/51630

Ref: https://github.com/EnterpriseDB/edb-terraform/pull/211