### PR TITLE
FIX - edb-terraform cli - update user-templates default

### DIFF
--- a/edbterraform/__init__.py
+++ b/edbterraform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.6"
+__version__ = "1.8.7"
 __project_name__ = 'edb-terraform'
 from pathlib import Path
 __dot_project__ = f'{Path.home()}/.{__project_name__}'

--- a/edbterraform/args.py
+++ b/edbterraform/args.py
@@ -126,8 +126,8 @@ UserTemplatesPath = ArgumentConfig(
     type=Path,
     nargs='+',
     required=False,
-    default=[f'{__dot_project__}/templates',],
-    help="Users can pass in a list of template files or template directories, which will be rendered with the servers output. Default: %(default)s",
+    default=[],
+    help="Users can pass in a list of template files or template directories separated by space, which will be rendered with the servers output. No default template path is provided.",
 )
 
 InfrastructureFilePath = ArgumentConfig(


### PR DESCRIPTION
Issue: Default files removed in commit - 51c9968cf1445dd6b73f22ab2940bdc747205f52, and causes project creation to fail unless `--user-templates` due to the cli default: `Default: ['/home/user/.edb-terraform/templates']`
Fix: Remove the cli default for user templates
```
  --user-templates USER_TEMPLATE_FILES [USER_TEMPLATE_FILES ...]
                        Users can pass in a list of template files or template directories separated by space, which will be rendered with the servers output. No default template path is provided. | Environment variable: ET_USER_TEMPLATES
...
2025-04-14T18:04:11+0000 - edb-terraform - INFO - Saving user templates: []
2025-04-14T18:04:11+0000 - edb-terraform - INFO - Creating template directory: /home/user/Projects/edb-terraform/aws-terraform/templates
```

Fixes: #273 