### PR TITLE
PLAT-460 - AWS EKS fixes

### DIFF
--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.4"
+__version__ = "1.8.5"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -8,6 +8,8 @@ module "kubernetes_{{ region_ }}" {
   vpcAndClusterPrefix     = "${module.spec.base.tags.cluster_name}-${module.spec.pet_name}"  
   instanceType            = each.value.spec.instance_type
 
+  tags                    = each.value.spec.tags
+
   providers = {
     aws = aws.{{ region_ }}
   }

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -11,6 +11,10 @@ module "kubernetes_{{ region_ }}" {
   name_id                 = module.spec.hex_id
   tags                    = each.value.spec.tags
 
+  runtime_service_cidrblocks = local.kubernetes_service_cidrblocks
+  config_service_cidrblocks  = each.value.spec.service_cidrblocks
+  disable_public_access      = var.disable_eks_public_access
+
   providers = {
     aws = aws.{{ region_ }}
   }

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -3,6 +3,8 @@ module "kubernetes_{{ region_ }}" {
 
   for_each = { for rm in lookup(module.spec.region_kubernetes, "{{ region }}", []) : rm.name => rm }
 
+  cluster_version         = each.value.spec.cluster_version
+
   region                  = each.value.spec.region
   desiredCapacity         = each.value.spec.node_count
   instanceType            = each.value.spec.instance_type

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -5,9 +5,10 @@ module "kubernetes_{{ region_ }}" {
 
   region                  = each.value.spec.region
   desiredCapacity         = each.value.spec.node_count
-  vpcAndClusterPrefix     = "${module.spec.base.tags.cluster_name}-${module.spec.pet_name}"  
   instanceType            = each.value.spec.instance_type
 
+  name                    = each.key
+  name_id                 = module.spec.hex_id
   tags                    = each.value.spec.tags
 
   providers = {

--- a/edbterraform/data/templates/aws/kubernetes.tf.j2
+++ b/edbterraform/data/templates/aws/kubernetes.tf.j2
@@ -10,7 +10,6 @@ module "kubernetes_{{ region_ }}" {
 
   providers = {
     aws = aws.{{ region_ }}
-    kubernetes = kubernetes.{{ region_ }}
   }
 
 # This statement works for: Azure Kubernetes Services and Google Kubernetes Engine

--- a/edbterraform/data/templates/azure/kubernetes.tf.j2
+++ b/edbterraform/data/templates/azure/kubernetes.tf.j2
@@ -6,6 +6,8 @@ module "kubernetes_{{ region_ }}" {
       rm.name => rm 
     })
 
+  cluster_version                 = each.value.spec.cluster_version
+
   nodeCount                       = each.value.spec.node_count
   cluster_name                    = module.spec.base.tags.cluster_name
   logAnalyticsWorkspaceLocation   = each.value.spec.log_analytics_location

--- a/edbterraform/data/templates/gcloud/kubernetes.tf.j2
+++ b/edbterraform/data/templates/gcloud/kubernetes.tf.j2
@@ -6,6 +6,8 @@ module "kubernetes_{{ region_ }}" {
       rm.name => rm 
     })
 
+  cluster_version                 = each.value.spec.cluster_version
+
   cluster_name                    = module.spec.base.tags.cluster_name
   region                          = each.value.spec.region
   machine                         = each.value

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -46,6 +46,11 @@ module "eks" {
     }
   }
 
+  enable_cluster_creator_admin_permissions = true
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access = local.public_access
+  cluster_endpoint_public_access_cidrs = local.public_access_cidrs
+
   tags = var.tags
 }
 

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -1,13 +1,5 @@
 data "aws_availability_zones" "available" {}
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_name
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_name
-}
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.9.0"
@@ -55,4 +47,13 @@ module "eks" {
   }
 
   tags = var.tags
+}
+
+# Defer data read until the cluster is created
+data "aws_eks_cluster" "cluster" {
+  name = can(module.eks) ? module.eks.cluster_name : module.eks.cluster_name
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = can(module.eks) ? module.eks.cluster_name : module.eks.cluster_name
 }

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -30,6 +30,8 @@ module "vpc" {
     "kubernetes.io/cluster/${var.vpcAndClusterPrefix}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
   }
+
+  tags = var.tags
 }
 
 module "eks" {
@@ -51,4 +53,6 @@ module "eks" {
       instance_type = var.instanceType
     }
   }
+
+  tags = var.tags
 }

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -10,7 +10,7 @@ data "aws_eks_cluster_auth" "cluster" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.18.1"
+  version = "5.9.0"
 
   name                 = var.vpcAndClusterPrefix
   cidr                 = var.vpcCidr
@@ -34,7 +34,7 @@ module "vpc" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.30.3"
+  version = "20.2.2"
 
   cluster_name    = var.vpcAndClusterPrefix
   cluster_version = var.clusterVersion

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -4,7 +4,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.9.0"
 
-  name                 = var.vpcAndClusterPrefix
+  name                 = local.vpc_name
   cidr                 = var.vpcCidr
   azs                  = data.aws_availability_zones.available.names
   private_subnets      = [var.privateSubnet1, var.privateSubnet2, var.privateSubnet3]
@@ -14,12 +14,12 @@ module "vpc" {
   enable_dns_hostnames = true
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${var.vpcAndClusterPrefix}" = "shared"
+    "kubernetes.io/cluster/${local.name}" = "shared"
     "kubernetes.io/role/elb"                           = "1"
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${var.vpcAndClusterPrefix}" = "shared"
+    "kubernetes.io/cluster/${local.name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
   }
 
@@ -30,7 +30,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "20.2.2"
 
-  cluster_name    = var.vpcAndClusterPrefix
+  cluster_name    = local.name
   cluster_version = var.clusterVersion
   subnet_ids      = module.vpc.private_subnets
 

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -1,11 +1,11 @@
 data "aws_availability_zones" "available" {}
 
 data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 module "vpc" {

--- a/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/main.tf
@@ -31,7 +31,7 @@ module "eks" {
   version = "20.2.2"
 
   cluster_name    = local.name
-  cluster_version = var.clusterVersion
+  cluster_version = var.cluster_version
   subnet_ids      = module.vpc.private_subnets
 
   vpc_id = module.vpc.vpc_id

--- a/edbterraform/data/terraform/aws/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/outputs.tf
@@ -1,3 +1,8 @@
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}
+
 output "cluster_id" {
   description = "EKS cluster ID - only available for local Amazon EKS cluster on the AWS Outpost. Not available for an AWS EKS cluster on AWS cloud"
   value       = module.eks.cluster_id
@@ -23,8 +28,17 @@ output "region" {
   value       = var.region
 }
 
-output "cluster_name" {
-  description = "Kubernetes Cluster Name"
-  value       = module.eks.cluser_name
+output "raw" {
+  description = "Raw EKS cluster output"
+  value       = module.eks
 }
 
+output "cluster_info" {
+  description = "Cluster general information"
+  value       = data.aws_eks_cluster.cluster
+}
+
+output "cluster_auth" {
+  description = "Cluster authentication information"
+  value       = data.aws_eks_cluster_auth.cluster
+}

--- a/edbterraform/data/terraform/aws/modules/kubernetes/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "cluster_id" {
-  description = "EKS cluster ID"
+  description = "EKS cluster ID - only available for local Amazon EKS cluster on the AWS Outpost. Not available for an AWS EKS cluster on AWS cloud"
   value       = module.eks.cluster_id
 }
 
@@ -25,6 +25,6 @@ output "region" {
 
 output "cluster_name" {
   description = "Kubernetes Cluster Name"
-  value       = var.vpcAndClusterPrefix
+  value       = module.eks.cluser_name
 }
 

--- a/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
@@ -18,6 +18,42 @@ locals {
   vpc_name = format("eks-%s", local.name)
 }
 
+variable "runtime_service_cidrblocks" {
+  description = "CIDRs to allow access to the kubernetes api from a public network. Private networking (reused vpc, peered vpc, private endpoints) access enabled by default"
+  type = list(string)
+  default = []
+  nullable = false
+}
+
+variable "config_service_cidrblocks" {
+  description = "CIDRs to allow access to the kubernetes api from a public network. Private networking (reused vpc, peered vpc, private endpoints) access enabled by default"
+  type = list(string)
+  default = []
+  nullable = false
+}
+
+variable "disable_public_access" {
+  description = "Disable public access to the kubernetes api. Required to force refresh of the public access cidrs for eks"
+  type = bool
+  default = false
+  nullable = false
+}
+
+locals {
+  # If the service_cidrblocks list is an empty list then disable public access to the kubernetes api.
+  # This ensures that the kubernetes api is not accidentally exposed to all of the internet and forces the use of a bastion host.
+  # This also works as a workaround for the bug in the aws_eks_cluster resource which does not allow for the public_access_cidrs to be updated.
+  # Error:
+  # | module.kubernetes_us_west_2["mydb2"].module.eks.aws_eks_cluster.this[0]: Modifying... [id=mydb2-2f7a3a82]
+  # | Error: updating EKS Cluster (mydb2-2f7a3a82) VPC configuration: operation error EKS: UpdateClusterConfig, https response error StatusCode: 400, RequestID: 9ec38b4f-3a0f-4b44-9e4c-a58c84dea2a8, InvalidParameterException: Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: true, and Public Endpoint Restrictions: [0.0.0.0/0]
+  # Workaround:
+  # - disable public access by setting an empty access list or set disable_public_access to 'true' and 'terraform apply'
+  # - re-enable public access by adding the new access list and set disable_public_access to 'false' and 'terraform apply'
+  service_cidrblocks = setunion(var.runtime_service_cidrblocks, var.config_service_cidrblocks)
+  public_access = var.disable_public_access || (local.service_cidrblocks) == 0 ? false : true
+  public_access_cidrs = local.public_access ? local.service_cidrblocks : null
+}
+
 variable "clusterVersion" {
   default = "1.24"
 }

--- a/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
@@ -54,8 +54,10 @@ locals {
   public_access_cidrs = local.public_access ? local.service_cidrblocks : null
 }
 
-variable "clusterVersion" {
-  default = "1.24"
+variable "cluster_version" {
+  type = string
+  default = "1.28"
+  nullable = false
 }
 
 variable "desiredCapacity" {

--- a/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
@@ -2,6 +2,8 @@ variable "region" {
   default = "us-east-1"
 }
 
+# NAME SHOULD MAKE USE OF THE SAME ID AS OTHER RESOURCES and the key name, NOT THE PET NAME ID and pre-set prefix
+# EX of current naming: EDB-K8s-CNP-lasting-pug
 variable "vpcAndClusterPrefix" {
   default = "EDB-K8s-CNP"
 }
@@ -52,4 +54,8 @@ variable "publicSubnet2" {
 
 variable "publicSubnet3" {
   default = "172.16.6.0/24"
+}
+
+variable "tags" {
+  default = {}
 }

--- a/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/kubernetes/variables.tf
@@ -2,10 +2,20 @@ variable "region" {
   default = "us-east-1"
 }
 
-# NAME SHOULD MAKE USE OF THE SAME ID AS OTHER RESOURCES and the key name, NOT THE PET NAME ID and pre-set prefix
-# EX of current naming: EDB-K8s-CNP-lasting-pug
-variable "vpcAndClusterPrefix" {
-  default = "EDB-K8s-CNP"
+variable "name" {
+  default = "K8s-Default-Name"
+  nullable = false
+}
+
+variable "name_id" {
+  type     = string
+  default  = null
+  nullable = true
+}
+
+locals {
+  name = var.name_id != null && var.name_id != "" ? "${var.name}-${var.name_id}" : var.name
+  vpc_name = format("eks-%s", local.name)
 }
 
 variable "clusterVersion" {

--- a/edbterraform/data/terraform/aws/modules/specification/main.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/main.tf
@@ -1,7 +1,3 @@
-resource "random_id" "apply" {
-  byte_length = 4
-}
-
 resource "time_static" "first_created" {
 }
 

--- a/edbterraform/data/terraform/aws/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/outputs.tf
@@ -1,9 +1,9 @@
 locals {
+  # Expects included tags for tracking:
+  # - terraform_hex
+  # - terraform_id
+  # - terraform_time
   tags = merge(var.spec.tags, {
-    # add ids for tracking
-    terraform_hex   = random_id.apply.hex
-    terraform_id    = random_id.apply.id
-    terraform_time  = time_static.first_created.id
     created_by      = local.created_by
     cluster_name    = local.cluster_name
   })
@@ -78,7 +78,7 @@ locals {
           tags = merge(local.tags, machine_spec.tags, {
           # machine module specific tags
           # Use 'Name' tag to have instance name set for AWS UI
-          Name = format("%s-%s-%s", (machine_spec.count > 1 ? "${name}-${index}" : name), local.cluster_name, random_id.apply.hex)
+          Name = format("%s-%s-%s", (machine_spec.count > 1 ? "${name}-${index}" : name), local.cluster_name, local.tags.terraform_hex)
           })
           # assign operating system from mapped names
           # add private and public key paths so they can be passed in the machine outputs
@@ -114,7 +114,7 @@ output "region_databases" {
         # spec project tags
         tags = merge(local.tags, database_spec.tags, {
           # database module specific tags
-          Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.hex)
+          Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_hex)
         })
       })
     }...
@@ -129,7 +129,7 @@ output "region_auroras" {
         # spec project tags
         tags = merge(local.tags, aurora_spec.tags, {
           # aurora module specific tags
-          Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
+          Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_id)
         })
       })
     }...
@@ -149,7 +149,7 @@ output "biganimal" {
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           # Biganimal reserves the Name tag
-          # Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
+          # Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_id)
         })
         data_groups = {
           for data_group_name, data_group_spec in biganimal_spec.data_groups : data_group_name => merge(data_group_spec, {
@@ -166,7 +166,7 @@ output "biganimal" {
 }
 
 output "hex_id" {
-  value = random_id.apply.hex
+  value = local.tags.terraform_hex
 }
 
 output "pet_name" {
@@ -181,7 +181,7 @@ output "region_kubernetes" {
         # spec project tags
         tags = merge(local.tags, spec.tags, {
           # kubernetes module specific tags
-          Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
+          Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_id)
         })
       })
     }...

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -209,6 +209,7 @@ variable "spec" {
       node_count    = number
       instance_type = string
       tags          = optional(map(string), {})
+      service_cidrblocks = optional(list(string), [])
     })), {})
   })
 }

--- a/edbterraform/data/terraform/aws/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/aws/modules/specification/variables.tf
@@ -205,6 +205,7 @@ variable "spec" {
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
+      cluster_version = optional(string)
       region        = string
       node_count    = number
       instance_type = string

--- a/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/main.tf
@@ -29,6 +29,9 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   name                = var.cluster_name
   resource_group_name = azurerm_resource_group.rg.name
   dns_prefix          = var.cluster_name
+
+  kubernetes_version = var.cluster_version
+
   tags                = var.tags
 
   default_node_pool {

--- a/edbterraform/data/terraform/azure/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/kubernetes/variables.tf
@@ -61,3 +61,9 @@ variable "sshPublicKey" {
 variable "region" {
   default = "westus"
 }
+
+variable "cluster_version" {
+  type = string
+  default = "1.28"
+  nullable = false
+}

--- a/edbterraform/data/terraform/azure/modules/specification/main.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/main.tf
@@ -1,7 +1,3 @@
-resource "random_id" "apply" {
-  byte_length = 4
-}
-
 resource "time_static" "first_created" {
 }
 

--- a/edbterraform/data/terraform/azure/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/outputs.tf
@@ -1,9 +1,9 @@
 locals {
+  # Expects included tags for tracking:
+  # - terraform_hex
+  # - terraform_id
+  # - terraform_time
   tags = merge(var.spec.tags, {
-    # add ids for tracking
-    terraform_hex   = random_id.apply.hex
-    terraform_id    = random_id.apply.id
-    terraform_time  = time_static.first_created.id
     created_by      = local.created_by
     cluster_name    = local.cluster_name
   })
@@ -139,7 +139,7 @@ output "biganimal" {
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           # Biganimal reserves the Name tag
-          # Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
+          # Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_id)
         })
         data_groups = {
           for data_group_name, data_group_spec in biganimal_spec.data_groups : data_group_name => merge(data_group_spec, {
@@ -171,7 +171,7 @@ output "region_kubernetes" {
 }
 
 output "hex_id" {
-  value = random_id.apply.hex
+  value = local.tags.terraform_hex
 }
 
 output "pet_name" {

--- a/edbterraform/data/terraform/azure/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/azure/modules/specification/variables.tf
@@ -153,6 +153,7 @@ variable "spec" {
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
+      cluster_version         = optional(string)
       region                  = string
       ssh_user                = optional(string)
       resource_group_location = optional(string)

--- a/edbterraform/data/terraform/common_vars.tf
+++ b/edbterraform/data/terraform/common_vars.tf
@@ -84,6 +84,18 @@ variable "force_service_biganimal" {
   default = true
 }
 
+variable "force_service_kubernetes" {
+  description = "Force the use of service_cidrblocks for public access of the kubernetes api instead of private networking and a bastion host"
+  type = bool
+  default = true
+}
+
+variable "disable_eks_public_access" {
+  description = "Temporarily disable eks public access to allow refreshing of the public_access_cidrs"
+  type = bool
+  default = false
+}
+
 variable "dynamic_service_ip_mask" {
   type = number
   default = 32
@@ -121,4 +133,5 @@ locals {
   ] : []
   service_cidrblocks = concat(var.service_cidrblocks, local.dynamic_ip)
   biganimal_service_cidrblocks = var.force_service_biganimal ? local.service_cidrblocks : []
+  kubernetes_service_cidrblocks = var.force_service_kubernetes ? local.service_cidrblocks : []
 }

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/main.tf
@@ -8,6 +8,8 @@ resource "google_container_cluster" "primary" {
   subnetwork = var.subnetwork
 
   resource_labels = local.labels
+
+  node_version = var.cluster_version
 }
 
 resource "google_container_node_pool" "primary_nodes" {

--- a/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/kubernetes/variables.tf
@@ -20,3 +20,9 @@ locals {
   # key-values as tags even though they are labels under gcloud
   labels = { for key,value in var.tags: key => lower(replace(value, ":", "_"))}
 }
+
+variable "cluster_version" {
+  type = string
+  default = "1.28"
+  nullable = false
+}

--- a/edbterraform/data/terraform/gcloud/modules/specification/main.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/main.tf
@@ -103,10 +103,6 @@ EOT
   }
 }
 
-resource "random_id" "apply" {
-  byte_length = 4
-}
-
 resource "time_static" "first_created" {
 }
 

--- a/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/outputs.tf
@@ -1,9 +1,9 @@
 locals {
+  # Expects included tags for tracking:
+  # - terraform_hex
+  # - terraform_id
+  # - terraform_time
   tags = merge(var.spec.tags, {
-    # add ids for tracking
-    terraform_hex   = random_id.apply.hex
-    terraform_id    = random_id.apply.id
-    terraform_time  = time_static.first_created.id
     created_by      = local.created_by
     cluster_name    = local.cluster_name
   })
@@ -142,7 +142,7 @@ output "biganimal" {
         # spec project tags
         tags = merge(local.tags, biganimal_spec.tags, {
           # Biganimal reserves the Name tag
-          # Name = format("%s-%s-%s", name, local.cluster_name, random_id.apply.id)
+          # Name = format("%s-%s-%s", name, local.cluster_name, local.tags.terraform_id)
         })
         data_groups = {
           for data_group_name, data_group_spec in biganimal_spec.data_groups : data_group_name => merge(data_group_spec, {
@@ -174,7 +174,7 @@ output "region_kubernetes" {
 }
 
 output "hex_id" {
-  value = random_id.apply.hex
+  value = local.tags.terraform_hex
 }
 
 output "pet_name" {

--- a/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
+++ b/edbterraform/data/terraform/gcloud/modules/specification/variables.tf
@@ -168,6 +168,7 @@ variable "spec" {
       tags = optional(map(string), {})
     })), {})
     kubernetes = optional(map(object({
+      cluster_version = optional(string)
       region        = string
       zone_name     = string
       node_count    = number


### PR DESCRIPTION
Changes:
- AWS Kubernetes (EKS)
  - outputs added, any unformatted outputs are subject to change, modification or removal by the api or between releases
    - `cluster_info`
    - `cluster_auth`
    - `raw`
  - `force_service_kubernetes` root module variable added to add host public access list
    - when no service cidrs are provided, public access is disabled to avoid exposing resources to `0.0.0.0/0`
- Azure Kubernetes
  - `cluster_version` added to spec configuration
- Gcloud Kubernetes
  - `cluster_version` added to spec configuration

Fixes:
- AWS Kubernetes (EKS)
  - update EKS and VPC module versions
  - remove unused Kubernetes provider list
  - reference cluster name instead of cluster id
  - use keyname and hex id for resource names
  - tag resources
  - `disable_eks_public_access` root module variable added as a workaround to refresh the access list or disable public access
- edb-terraform cli
  - create tags at generation time so they are known during `terraform plan` instead of relying on terraform resource which causes tags to be undefined until apply time or until a targeted apply.