### PR TITLE
Handle Biganimal alt postgres engine names

### DIFF
--- a/docs/examples/aws/biganimal.yml
+++ b/docs/examples/aws/biganimal.yml
@@ -25,7 +25,7 @@ aws:
           # type must match across data nodes
           type: pgd # single | ha | pgd - supports 1-2 data nodes
           node_count: 3 # single = 1 node | ha = 2-3 nodes | pgd = 2-3 nodes for 1 data group or 3 for 2 data groups
-          engine: epas # epas | pgextended | postgres
+          engine: epas # epas | pgextended or pge | postgres or pg
           engine_version: 14
           instance_type: c5.large
           volume:

--- a/docs/examples/azure/biganimal.yml
+++ b/docs/examples/azure/biganimal.yml
@@ -13,7 +13,7 @@ azure:
       region: eastus
       type: single
       node_count: 1
-      engine: epas
+      engine: # epas | pgextended or pge | postgres or pg
       engine_version: 14
       instance_type: Standard_D2s_v3
       password: "ndslniv&03ind**vDdjfnjv"

--- a/docs/examples/gcloud/biganimal.yml
+++ b/docs/examples/gcloud/biganimal.yml
@@ -13,7 +13,7 @@ gcloud:
       region: us-east4
       type: single # Options: single | ha
       node_count: 1 # must be 1 when using type: single
-      engine: epas
+      engine: # epas | pgextended or pge | postgres or pg
       engine_version: 14
       instance_type: e2-highcpu-4
       password: "ndslniv&03ind**vDdjfnjv"

--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.0-rc.3"
+__version__ = "1.8.0-rc.4"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
@@ -149,9 +149,16 @@ resource "toolbox_external" "api_biganimal" {
       REQUEST_TYPE="DELETE"
       if ! RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "$AUTH_HEADER" --url "$URI/$ENDPOINT" 2>&1)
       then
-        RC="$${PIPESTATUS[0]}"
-        printf "%s\n" "$RESULT" 1>&2
-        exit "$RC"
+        # Skip error if cluster does not exist
+        if $(echo $RESULT | grep -q "no such cluster")
+        then
+          RESULT="cluster does not exist"
+        else
+          RC="$${PIPESTATUS[0]}"
+          printf "new error" 1>&2
+          printf "%s\n" "$RESULT" 1>&2
+          exit "$RC"
+        fi
       fi
 
       printf '{"done":"%s"}' "$RESULT"


### PR DESCRIPTION
Changes:
- Handle postgres engine abbreviations
  - `postgres` = `pg`
  - `pgextended` = `pge` 
- Allow terraform destruction to continue if the biganimal cluster was already destroyed or does not exist.