### PR TITLE
PLAT-459 - Biganimal fixes

### DIFF
--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
@@ -17,7 +17,7 @@ resource "biganimal_cluster" "instance" {
     storage = {
         volume_type = each.value.volume.type
         volume_properties = each.value.volume.properties
-        size = each.value.volume_size
+        size = each.value.volume.size
         # optional
         iops = each.value.volume.iops
         throughput = each.value.volume.throughput
@@ -74,7 +74,7 @@ resource "biganimal_pgd" "clusters" {
         storage = {
             volume_type = values.volume.type
             volume_properties = values.volume.properties
-            size = values.volume_size
+            size = values.volume.size
             # optional
             iops = values.volume.iops
             throughput = values.volume.throughput

--- a/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
+++ b/edbterraform/data/terraform/biganimal/modules/biganimal/main.tf
@@ -210,7 +210,7 @@ resource "toolbox_external" "api_biganimal" {
         # Exit with result if no retry is needed
         if ! $(echo $RESULT | grep -q "failed to ValidateQuota")
         then
-          printf "$RESULT"
+          printf "%s" "$RESULT"
           exit 0
         fi
 
@@ -323,7 +323,7 @@ resource "toolbox_external" "api_status" {
     while [[ $PHASE != *"healthy"* ]]
     do
       if ! RESULT=$(curl --silent --show-error --fail-with-body --location --request $REQUEST_TYPE --header "content-type: application/json" --header "$AUTH_HEADER" --url "$URI/$ENDPOINT" 2>&1) \
-        || ! PHASE=$(printf "$RESULT" | jq -er ".data.phase" 2>&1) \
+        || ! PHASE=$(printf "%s" "$RESULT" | jq -er ".data.phase" 2>&1) \
         || ! $([[ $PHASE == *"Failed"* ]] && exit 1 || exit 0)
       then
         RC="$${PIPESTATUS[0]}"
@@ -335,8 +335,8 @@ resource "toolbox_external" "api_status" {
       if [[ $COUNT -gt COUNT_LIMIT ]] && [[ $PHASE != *"healthy"* ]]
       then
         printf "Cluster creation timed out\n" 1>&2
-        printf "Last phase: $PHASE\n" 1>&2
-        printf "Cluster data: $RESULT\n" 1>&2
+        printf "Last phase: %s\n" "$PHASE" 1>&2
+        printf "Cluster data: %s\n" "$RESULT" 1>&2
         exit 1
       fi
 
@@ -344,7 +344,7 @@ resource "toolbox_external" "api_status" {
       sleep $SLEEP_TIME
     done
   
-    printf "$RESULT"
+    printf "%s" "$RESULT"
     EOT
   ]
 }


### PR DESCRIPTION
Fixes:
- biganimal module
  - handle premium storage `azure` prefix for biganimal azure
  - check for duplicate clusters instead of waiting for the api name constraint error
  - delete leftover clusters after internal server failures
    - Error:
      ```terraform
      │ ERROR: curl: (22) The requested URL returned error: 500
      │ {"error":{"status":500,"message":"Internal Server
      │ Error","errors":[{"message":"failed to insert tags linked to the resource
      │ p-r5xhp7i38n, reason: failed to create tags prior to linking them with the
      │ resource p-r5xhp7i38n: failed to create tag: tag name
      │ run_set_id:20241122112556347 already
      │ exist"}],"reference":"upmrid/-oMzKhBF4QYPhyNVLy_Yr/2b6frNEA0I-EqYtfbVwfH","source":"mSvc"}}
      ```
  - do not interpret special characters
    - Error:
      ```terraform
      │ Phase: parse error: Invalid string: control characters from U+0000 through
      │ U+001F must be escaped at line 2, column 135
      │ 
      │ State: exit status 4
      ```